### PR TITLE
[#17] fetch PRs merged for a repo in the current week

### DIFF
--- a/apps/worker/src/jobs/github.ts
+++ b/apps/worker/src/jobs/github.ts
@@ -10,8 +10,12 @@ async function withRateLimit<T>(fn: () => Promise<T>, retries = 3): Promise<T> {
       const status = (err as { status?: number })?.status
       const headers = (err as { response?: { headers?: Record<string, string> } })?.response
         ?.headers
-      const isRateLimit = status === 429 || status === 403
-      if (isRateLimit && attempt < retries) {
+
+      // 403 can mean permission denied OR secondary rate limit — check for retry-after header
+      const isSecondaryRateLimit = status === 403 && headers?.['retry-after'] !== undefined
+      const isPrimaryRateLimit = status === 429
+
+      if (isPrimaryRateLimit && attempt < retries) {
         const retryAfter = parseInt(headers?.['retry-after'] ?? '60', 10)
         logger.warn(
           `Rate limit hit. Retrying after ${retryAfter}s (attempt ${attempt + 1}/${retries})`
@@ -19,6 +23,20 @@ async function withRateLimit<T>(fn: () => Promise<T>, retries = 3): Promise<T> {
         await new Promise((r) => setTimeout(r, retryAfter * 1000))
         continue
       }
+
+      if (isSecondaryRateLimit && attempt < retries) {
+        const retryAfter = parseInt(headers['retry-after']!, 10)
+        logger.warn(
+          `Secondary rate limit hit. Retrying after ${retryAfter}s (attempt ${attempt + 1}/${retries})`
+        )
+        await new Promise((r) => setTimeout(r, retryAfter * 1000))
+        continue
+      }
+
+      if (status === 403) {
+        logger.error('Permission denied (403). Check GitHub App permissions or installation scope.')
+      }
+
       throw err
     }
   }
@@ -66,20 +84,12 @@ async function ingestRepoMergedPRs(
 
   const octokit = await getInstallationOctokit(repo.installationId)
 
-  // Fetch closed PRs and filter to those merged this week
-  const pulls = await withRateLimit(() =>
-    octokit.paginate('GET /repos/{owner}/{repo}/pulls', {
-      owner: repo.owner,
-      repo: repo.name,
-      state: 'closed',
-      sort: 'updated',
-      direction: 'desc',
+  const since = weekStart.toISOString().split('T')[0] // YYYY-MM-DD
+  const mergedThisWeek = await withRateLimit(() =>
+    octokit.paginate('GET /search/issues', {
+      q: `repo:${repo.owner}/${repo.name} is:pr is:merged merged:>=${since}`,
       per_page: 100,
     })
-  )
-
-  const mergedThisWeek = pulls.filter(
-    (pr) => pr.merged_at !== null && new Date(pr.merged_at) >= weekStart
   )
 
   if (mergedThisWeek.length === 0) {

--- a/apps/worker/src/jobs/github.ts
+++ b/apps/worker/src/jobs/github.ts
@@ -1,7 +1,147 @@
-/**
- * GitHub ingestion job.
- * TODO: Implement GitHub ingestion
- */
+import { db } from '@repo/db'
+import { getInstallationOctokit } from '../lib/github-auth'
+import { logger } from '../lib/logger'
+
 export async function runGitHubIngestion(): Promise<void> {
-  throw new Error('Not implemented')
+  const syncJob = await db.syncJob.create({
+    data: { type: 'GITHUB', status: 'RUNNING', startedAt: new Date() },
+  })
+
+  try {
+    const weekStart = getWeekStart()
+    const repos = await db.gitHubRepository.findMany()
+    let totalProcessed = 0
+
+    for (const repo of repos) {
+      try {
+        const count = await ingestRepoMergedPRs(repo, weekStart)
+        totalProcessed += count
+      } catch (err) {
+        logger.error(`Failed to ingest PRs for ${repo.owner}/${repo.name}: ${err}`)
+      }
+    }
+
+    await db.syncJob.update({
+      where: { id: syncJob.id },
+      data: { status: 'SUCCESS', finishedAt: new Date(), itemsProcessed: totalProcessed },
+    })
+    logger.info(`GitHub ingestion complete. ${totalProcessed} PRs processed.`)
+  } catch (err) {
+    await db.syncJob.update({
+      where: { id: syncJob.id },
+      data: { status: 'FAILED', finishedAt: new Date(), errorMessage: String(err) },
+    })
+    throw err
+  }
+}
+
+async function ingestRepoMergedPRs(
+  repo: { id: string; owner: string; name: string; installationId: string },
+  weekStart: Date
+): Promise<number> {
+  logger.info(`Fetching merged PRs for ${repo.owner}/${repo.name} since ${weekStart.toISOString()}`)
+
+  const octokit = await getInstallationOctokit(repo.installationId)
+
+  // Fetch closed PRs and filter to those merged this week
+  const pulls = await octokit.paginate('GET /repos/{owner}/{repo}/pulls', {
+    owner: repo.owner,
+    repo: repo.name,
+    state: 'closed',
+    sort: 'updated',
+    direction: 'desc',
+    per_page: 100,
+  })
+
+  const mergedThisWeek = pulls.filter(
+    (pr) => pr.merged_at !== null && new Date(pr.merged_at) >= weekStart
+  )
+
+  if (mergedThisWeek.length === 0) {
+    logger.info(`No merged PRs found for ${repo.owner}/${repo.name} this week.`)
+    return 0
+  }
+
+  let count = 0
+  for (const pr of mergedThisWeek) {
+    // Fetch full PR details to get additions/deletions
+    const { data: fullPr } = await octokit.request(
+      'GET /repos/{owner}/{repo}/pulls/{pull_number}',
+      {
+        owner: repo.owner,
+        repo: repo.name,
+        pull_number: pr.number,
+      }
+    )
+
+    const authorIdentityId = await resolveIdentity(
+      fullPr.user ? { id: fullPr.user.id, login: fullPr.user.login } : null
+    )
+    const mergedByIdentityId = await resolveIdentity(
+      fullPr.merged_by ? { id: fullPr.merged_by.id, login: fullPr.merged_by.login } : null
+    )
+
+    await db.pRFact.upsert({
+      where: { repoId_number: { repoId: repo.id, number: fullPr.number } },
+      create: {
+        repoId: repo.id,
+        number: fullPr.number,
+        authorIdentityId,
+        mergedByIdentityId,
+        title: fullPr.title,
+        body: fullPr.body ?? null,
+        url: fullPr.html_url,
+        labels: fullPr.labels.map((l) => l.name),
+        createdAt: new Date(fullPr.created_at),
+        mergedAt: fullPr.merged_at ? new Date(fullPr.merged_at) : null,
+        closedAt: fullPr.closed_at ? new Date(fullPr.closed_at) : null,
+        linesAdded: fullPr.additions,
+        linesRemoved: fullPr.deletions,
+        ingestedAt: new Date(),
+      },
+      update: {
+        mergedAt: fullPr.merged_at ? new Date(fullPr.merged_at) : null,
+        closedAt: fullPr.closed_at ? new Date(fullPr.closed_at) : null,
+        linesAdded: fullPr.additions,
+        linesRemoved: fullPr.deletions,
+        ingestedAt: new Date(),
+      },
+    })
+    count++
+  }
+
+  logger.info(`Saved ${count} merged PRs for ${repo.owner}/${repo.name}.`)
+  return count
+}
+
+async function resolveIdentity(user: { id: number; login: string } | null): Promise<string | null> {
+  if (!user) return null
+
+  const existing = await db.personIdentity.findUnique({
+    where: { provider_externalId: { provider: 'GITHUB', externalId: String(user.id) } },
+  })
+  if (existing) return existing.id
+
+  await db.unmatchedIdentity.upsert({
+    where: { provider_externalId: { provider: 'GITHUB', externalId: String(user.id) } },
+    create: {
+      provider: 'GITHUB',
+      externalId: String(user.id),
+      username: user.login,
+      firstSeenAt: new Date(),
+      lastSeenAt: new Date(),
+    },
+    update: { lastSeenAt: new Date(), username: user.login },
+  })
+  return null
+}
+
+function getWeekStart(): Date {
+  const now = new Date()
+  const day = now.getUTCDay() // 0=Sun, 1=Mon...
+  const diff = day === 0 ? 6 : day - 1 // days since Monday
+  const monday = new Date(now)
+  monday.setUTCDate(now.getUTCDate() - diff)
+  monday.setUTCHours(0, 0, 0, 0)
+  return monday
 }

--- a/apps/worker/src/jobs/github.ts
+++ b/apps/worker/src/jobs/github.ts
@@ -11,12 +11,16 @@ async function withRateLimit<T>(fn: () => Promise<T>, retries = 3): Promise<T> {
       const headers = (err as { response?: { headers?: Record<string, string> } })?.response
         ?.headers
 
-      // 403 can mean permission denied OR secondary rate limit — check for retry-after header
-      const isSecondaryRateLimit = status === 403 && headers?.['retry-after'] !== undefined
-      const isPrimaryRateLimit = status === 429
+      const isPrimaryRateLimit =
+        status === 429 || (status === 403 && headers?.['x-ratelimit-remaining'] === '0')
+      const isSecondaryRateLimit =
+        status === 403 && !isPrimaryRateLimit && headers?.['retry-after'] !== undefined
 
       if (isPrimaryRateLimit && attempt < retries) {
-        const retryAfter = parseInt(headers?.['retry-after'] ?? '60', 10)
+        const resetAt = headers?.['x-ratelimit-reset']
+        const retryAfter = resetAt
+          ? Math.ceil(parseInt(resetAt, 10) - Date.now() / 1000)
+          : parseInt(headers?.['retry-after'] ?? '60', 10)
         logger.warn(
           `Rate limit hit. Retrying after ${retryAfter}s (attempt ${attempt + 1}/${retries})`
         )
@@ -25,7 +29,7 @@ async function withRateLimit<T>(fn: () => Promise<T>, retries = 3): Promise<T> {
       }
 
       if (isSecondaryRateLimit && attempt < retries) {
-        const retryAfter = parseInt(headers['retry-after']!, 10)
+        const retryAfter = parseInt(headers!['retry-after']!, 10)
         logger.warn(
           `Secondary rate limit hit. Retrying after ${retryAfter}s (attempt ${attempt + 1}/${retries})`
         )
@@ -109,10 +113,12 @@ async function ingestRepoMergedPRs(
     )
 
     const authorIdentityId = await resolveIdentity(
-      fullPr.user ? { id: fullPr.user.id, login: fullPr.user.login } : null
+      fullPr.user ? { id: fullPr.user.id, login: fullPr.user.login } : null,
+      repo.name
     )
     const mergedByIdentityId = await resolveIdentity(
-      fullPr.merged_by ? { id: fullPr.merged_by.id, login: fullPr.merged_by.login } : null
+      fullPr.merged_by ? { id: fullPr.merged_by.id, login: fullPr.merged_by.login } : null,
+      repo.name
     )
 
     await db.pRFact.upsert({
@@ -134,6 +140,12 @@ async function ingestRepoMergedPRs(
         ingestedAt: new Date(),
       },
       update: {
+        title: fullPr.title,
+        body: fullPr.body ?? null,
+        url: fullPr.html_url,
+        labels: fullPr.labels.map((l) => l.name),
+        authorIdentityId,
+        mergedByIdentityId,
         mergedAt: fullPr.merged_at ? new Date(fullPr.merged_at) : null,
         closedAt: fullPr.closed_at ? new Date(fullPr.closed_at) : null,
         linesAdded: fullPr.additions,
@@ -148,7 +160,10 @@ async function ingestRepoMergedPRs(
   return count
 }
 
-async function resolveIdentity(user: { id: number; login: string } | null): Promise<string | null> {
+async function resolveIdentity(
+  user: { id: number; login: string } | null,
+  repoName: string
+): Promise<string | null> {
   if (!user) return null
 
   const existing = await db.personIdentity.findUnique({
@@ -164,6 +179,7 @@ async function resolveIdentity(user: { id: number; login: string } | null): Prom
       username: user.login,
       firstSeenAt: new Date(),
       lastSeenAt: new Date(),
+      sampleRepoName: repoName,
     },
     update: { lastSeenAt: new Date(), username: user.login },
   })

--- a/apps/worker/src/jobs/github.ts
+++ b/apps/worker/src/jobs/github.ts
@@ -2,6 +2,29 @@ import { db } from '@repo/db'
 import { getInstallationOctokit } from '../lib/github-auth'
 import { logger } from '../lib/logger'
 
+async function withRateLimit<T>(fn: () => Promise<T>, retries = 3): Promise<T> {
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    try {
+      return await fn()
+    } catch (err: unknown) {
+      const status = (err as { status?: number })?.status
+      const headers = (err as { response?: { headers?: Record<string, string> } })?.response
+        ?.headers
+      const isRateLimit = status === 429 || status === 403
+      if (isRateLimit && attempt < retries) {
+        const retryAfter = parseInt(headers?.['retry-after'] ?? '60', 10)
+        logger.warn(
+          `Rate limit hit. Retrying after ${retryAfter}s (attempt ${attempt + 1}/${retries})`
+        )
+        await new Promise((r) => setTimeout(r, retryAfter * 1000))
+        continue
+      }
+      throw err
+    }
+  }
+  throw new Error('Unreachable')
+}
+
 export async function runGitHubIngestion(): Promise<void> {
   const syncJob = await db.syncJob.create({
     data: { type: 'GITHUB', status: 'RUNNING', startedAt: new Date() },
@@ -44,14 +67,16 @@ async function ingestRepoMergedPRs(
   const octokit = await getInstallationOctokit(repo.installationId)
 
   // Fetch closed PRs and filter to those merged this week
-  const pulls = await octokit.paginate('GET /repos/{owner}/{repo}/pulls', {
-    owner: repo.owner,
-    repo: repo.name,
-    state: 'closed',
-    sort: 'updated',
-    direction: 'desc',
-    per_page: 100,
-  })
+  const pulls = await withRateLimit(() =>
+    octokit.paginate('GET /repos/{owner}/{repo}/pulls', {
+      owner: repo.owner,
+      repo: repo.name,
+      state: 'closed',
+      sort: 'updated',
+      direction: 'desc',
+      per_page: 100,
+    })
+  )
 
   const mergedThisWeek = pulls.filter(
     (pr) => pr.merged_at !== null && new Date(pr.merged_at) >= weekStart
@@ -65,13 +90,12 @@ async function ingestRepoMergedPRs(
   let count = 0
   for (const pr of mergedThisWeek) {
     // Fetch full PR details to get additions/deletions
-    const { data: fullPr } = await octokit.request(
-      'GET /repos/{owner}/{repo}/pulls/{pull_number}',
-      {
+    const { data: fullPr } = await withRateLimit(() =>
+      octokit.request('GET /repos/{owner}/{repo}/pulls/{pull_number}', {
         owner: repo.owner,
         repo: repo.name,
         pull_number: pr.number,
-      }
+      })
     )
 
     const authorIdentityId = await resolveIdentity(

--- a/apps/worker/src/lib/github-auth.ts
+++ b/apps/worker/src/lib/github-auth.ts
@@ -1,8 +1,4 @@
-type InstallationOctokit = Awaited<
-  ReturnType<
-    import('octokit', { with: { 'resolution-mode': 'import' } }).App['getInstallationOctokit']
-  >
->
+type InstallationOctokit = import('octokit', { with: { 'resolution-mode': 'import' } }).Octokit
 
 // Kept intentionally minimal to avoid CJS/ESM type import issues with octokit.
 type GitHubAppClient = {


### PR DESCRIPTION
## Description

Weekly job that ingests merged PRs from tracked GitHub repositories

## Solution

- All PRs merged within the current week for a given repo are retrieved and saved
- Only merged PRs are counted. Open or closed-without-merging PRs are ignored
- If the repo has no merged PRs for the week, this is handled gracefully without errors
- Handles rate limits and errors.

## Notes

<!-- Add any notes you think are needed -->
