### PR TITLE
[#36] Adding/Removing Admin and Exec accounts

### DIFF
--- a/apps/web/src/app/(admin)/roles/page.tsx
+++ b/apps/web/src/app/(admin)/roles/page.tsx
@@ -2,24 +2,28 @@
 
 export default function ManageRolesPage() {
   const handleSubmit = async (formData: FormData, method: 'POST' | 'DELETE') => {
-    const response = await fetch('/api/roles', {
-      method,
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        email: formData.get('email'),
-        adminRole: formData.get('adminRole') === 'on',
-        execRole: formData.get('execRole') === 'on',
-      }),
-    })
+    try {
+      const response = await fetch('/api/roles', {
+        method,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          email: formData.get('email'),
+          adminRole: formData.get('adminRole') === 'on',
+          execRole: formData.get('execRole') === 'on',
+        }),
+      })
 
-    const data = await response.json()
+      const data = await response.json()
 
-    if (!response.ok) {
-      alert('Failed: ' + (data?.error ?? 'Unknown error'))
-      return
+      if (!response.ok) {
+        alert('Failed: ' + (data?.error ?? 'Unknown error'))
+        return
+      }
+
+      alert('Success, current user roles:' + (data.roles?.join(', ') || ' none'))
+    } catch {
+      alert('Failed, server error or response failed to parse')
     }
-
-    alert('Success, current user roles:' + (data.roles?.join(', ') || ' none'))
   }
 
   return (

--- a/apps/web/src/app/(admin)/roles/page.tsx
+++ b/apps/web/src/app/(admin)/roles/page.tsx
@@ -1,0 +1,70 @@
+'use client'
+
+export default function ManageRolesPage() {
+  const handleSubmit = async (formData: FormData, method: 'POST' | 'DELETE') => {
+    const response = await fetch('/api/roles', {
+      method,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        email: formData.get('email'),
+        adminRole: formData.get('adminRole') === 'on',
+        execRole: formData.get('execRole') === 'on',
+      }),
+    })
+
+    const data = await response.json()
+
+    if (!response.ok) {
+      alert('Failed: ' + (data?.error ?? 'Unknown error'))
+      return
+    }
+
+    alert('Success, current user roles:' + (data.roles?.join(', ') || ' none'))
+  }
+
+  return (
+    <main>
+      <h1>Add role</h1>
+      <form action={(formData) => handleSubmit(formData, 'POST')}>
+        <label>
+          Email:
+          <input type="email" style={{ border: '1px solid #000000' }} name="email" required />
+        </label>
+        <br />
+        <label>
+          <input type="checkbox" name="adminRole" />
+          Admin
+        </label>
+        <br />
+        <label>
+          <input type="checkbox" name="execRole" />
+          Exec
+        </label>
+        <br />
+        <button type="submit">Add Role(s)</button>
+      </form>
+
+      <br />
+
+      <h1>Remove role</h1>
+      <form action={(formData) => handleSubmit(formData, 'DELETE')}>
+        <label>
+          Email:
+          <input type="email" style={{ border: '1px solid #000000' }} name="email" required />
+        </label>
+        <br />
+        <label>
+          <input type="checkbox" name="adminRole" />
+          Admin
+        </label>
+        <br />
+        <label>
+          <input type="checkbox" name="execRole" />
+          Exec
+        </label>
+        <br />
+        <button type="submit">Remove Role(s)</button>
+      </form>
+    </main>
+  )
+}

