### PR TITLE
[#13] Added Project Creation Board

### DIFF
--- a/apps/web/src/app/(admin)/dashboard/page.tsx
+++ b/apps/web/src/app/(admin)/dashboard/page.tsx
@@ -15,6 +15,9 @@ import { useRouter } from 'next/navigation'
 type Project = {
   id: string
   name: string
+  slug: string
+  description: string | null
+  startedAt: string | null
   createdAt: string
   repositories: {
     id: string
@@ -64,6 +67,9 @@ export default function AdminDashboardPage() {
         {projects.map((project) => (
           <li key={project.id}>
             <strong>{project.name}</strong>
+            <p>{project.description}</p>
+            <p>Slug: {project.slug}</p>
+            <p>Started at: {project.startedAt}</p>
             <p>Created at: {project.createdAt}</p>
             <div style={{ marginTop: 8 }}>
               <h4>Repositories:</h4>
@@ -76,7 +82,6 @@ export default function AdminDashboardPage() {
                       </strong>
                     </div>
                     <div>Installation ID: {repo.installationId}</div>
-                    <div>Repo ID: {repo.id}</div>
                   </li>
                 ))}
               </ul>

--- a/apps/web/src/app/(admin)/dashboard/page.tsx
+++ b/apps/web/src/app/(admin)/dashboard/page.tsx
@@ -1,0 +1,104 @@
+/**
+ * Admin dashboard — only should be accessible to administrators.
+ * Currently should allow administrators to create projects and view their current projects.
+ *
+ * TODO: Implement the design
+ * Make it so that it is only accessible to the admin who owns the projects once authentication is implemented.
+ * Add functionality to delete projects and edit projects.
+ */
+
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useRouter } from 'next/navigation'
+
+type Project = {
+  id: string
+  name: string
+  createdAt: string
+  repositories: {
+    id: string
+    owner: string
+    name: string
+    installationId: string
+  }[]
+  channels: {
+    id: string
+    externalId: string
+    name: string
+  }[]
+}
+
+const fetchProjects = async (): Promise<Project[]> => {
+  try {
+    const response = await fetch('/api/project')
+    if (!response.ok) {
+      throw new Error('Failed to fetch projects')
+    }
+    const projects = await response.json()
+    return projects as Project[]
+  } catch (error) {
+    console.error('Error fetching projects:', error)
+    return []
+  }
+}
+
+export default function AdminDashboardPage() {
+  const [projects, setProjects] = useState<Project[]>([])
+  const router = useRouter()
+
+  useEffect(() => {
+    const load = async () => {
+      const data = await fetchProjects()
+      setProjects(data)
+    }
+
+    load()
+  }, [])
+
+  return (
+    <main>
+      <h1>WDCC Projects Health Dashboard - Admin View</h1>
+      <p>Projects:</p>
+      <ul>
+        {projects.map((project) => (
+          <li key={project.id}>
+            <strong>{project.name}</strong>
+            <p>Created at: {project.createdAt}</p>
+            <div style={{ marginTop: 8 }}>
+              <h4>Repositories:</h4>
+              <ul>
+                {project.repositories.map((repo) => (
+                  <li key={repo.id}>
+                    <div>
+                      <strong>
+                        {repo.owner}/{repo.name}
+                      </strong>
+                    </div>
+                    <div>Installation ID: {repo.installationId}</div>
+                    <div>Repo ID: {repo.id}</div>
+                  </li>
+                ))}
+              </ul>
+            </div>
+            <div style={{ marginTop: 8 }}>
+              <h4>Discord Channels:</h4>
+              <ul>
+                {project.channels?.map((ch) => (
+                  <li key={ch.id}>
+                    <div>
+                      <strong>{ch.name}</strong>
+                    </div>
+                    <div>External ID: {ch.externalId}</div>
+                    <div>Channel Name: {ch.name}</div>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </li>
+        ))}
+      </ul>
+      <button onClick={() => router.push('/projects/new')}>Create New Project (Button)</button>
+    </main>
+  )
+}

--- a/apps/web/src/app/(admin)/projects/new/page.tsx
+++ b/apps/web/src/app/(admin)/projects/new/page.tsx
@@ -23,8 +23,10 @@ export default function CreateProjectPage() {
     })
 
     if (!response.ok) {
-      alert('Failed to create project')
-      console.error('Failed to create project:', await response.text())
+      const text = await response.text()
+      const data = JSON.parse(text)
+      const errorMessage = data?.error ?? data?.message ?? text
+      alert('Failed to create project: ' + errorMessage)
       return
     }
 
@@ -46,8 +48,23 @@ export default function CreateProjectPage() {
         </label>
         <br />
         <label>
-          Discord Channel Link:
-          <input type="url" style={{ border: '1px solid #ccc' }} name="discordLink" required />
+          Discord Snowflake ID:
+          <input
+            type="text"
+            style={{ border: '1px solid #ccc' }}
+            name="discordSnowflakeId"
+            required
+          />
+        </label>
+        <br />
+        <label>
+          Project Description:
+          <input type="text" style={{ border: '1px solid #ccc' }} name="projectDescription" />
+        </label>
+        <br />
+        <label>
+          Project Start Date:
+          <input type="month" style={{ border: '1px solid #ccc' }} name="projectStartDate" />
         </label>
         <br />
         <button type="submit">Create Project (Button)</button>

--- a/apps/web/src/app/(admin)/projects/new/page.tsx
+++ b/apps/web/src/app/(admin)/projects/new/page.tsx
@@ -1,0 +1,57 @@
+/**
+ * Project creation page — only should be accessible to administrators.
+ * Should take in the necessary information to create a new project (e.g., project name, GitHub repository link, Discord Channel link, etc.)
+ * and store it in the database.
+ *
+ * TODO: Implement the design
+ */
+
+'use client'
+
+import type { FormEvent } from 'react'
+import { useRouter } from 'next/navigation'
+
+export default function CreateProjectPage() {
+  const router = useRouter()
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    const formData = new FormData(event.currentTarget)
+    const response = await fetch('/api/project', {
+      method: 'POST',
+      body: formData,
+    })
+
+    if (!response.ok) {
+      alert('Failed to create project')
+      console.error('Failed to create project:', await response.text())
+      return
+    }
+
+    router.replace('/dashboard')
+  }
+
+  return (
+    <main>
+      <h1>Create New Project</h1>
+      <form onSubmit={handleSubmit}>
+        <label>
+          Project Name:
+          <input type="text" style={{ border: '1px solid #ccc' }} name="projectName" required />
+        </label>
+        <br />
+        <label>
+          GitHub Repository Link:
+          <input type="url" style={{ border: '1px solid #ccc' }} name="githubLink" required />
+        </label>
+        <br />
+        <label>
+          Discord Channel Link:
+          <input type="url" style={{ border: '1px solid #ccc' }} name="discordLink" required />
+        </label>
+        <br />
+        <button type="submit">Create Project (Button)</button>
+      </form>
+    </main>
+  )
+}

--- a/apps/web/src/app/api/project/route.ts
+++ b/apps/web/src/app/api/project/route.ts
@@ -38,56 +38,61 @@ export async function POST(request: Request) {
       return Response.json({ error: 'Invalid GitHub Repository Link' }, { status: 400 })
     }
 
+    const [existingProject, existingRepo, existingChannel] = await Promise.all([
+      db.project.findUnique({ where: { slug: projectName.toLowerCase().replace(/\s+/g, '-') } }),
+      db.gitHubRepository.findFirst({
+        where: { owner: githubLink.split('/')[3], name: githubLink.split('/')[4] },
+      }),
+      db.discordChannel.findUnique({ where: { externalId: discordSnowflakeId } }),
+    ])
+
+    if (existingProject) {
+      return Response.json({ error: 'Project with this name already exists' }, { status: 409 })
+    } else if (existingRepo) {
+      return Response.json(
+        {
+          error:
+            'GitHub Repository with this owner and name has already been linked to another project',
+        },
+        { status: 409 }
+      )
+    } else if (existingChannel) {
+      return Response.json(
+        {
+          error:
+            'Discord Channel with this Snowflake ID has already been linked to another project',
+        },
+        { status: 409 }
+      )
+    }
+
     const newProject = await db.$transaction(async (tx) => {
-      const createdProject = await tx.project.create({
+      return await tx.project.create({
         data: {
           name: projectName,
           slug: projectName.toLowerCase().replace(/\s+/g, '-'),
           description: projectDescription || null,
           startedAt: parseDate(projectStartDate),
+          repositories: {
+            create: {
+              owner: githubLink.split('/')[3],
+              name: githubLink.split('/')[4],
+              // placeholder value
+              installationId: '0',
+            },
+          },
+          channels: {
+            create: {
+              externalId: discordSnowflakeId,
+              // placeholder value
+              name: projectName + ' Discord Channel',
+            },
+          },
         },
-      })
-
-      const existingRepo = await tx.gitHubRepository.findFirst({
-        where: { owner: githubLink.split('/')[3], name: githubLink.split('/')[4] },
-      })
-      if (!existingRepo) {
-        await tx.gitHubRepository.create({
-          data: {
-            projectId: createdProject.id,
-            owner: githubLink.split('/')[3],
-            name: githubLink.split('/')[4],
-            // placeholder value
-            installationId: '0',
-          },
-        })
-      } else {
-        throw new Error(
-          'GitHub Repository with this owner and name has already been linked to another project'
-        )
-      }
-
-      const existingChannel = await tx.discordChannel.findFirst({
-        where: { externalId: discordSnowflakeId },
-      })
-      if (!existingChannel) {
-        await tx.discordChannel.create({
-          data: {
-            projectId: createdProject.id,
-            externalId: discordSnowflakeId,
-            // placeholder value
-            name: projectName + ' Discord Channel',
-          },
-        })
-      } else {
-        throw new Error(
-          'Discord Channel with this Snowflake ID has already been linked to another project'
-        )
-      }
-
-      return tx.project.findUnique({
-        where: { id: createdProject.id },
-        include: { repositories: true, channels: true },
+        include: {
+          repositories: true,
+          channels: true,
+        },
       })
     })
 

--- a/apps/web/src/app/api/project/route.ts
+++ b/apps/web/src/app/api/project/route.ts
@@ -1,0 +1,70 @@
+import { db } from '@repo/db'
+
+/**
+ * TODO: Add authentication and authorization to ensure only admins can access these routes
+ * Add error validation for checking if the project name is unique, if the GitHub link is valid, and if the Discord link is valid.
+ */
+
+// API route for handling project creation
+export async function POST(request: Request) {
+  try {
+    const formData = await request.formData()
+    const projectName = String(formData.get('projectName') ?? '').trim()
+    const githubLink = String(formData.get('githubLink') ?? '').trim()
+    const discordLink = String(formData.get('discordLink') ?? '').trim()
+
+    if (!projectName || !githubLink || !discordLink) {
+      return new Response('Missing required fields', { status: 400 })
+    }
+
+    const createdProject = await db.project.create({
+      data: {
+        name: projectName,
+        slug: projectName.toLowerCase().replace(/\s+/g, '-'),
+        isActive: true,
+        createdAt: new Date(),
+      },
+    })
+
+    await db.gitHubRepository.create({
+      data: {
+        projectId: createdProject.id,
+        owner: githubLink.split('/')[3],
+        name: githubLink.split('/')[4],
+        // Need to change to actual installation ID
+        installationId: '0',
+      },
+    })
+
+    await db.discordChannel.create({
+      data: {
+        projectId: createdProject.id,
+        externalId: discordLink,
+        // Need to change to actual channel name
+        name: projectName + ' Discord Channel',
+      },
+    })
+  } catch (error) {
+    console.error('Error creating project:', error)
+    return new Response('Failed to create project', { status: 500 })
+  }
+
+  return new Response('Project created successfully', { status: 200 })
+}
+
+// API route for fetching all active projects
+export async function GET() {
+  try {
+    const projects = await db.project.findMany({
+      where: { isActive: true },
+      include: {
+        repositories: true,
+        channels: true,
+      },
+    })
+    return Response.json(projects, { status: 200 })
+  } catch (error) {
+    console.error('Error fetching projects:', error)
+    return new Response('Failed to fetch projects', { status: 500 })
+  }
+}

--- a/apps/web/src/app/api/project/route.ts
+++ b/apps/web/src/app/api/project/route.ts
@@ -2,8 +2,23 @@ import { db } from '@repo/db'
 
 /**
  * TODO: Add authentication and authorization to ensure only admins can access these routes
- * Add error validation for checking if the project name is unique, if the GitHub link is valid, and if the Discord link is valid.
+ * Add error validation for checking if the project name is unique and if the Discord link is valid.
  */
+
+function validateGitHubLink(link: string) {
+  // expected GitHub Link - https://github.com/owner/reponame
+  const regex = /^https:\/\/github\.com\/[^\/]+\/[^\/]+$/
+  return regex.test(link)
+}
+
+function parseDate(input: string): Date | null {
+  // expected input format - YYYY-MM
+  const [year, month] = input.split('-').map(Number)
+  if (!year || !month || month < 1 || month > 12) {
+    return null
+  }
+  return new Date(Date.UTC(year, month - 1))
+}
 
 // API route for handling project creation
 export async function POST(request: Request) {
@@ -11,45 +26,78 @@ export async function POST(request: Request) {
     const formData = await request.formData()
     const projectName = String(formData.get('projectName') ?? '').trim()
     const githubLink = String(formData.get('githubLink') ?? '').trim()
-    const discordLink = String(formData.get('discordLink') ?? '').trim()
+    const discordSnowflakeId = String(formData.get('discordSnowflakeId') ?? '').trim()
+    const projectDescription = String(formData.get('projectDescription') ?? '').trim()
+    const projectStartDate = String(formData.get('projectStartDate') ?? '').trim()
 
-    if (!projectName || !githubLink || !discordLink) {
-      return new Response('Missing required fields', { status: 400 })
+    if (!projectName || !githubLink || !discordSnowflakeId) {
+      return Response.json({ error: 'Missing required fields' }, { status: 400 })
     }
 
-    const createdProject = await db.project.create({
-      data: {
-        name: projectName,
-        slug: projectName.toLowerCase().replace(/\s+/g, '-'),
-        isActive: true,
-        createdAt: new Date(),
-      },
+    if (!validateGitHubLink(githubLink)) {
+      return Response.json({ error: 'Invalid GitHub Repository Link' }, { status: 400 })
+    }
+
+    const newProject = await db.$transaction(async (tx) => {
+      const createdProject = await tx.project.create({
+        data: {
+          name: projectName,
+          slug: projectName.toLowerCase().replace(/\s+/g, '-'),
+          description: projectDescription || null,
+          startedAt: parseDate(projectStartDate),
+        },
+      })
+
+      const existingRepo = await tx.gitHubRepository.findFirst({
+        where: { owner: githubLink.split('/')[3], name: githubLink.split('/')[4] },
+      })
+      if (!existingRepo) {
+        await tx.gitHubRepository.create({
+          data: {
+            projectId: createdProject.id,
+            owner: githubLink.split('/')[3],
+            name: githubLink.split('/')[4],
+            // placeholder value
+            installationId: '0',
+          },
+        })
+      } else {
+        throw new Error(
+          'GitHub Repository with this owner and name has already been linked to another project'
+        )
+      }
+
+      const existingChannel = await tx.discordChannel.findFirst({
+        where: { externalId: discordSnowflakeId },
+      })
+      if (!existingChannel) {
+        await tx.discordChannel.create({
+          data: {
+            projectId: createdProject.id,
+            externalId: discordSnowflakeId,
+            // placeholder value
+            name: projectName + ' Discord Channel',
+          },
+        })
+      } else {
+        throw new Error(
+          'Discord Channel with this Snowflake ID has already been linked to another project'
+        )
+      }
+
+      return tx.project.findUnique({
+        where: { id: createdProject.id },
+        include: { repositories: true, channels: true },
+      })
     })
 
-    await db.gitHubRepository.create({
-      data: {
-        projectId: createdProject.id,
-        owner: githubLink.split('/')[3],
-        name: githubLink.split('/')[4],
-        // Need to change to actual installation ID
-        installationId: '0',
-      },
-    })
-
-    await db.discordChannel.create({
-      data: {
-        projectId: createdProject.id,
-        externalId: discordLink,
-        // Need to change to actual channel name
-        name: projectName + ' Discord Channel',
-      },
-    })
+    return Response.json(newProject, { status: 201 })
   } catch (error) {
-    console.error('Error creating project:', error)
-    return new Response('Failed to create project', { status: 500 })
+    return Response.json(
+      { error: error instanceof Error ? error.message : 'Failed to create project' },
+      { status: 500 }
+    )
   }
-
-  return new Response('Project created successfully', { status: 200 })
 }
 
 // API route for fetching all active projects
@@ -65,6 +113,6 @@ export async function GET() {
     return Response.json(projects, { status: 200 })
   } catch (error) {
     console.error('Error fetching projects:', error)
-    return new Response('Failed to fetch projects', { status: 500 })
+    return Response.json({ error: 'Failed to fetch projects' }, { status: 500 })
   }
 }


### PR DESCRIPTION
Features: 
- Shows the projects that have been created and that are stored in the database at http://localhost:3000/dashboard.
- Allows for the creation of projects with linking GitHub Repositories and Discord Channels
- Created an API router that gets and creates projects.

Things to Note:
- It currently displays all the projects, will change it to only show the current admin's work once authentication is sorted.
- I'm assuming that the installationId and channel name properties are related to GitHub and Discord's APIs as I was not quite sure how to get them from the pasted links. I left some random placeholder text for them.
- I have left a row in the dev database so that you can see the data was created and stored.

Screenshots:
<img width="733" height="358" alt="image" src="https://github.com/user-attachments/assets/94c71aed-3986-488c-a157-b7cc4a78cc34" />
<img width="1592" height="222" alt="image" src="https://github.com/user-attachments/assets/557586ad-b89a-4e69-a18c-25a494e13074" />

