### PR TITLE
[#51] Resolve deprecated eslint configs

### DIFF
--- a/apps/worker/eslint.config.mjs
+++ b/apps/worker/eslint.config.mjs
@@ -1,3 +1,20 @@
+import { defineConfig } from 'eslint/config'
 import tseslint from 'typescript-eslint'
 
-export default tseslint.config(...tseslint.configs.recommended)
+export default defineConfig(
+  tseslint.configs.recommended,
+  {
+    plugins: {
+      '@typescript-eslint': tseslint.plugin,
+    },
+    languageOptions: {
+      parser: tseslint.parser,
+      parserOptions: {
+        projectService: {
+          allowDefaultProject: ['*.config.mjs'],
+        },
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  }
+)

--- a/packages/db/eslint.config.mjs
+++ b/packages/db/eslint.config.mjs
@@ -1,3 +1,20 @@
+import { defineConfig } from 'eslint/config'
 import tseslint from 'typescript-eslint'
 
-export default tseslint.config(...tseslint.configs.recommended)
+export default defineConfig(
+  tseslint.configs.recommended,
+  {
+    plugins: {
+      '@typescript-eslint': tseslint.plugin,
+    },
+    languageOptions: {
+      parser: tseslint.parser,
+      parserOptions: {
+        projectService: {
+          allowDefaultProject: ['*.config.mjs'],
+        },
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  }
+)

--- a/packages/db/tsconfig.json
+++ b/packages/db/tsconfig.json
@@ -8,7 +8,8 @@
     "declaration": true,
     "declarationMap": true,
     "outDir": "./dist",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "types": ["node"]
   },
   "include": ["src"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
## Description
apps/worker/eslint.config.mjs and packages/db/eslint.config.mjs both call tseslint.config() which is deprecated. The replacement is defineConfig from eslint/config, which is the new standard way to define ESLint flat configs. Switching to it also unlocks type-aware linting by wiring in the TypeScript parser and project service.

## Solution
Replaces deprecated tseslint config with new defineConfig function from eslint in `packages/db` and `apps/worker`.
Adds `node` to tsconfig `types` in `packages/db` to resolve missing type definitions for node.

## Notes

<!-- Add any notes you think are needed -->