--- a/apps/web/src/app/api/roles/route.ts
+++ b/apps/web/src/app/api/roles/route.ts
@@ -1,0 +1,143 @@
+import { db, Role } from '@repo/db'
+import { createClient } from '@/lib/supabase/server'
+
+/**
+ * TODO: Add authentication and authorization to ensure only admins can access these routes
+ */
+
+function isValidEmail(email: string) {
+  const regex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+  return regex.test(email)
+}
+
+// API route for adding new admin and/or execs
+export async function POST(request: Request) {
+  try {
+    const body = await request.json()
+    const email = String(body.email).trim()
+    const addAdmin = Boolean(body.adminRole ?? '')
+    const addExec = Boolean(body.execRole ?? '')
+
+    if (!isValidEmail(email)) {
+      return Response.json({ error: 'Invalid email address' }, { status: 400 })
+    }
+
+    if (!email || (!addAdmin && !addExec)) {
+      return Response.json(
+        { error: 'Missing required fields, add at least one role' },
+        { status: 400 }
+      )
+    }
+    const profile = await db.profile.findUnique({ where: { email } })
+
+    if (!profile) {
+      return Response.json({ error: 'Email does not exist' }, { status: 404 })
+    }
+
+    const rolesToAdd: Role[] = []
+    if (addAdmin) {
+      rolesToAdd.push(Role.ADMIN)
+    }
+    if (addExec) {
+      rolesToAdd.push(Role.EXEC)
+    }
+
+    await db.userRole.createMany({
+      data: rolesToAdd.map((role) => ({
+        userId: profile.id,
+        role,
+      })),
+      skipDuplicates: true,
+    })
+
+    const userRoles = await db.userRole.findMany({
+      where: { userId: profile.id },
+      select: { role: true },
+    })
+
+    return Response.json(
+      {
+        email,
+        roles: userRoles.map((userRole) => userRole.role),
+      },
+      { status: 200 }
+    )
+  } catch (error) {
+    return Response.json(
+      { error: error instanceof Error ? error.message : 'Failed to add user roles' },
+      { status: 500 }
+    )
+  }
+}
+
+// API route for removing admin and/or exec roles
+export async function DELETE(request: Request) {
+  try {
+    const body = await request.json()
+    const email = String(body.email).trim()
+    const removeAdmin = Boolean(body.adminRole)
+    const removeExec = Boolean(body.execRole)
+
+    if (!email || (!removeAdmin && !removeExec)) {
+      return Response.json(
+        { error: 'Missing required fields, remove at least one role' },
+        { status: 400 }
+      )
+    }
+
+    if (!isValidEmail(email)) {
+      return Response.json({ error: 'Invalid email address' }, { status: 400 })
+    }
+
+    const supabase = await createClient()
+    const {
+      data: { user },
+    } = await supabase.auth.getUser()
+
+    if (user?.email === email && removeAdmin) {
+      return Response.json({ error: 'You cannot remove your own admin role' }, { status: 403 })
+    }
+
+    const profile = await db.profile.findUnique({ where: { email } })
+
+    if (!profile) {
+      return Response.json({ error: 'Email does not exist' }, { status: 404 })
+    }
+
+    const rolesToRemove: Role[] = []
+    if (removeAdmin) {
+      rolesToRemove.push(Role.ADMIN)
+    }
+    if (removeExec) {
+      rolesToRemove.push(Role.EXEC)
+    }
+
+    const existingRoles = await db.userRole
+      .findMany({
+        where: { userId: profile.id },
+        select: { role: true },
+      })
+      .then((rows) => rows.map((userRole) => userRole.role))
+
+    if (!rolesToRemove.some((role) => existingRoles.includes(role))) {
+      return Response.json({ error: 'User does not have the specified role(s)' }, { status: 409 })
+    }
+
+    await db.userRole.deleteMany({
+      where: { userId: profile.id, role: { in: rolesToRemove } },
+    })
+
+    return Response.json(
+      {
+        email,
+        roles: existingRoles.filter((role) => !rolesToRemove.includes(role)),
+      },
+      { status: 200 }
+    )
+  } catch (error) {
+    return Response.json(
+      { error: error instanceof Error ? error.message : 'Failed to remove user roles' },
+      { status: 500 }
+    )
+  }
+}

--- a/apps/web/src/app/api/roles/route.ts
+++ b/apps/web/src/app/api/roles/route.ts
@@ -22,7 +22,7 @@ export async function POST(request: Request) {
       return Response.json({ error: 'Invalid email address' }, { status: 400 })
     }
 
-    if (!email || (!addAdmin && !addExec)) {
+    if (!addAdmin && !addExec) {
       return Response.json(
         { error: 'Missing required fields, add at least one role' },
         { status: 400 }
@@ -78,15 +78,15 @@ export async function DELETE(request: Request) {
     const removeAdmin = Boolean(body.adminRole)
     const removeExec = Boolean(body.execRole)
 
-    if (!email || (!removeAdmin && !removeExec)) {
+    if (!isValidEmail(email)) {
+      return Response.json({ error: 'Invalid email address' }, { status: 400 })
+    }
+
+    if (!removeAdmin && !removeExec) {
       return Response.json(
         { error: 'Missing required fields, remove at least one role' },
         { status: 400 }
       )
-    }
-
-    if (!isValidEmail(email)) {
-      return Response.json({ error: 'Invalid email address' }, { status: 400 })
     }
 
     const supabase = await createClient()


### PR DESCRIPTION
## Description

Add ability to add/remove admin and exec accounts from email

Created two profiles with emails in dev database:
test1@gmail.com
test2@gmail.com

#36 

## Solution

  - `POST /api/roles` - assigns one or both roles to a user by email
  - `DELETE /api/roles` - removes one or both roles from a user by email
  -  Frontend page at /roles to add/remove accounts - http://localhost:3000/roles

## Notes
"An admin cannot delete their own account from the admin list" is waiting on supabase auth to be implemented.