### PR TITLE
[#19] Fetch number of commits for a repo in the current week 

### DIFF
--- a/apps/worker/src/jobs/github.ts
+++ b/apps/worker/src/jobs/github.ts
@@ -10,8 +10,12 @@ async function withRateLimit<T>(fn: () => Promise<T>, retries = 3): Promise<T> {
       const status = (err as { status?: number })?.status
       const headers = (err as { response?: { headers?: Record<string, string> } })?.response
         ?.headers
-      const isRateLimit = status === 429 || status === 403
-      if (isRateLimit && attempt < retries) {
+
+      // 403 can mean permission denied OR secondary rate limit — check for retry-after header
+      const isSecondaryRateLimit = status === 403 && headers?.['retry-after'] !== undefined
+      const isPrimaryRateLimit = status === 429
+
+      if (isPrimaryRateLimit && attempt < retries) {
         const retryAfter = parseInt(headers?.['retry-after'] ?? '60', 10)
         logger.warn(
           `Rate limit hit. Retrying after ${retryAfter}s (attempt ${attempt + 1}/${retries})`
@@ -19,6 +23,20 @@ async function withRateLimit<T>(fn: () => Promise<T>, retries = 3): Promise<T> {
         await new Promise((r) => setTimeout(r, retryAfter * 1000))
         continue
       }
+
+      if (isSecondaryRateLimit && attempt < retries) {
+        const retryAfter = parseInt(headers['retry-after']!, 10)
+        logger.warn(
+          `Secondary rate limit hit. Retrying after ${retryAfter}s (attempt ${attempt + 1}/${retries})`
+        )
+        await new Promise((r) => setTimeout(r, retryAfter * 1000))
+        continue
+      }
+
+      if (status === 403) {
+        logger.error('Permission denied (403). Check GitHub App permissions or installation scope.')
+      }
+
       throw err
     }
   }
@@ -66,20 +84,12 @@ async function ingestRepoMergedPRs(
 
   const octokit = await getInstallationOctokit(repo.installationId)
 
-  // Fetch closed PRs and filter to those merged this week
-  const pulls = await withRateLimit(() =>
-    octokit.paginate('GET /repos/{owner}/{repo}/pulls', {
-      owner: repo.owner,
-      repo: repo.name,
-      state: 'closed',
-      sort: 'updated',
-      direction: 'desc',
+  const since = weekStart.toISOString().split('T')[0] // YYYY-MM-DD
+  const mergedThisWeek = await withRateLimit(() =>
+    octokit.paginate('GET /search/issues', {
+      q: `repo:${repo.owner}/${repo.name} is:pr is:merged merged:>=${since}`,
       per_page: 100,
     })
-  )
-
-  const mergedThisWeek = pulls.filter(
-    (pr) => pr.merged_at !== null && new Date(pr.merged_at) >= weekStart
   )
 
   if (mergedThisWeek.length === 0) {

--- a/apps/worker/src/jobs/github.ts
+++ b/apps/worker/src/jobs/github.ts
@@ -2,6 +2,7 @@ import { db } from '@repo/db'
 import { getInstallationOctokit } from '../lib/github-auth'
 import { logger } from '../lib/logger'
 import { ingestRepoCommits } from '../lib/github-commit-tracker'
+import path from 'path'
 
 export async function withRateLimit<T>(fn: () => Promise<T>, retries = 3): Promise<T> {
   for (let attempt = 0; attempt <= retries; attempt++) {
@@ -12,25 +13,29 @@ export async function withRateLimit<T>(fn: () => Promise<T>, retries = 3): Promi
       const headers = (err as { response?: { headers?: Record<string, string> } })?.response
         ?.headers
 
-      // 403 can mean permission denied OR secondary rate limit — check for retry-after header
-      const isSecondaryRateLimit = status === 403 && headers?.['retry-after'] !== undefined
-      const isPrimaryRateLimit = status === 429
+      const isPrimaryRateLimit =
+        status === 429 || (status === 403 && headers?.['x-ratelimit-remaining'] === '0')
+      const isSecondaryRateLimit =
+        status === 403 && !isPrimaryRateLimit && headers?.['retry-after'] !== undefined
 
-      if (isPrimaryRateLimit && attempt < retries) {
-        const retryAfter = parseInt(headers?.['retry-after'] ?? '60', 10)
-        logger.warn(
-          `Rate limit hit. Retrying after ${retryAfter}s (attempt ${attempt + 1}/${retries})`
-        )
-        await new Promise((r) => setTimeout(r, retryAfter * 1000))
-        continue
+      const rateLimitReset = headers?.['x-ratelimit-reset']
+      const retryAfter = headers?.['retry-after']
+
+      let retryAfterSeconds = 60 // default retry after 60 seconds if not specified
+
+      if (isPrimaryRateLimit && rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10) * 1000
+        const currentTime = Date.now()
+        retryAfterSeconds = Math.max(Math.ceil((resetTime - currentTime) / 1000), 10)
+      } else if (isSecondaryRateLimit && retryAfter) {
+        retryAfterSeconds = Math.max(parseInt(retryAfter, 10), 10)
       }
 
-      if (isSecondaryRateLimit && attempt < retries) {
-        const retryAfter = parseInt(headers['retry-after']!, 10)
+      if ((isPrimaryRateLimit || isSecondaryRateLimit) && attempt < retries) {
         logger.warn(
-          `Secondary rate limit hit. Retrying after ${retryAfter}s (attempt ${attempt + 1}/${retries})`
+          `Rate limit hit. Retrying after ${retryAfterSeconds}s (attempt ${attempt + 1}/${retries})`
         )
-        await new Promise((r) => setTimeout(r, retryAfter * 1000))
+        await new Promise((r) => setTimeout(r, retryAfterSeconds * 1000))
         continue
       }
 
@@ -116,12 +121,12 @@ async function ingestRepoMergedPRs(
       })
     )
 
-    const authorIdentityId = await resolveIdentity(
-      fullPr.user ? { id: fullPr.user.id, login: fullPr.user.login } : null
-    )
-    const mergedByIdentityId = await resolveIdentity(
-      fullPr.merged_by ? { id: fullPr.merged_by.id, login: fullPr.merged_by.login } : null
-    )
+    const [authorIdentityId, mergedByIdentityId] = await Promise.all([
+      fullPr.user ? resolveIdentity({ id: fullPr.user.id, login: fullPr.user.login }, repo) : null,
+      fullPr.merged_by
+        ? resolveIdentity({ id: fullPr.merged_by.id, login: fullPr.merged_by.login }, repo)
+        : null,
+    ])
 
     await db.pRFact.upsert({
       where: { repoId_number: { repoId: repo.id, number: fullPr.number } },
@@ -157,7 +162,8 @@ async function ingestRepoMergedPRs(
 }
 
 export async function resolveIdentity(
-  user: { id: number; login: string } | null
+  user: { id: number; login: string } | null,
+  repo?: { id: string; owner: string; name: string } | null
 ): Promise<string | null> {
   if (!user) return null
 
@@ -174,9 +180,15 @@ export async function resolveIdentity(
       username: user.login,
       firstSeenAt: new Date(),
       lastSeenAt: new Date(),
+      sampleRepoName: repo ? `${repo.owner}/${repo.name}` : undefined,
     },
-    update: { lastSeenAt: new Date(), username: user.login },
+    update: {
+      lastSeenAt: new Date(),
+      username: user.login,
+      sampleRepoName: repo ? `${repo.owner}/${repo.name}` : undefined,
+    },
   })
+
   return null
 }
 
@@ -188,4 +200,21 @@ export function getWeekStart(): Date {
   monday.setUTCDate(now.getUTCDate() - diff)
   monday.setUTCHours(0, 0, 0, 0)
   return monday
+}
+
+// If this file is executed directly (eg. `tsx src/jobs/github.ts`), run the job once.
+const invokedScript = process.argv[1] ? path.resolve(process.argv[1]) : null
+// When run with `tsx src/jobs/github.ts`, process.argv[1] will point to that path.
+// Avoid using `import.meta` to keep compatibility with CommonJS builds.
+const targetPathEnding = path.join('src', 'jobs', 'github.ts')
+if (invokedScript && invokedScript.endsWith(targetPathEnding)) {
+  ;(async () => {
+    try {
+      await runGitHubIngestion()
+      process.exit(0)
+    } catch (err) {
+      console.error('runGitHubIngestion failed:', err)
+      process.exit(1)
+    }
+  })()
 }

--- a/apps/worker/src/jobs/github.ts
+++ b/apps/worker/src/jobs/github.ts
@@ -2,7 +2,6 @@ import { db } from '@repo/db'
 import { getInstallationOctokit } from '../lib/github-auth'
 import { logger } from '../lib/logger'
 import { ingestRepoCommits } from '../lib/github-commit-tracker'
-import path from 'path'
 
 export async function withRateLimit<T>(fn: () => Promise<T>, retries = 3): Promise<T> {
   for (let attempt = 0; attempt <= retries; attempt++) {
@@ -200,21 +199,4 @@ export function getWeekStart(): Date {
   monday.setUTCDate(now.getUTCDate() - diff)
   monday.setUTCHours(0, 0, 0, 0)
   return monday
-}
-
-// If this file is executed directly (eg. `tsx src/jobs/github.ts`), run the job once.
-const invokedScript = process.argv[1] ? path.resolve(process.argv[1]) : null
-// When run with `tsx src/jobs/github.ts`, process.argv[1] will point to that path.
-// Avoid using `import.meta` to keep compatibility with CommonJS builds.
-const targetPathEnding = path.join('src', 'jobs', 'github.ts')
-if (invokedScript && invokedScript.endsWith(targetPathEnding)) {
-  ;(async () => {
-    try {
-      await runGitHubIngestion()
-      process.exit(0)
-    } catch (err) {
-      console.error('runGitHubIngestion failed:', err)
-      process.exit(1)
-    }
-  })()
 }

--- a/apps/worker/src/jobs/github.ts
+++ b/apps/worker/src/jobs/github.ts
@@ -1,7 +1,147 @@
-/**
- * GitHub ingestion job.
- * TODO: Implement GitHub ingestion
- */
+import { db } from '@repo/db'
+import { getInstallationOctokit } from '../lib/github-auth'
+import { logger } from '../lib/logger'
+
 export async function runGitHubIngestion(): Promise<void> {
-  throw new Error('Not implemented')
+  const syncJob = await db.syncJob.create({
+    data: { type: 'GITHUB', status: 'RUNNING', startedAt: new Date() },
+  })
+
+  try {
+    const weekStart = getWeekStart()
+    const repos = await db.gitHubRepository.findMany()
+    let totalProcessed = 0
+
+    for (const repo of repos) {
+      try {
+        const count = await ingestRepoMergedPRs(repo, weekStart)
+        totalProcessed += count
+      } catch (err) {
+        logger.error(`Failed to ingest PRs for ${repo.owner}/${repo.name}: ${err}`)
+      }
+    }
+
+    await db.syncJob.update({
+      where: { id: syncJob.id },
+      data: { status: 'SUCCESS', finishedAt: new Date(), itemsProcessed: totalProcessed },
+    })
+    logger.info(`GitHub ingestion complete. ${totalProcessed} PRs processed.`)
+  } catch (err) {
+    await db.syncJob.update({
+      where: { id: syncJob.id },
+      data: { status: 'FAILED', finishedAt: new Date(), errorMessage: String(err) },
+    })
+    throw err
+  }
+}
+
+async function ingestRepoMergedPRs(
+  repo: { id: string; owner: string; name: string; installationId: string },
+  weekStart: Date
+): Promise<number> {
+  logger.info(`Fetching merged PRs for ${repo.owner}/${repo.name} since ${weekStart.toISOString()}`)
+
+  const octokit = await getInstallationOctokit(repo.installationId)
+
+  // Fetch closed PRs and filter to those merged this week
+  const pulls = await octokit.paginate('GET /repos/{owner}/{repo}/pulls', {
+    owner: repo.owner,
+    repo: repo.name,
+    state: 'closed',
+    sort: 'updated',
+    direction: 'desc',
+    per_page: 100,
+  })
+
+  const mergedThisWeek = pulls.filter(
+    (pr) => pr.merged_at !== null && new Date(pr.merged_at) >= weekStart
+  )
+
+  if (mergedThisWeek.length === 0) {
+    logger.info(`No merged PRs found for ${repo.owner}/${repo.name} this week.`)
+    return 0
+  }
+
+  let count = 0
+  for (const pr of mergedThisWeek) {
+    // Fetch full PR details to get additions/deletions
+    const { data: fullPr } = await octokit.request(
+      'GET /repos/{owner}/{repo}/pulls/{pull_number}',
+      {
+        owner: repo.owner,
+        repo: repo.name,
+        pull_number: pr.number,
+      }
+    )
+
+    const authorIdentityId = await resolveIdentity(
+      fullPr.user ? { id: fullPr.user.id, login: fullPr.user.login } : null
+    )
+    const mergedByIdentityId = await resolveIdentity(
+      fullPr.merged_by ? { id: fullPr.merged_by.id, login: fullPr.merged_by.login } : null
+    )
+
+    await db.pRFact.upsert({
+      where: { repoId_number: { repoId: repo.id, number: fullPr.number } },
+      create: {
+        repoId: repo.id,
+        number: fullPr.number,
+        authorIdentityId,
+        mergedByIdentityId,
+        title: fullPr.title,
+        body: fullPr.body ?? null,
+        url: fullPr.html_url,
+        labels: fullPr.labels.map((l) => l.name),
+        createdAt: new Date(fullPr.created_at),
+        mergedAt: fullPr.merged_at ? new Date(fullPr.merged_at) : null,
+        closedAt: fullPr.closed_at ? new Date(fullPr.closed_at) : null,
+        linesAdded: fullPr.additions,
+        linesRemoved: fullPr.deletions,
+        ingestedAt: new Date(),
+      },
+      update: {
+        mergedAt: fullPr.merged_at ? new Date(fullPr.merged_at) : null,
+        closedAt: fullPr.closed_at ? new Date(fullPr.closed_at) : null,
+        linesAdded: fullPr.additions,
+        linesRemoved: fullPr.deletions,
+        ingestedAt: new Date(),
+      },
+    })
+    count++
+  }
+
+  logger.info(`Saved ${count} merged PRs for ${repo.owner}/${repo.name}.`)
+  return count
+}
+
+async function resolveIdentity(user: { id: number; login: string } | null): Promise<string | null> {
+  if (!user) return null
+
+  const existing = await db.personIdentity.findUnique({
+    where: { provider_externalId: { provider: 'GITHUB', externalId: String(user.id) } },
+  })
+  if (existing) return existing.id
+
+  await db.unmatchedIdentity.upsert({
+    where: { provider_externalId: { provider: 'GITHUB', externalId: String(user.id) } },
+    create: {
+      provider: 'GITHUB',
+      externalId: String(user.id),
+      username: user.login,
+      firstSeenAt: new Date(),
+      lastSeenAt: new Date(),
+    },
+    update: { lastSeenAt: new Date(), username: user.login },
+  })
+  return null
+}
+
+function getWeekStart(): Date {
+  const now = new Date()
+  const day = now.getUTCDay() // 0=Sun, 1=Mon...
+  const diff = day === 0 ? 6 : day - 1 // days since Monday
+  const monday = new Date(now)
+  monday.setUTCDate(now.getUTCDate() - diff)
+  monday.setUTCHours(0, 0, 0, 0)
+  return monday
 }

--- a/apps/worker/src/jobs/github.ts
+++ b/apps/worker/src/jobs/github.ts
@@ -1,8 +1,9 @@
 import { db } from '@repo/db'
 import { getInstallationOctokit } from '../lib/github-auth'
 import { logger } from '../lib/logger'
+import { ingestRepoCommits } from '../lib/github-commit-tracker'
 
-async function withRateLimit<T>(fn: () => Promise<T>, retries = 3): Promise<T> {
+export async function withRateLimit<T>(fn: () => Promise<T>, retries = 3): Promise<T> {
   for (let attempt = 0; attempt <= retries; attempt++) {
     try {
       return await fn()
@@ -55,10 +56,17 @@ export async function runGitHubIngestion(): Promise<void> {
 
     for (const repo of repos) {
       try {
-        const count = await ingestRepoMergedPRs(repo, weekStart)
-        totalProcessed += count
+        const PRcount = await ingestRepoMergedPRs(repo, weekStart)
+        totalProcessed += PRcount
       } catch (err) {
         logger.error(`Failed to ingest PRs for ${repo.owner}/${repo.name}: ${err}`)
+      }
+
+      try {
+        const commitCount = await ingestRepoCommits(repo)
+        totalProcessed += commitCount
+      } catch (err) {
+        logger.error(`Failed to ingest commits for ${repo.owner}/${repo.name}: ${err}`)
       }
     }
 
@@ -66,7 +74,7 @@ export async function runGitHubIngestion(): Promise<void> {
       where: { id: syncJob.id },
       data: { status: 'SUCCESS', finishedAt: new Date(), itemsProcessed: totalProcessed },
     })
-    logger.info(`GitHub ingestion complete. ${totalProcessed} PRs processed.`)
+    logger.info(`GitHub ingestion complete. ${totalProcessed} items processed.`)
   } catch (err) {
     await db.syncJob.update({
       where: { id: syncJob.id },
@@ -148,7 +156,9 @@ async function ingestRepoMergedPRs(
   return count
 }
 
-async function resolveIdentity(user: { id: number; login: string } | null): Promise<string | null> {
+export async function resolveIdentity(
+  user: { id: number; login: string } | null
+): Promise<string | null> {
   if (!user) return null
 
   const existing = await db.personIdentity.findUnique({
@@ -170,7 +180,7 @@ async function resolveIdentity(user: { id: number; login: string } | null): Prom
   return null
 }
 
-function getWeekStart(): Date {
+export function getWeekStart(): Date {
   const now = new Date()
   const day = now.getUTCDay() // 0=Sun, 1=Mon...
   const diff = day === 0 ? 6 : day - 1 // days since Monday

--- a/apps/worker/src/jobs/github.ts
+++ b/apps/worker/src/jobs/github.ts
@@ -2,6 +2,29 @@ import { db } from '@repo/db'
 import { getInstallationOctokit } from '../lib/github-auth'
 import { logger } from '../lib/logger'
 
+async function withRateLimit<T>(fn: () => Promise<T>, retries = 3): Promise<T> {
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    try {
+      return await fn()
+    } catch (err: unknown) {
+      const status = (err as { status?: number })?.status
+      const headers = (err as { response?: { headers?: Record<string, string> } })?.response
+        ?.headers
+      const isRateLimit = status === 429 || status === 403
+      if (isRateLimit && attempt < retries) {
+        const retryAfter = parseInt(headers?.['retry-after'] ?? '60', 10)
+        logger.warn(
+          `Rate limit hit. Retrying after ${retryAfter}s (attempt ${attempt + 1}/${retries})`
+        )
+        await new Promise((r) => setTimeout(r, retryAfter * 1000))
+        continue
+      }
+      throw err
+    }
+  }
+  throw new Error('Unreachable')
+}
+
 export async function runGitHubIngestion(): Promise<void> {
   const syncJob = await db.syncJob.create({
     data: { type: 'GITHUB', status: 'RUNNING', startedAt: new Date() },
@@ -44,14 +67,16 @@ async function ingestRepoMergedPRs(
   const octokit = await getInstallationOctokit(repo.installationId)
 
   // Fetch closed PRs and filter to those merged this week
-  const pulls = await octokit.paginate('GET /repos/{owner}/{repo}/pulls', {
-    owner: repo.owner,
-    repo: repo.name,
-    state: 'closed',
-    sort: 'updated',
-    direction: 'desc',
-    per_page: 100,
-  })
+  const pulls = await withRateLimit(() =>
+    octokit.paginate('GET /repos/{owner}/{repo}/pulls', {
+      owner: repo.owner,
+      repo: repo.name,
+      state: 'closed',
+      sort: 'updated',
+      direction: 'desc',
+      per_page: 100,
+    })
+  )
 
   const mergedThisWeek = pulls.filter(
     (pr) => pr.merged_at !== null && new Date(pr.merged_at) >= weekStart
@@ -65,13 +90,12 @@ async function ingestRepoMergedPRs(
   let count = 0
   for (const pr of mergedThisWeek) {
     // Fetch full PR details to get additions/deletions
-    const { data: fullPr } = await octokit.request(
-      'GET /repos/{owner}/{repo}/pulls/{pull_number}',
-      {
+    const { data: fullPr } = await withRateLimit(() =>
+      octokit.request('GET /repos/{owner}/{repo}/pulls/{pull_number}', {
         owner: repo.owner,
         repo: repo.name,
         pull_number: pr.number,
-      }
+      })
     )
 
     const authorIdentityId = await resolveIdentity(

--- a/apps/worker/src/jobs/github.ts
+++ b/apps/worker/src/jobs/github.ts
@@ -1,60 +1,15 @@
 import { db } from '@repo/db'
-import { getInstallationOctokit } from '../lib/github-auth'
 import { logger } from '../lib/logger'
 import { ingestRepoCommits } from '../lib/github-commit-tracker'
+import { ingestRepoMergedPRs } from '../lib/github-PR-tracker'
+import { computeWeeklyGitHubMetrics } from '../lib/github-weekly-stats'
 
-export async function withRateLimit<T>(fn: () => Promise<T>, retries = 3): Promise<T> {
-  for (let attempt = 0; attempt <= retries; attempt++) {
-    try {
-      return await fn()
-    } catch (err: unknown) {
-      const status = (err as { status?: number })?.status
-      const headers = (err as { response?: { headers?: Record<string, string> } })?.response
-        ?.headers
-
-      const isPrimaryRateLimit =
-        status === 429 || (status === 403 && headers?.['x-ratelimit-remaining'] === '0')
-      const isSecondaryRateLimit =
-        status === 403 && !isPrimaryRateLimit && headers?.['retry-after'] !== undefined
-
-      const rateLimitReset = headers?.['x-ratelimit-reset']
-      const retryAfter = headers?.['retry-after']
-
-      let retryAfterSeconds = 60 // default retry after 60 seconds if not specified
-
-      if (isPrimaryRateLimit && rateLimitReset) {
-        const resetTime = parseInt(rateLimitReset, 10) * 1000
-        const currentTime = Date.now()
-        retryAfterSeconds = Math.max(Math.ceil((resetTime - currentTime) / 1000), 10)
-      } else if (isSecondaryRateLimit && retryAfter) {
-        retryAfterSeconds = Math.max(parseInt(retryAfter, 10), 10)
-      }
-
-      if ((isPrimaryRateLimit || isSecondaryRateLimit) && attempt < retries) {
-        logger.warn(
-          `Rate limit hit. Retrying after ${retryAfterSeconds}s (attempt ${attempt + 1}/${retries})`
-        )
-        await new Promise((r) => setTimeout(r, retryAfterSeconds * 1000))
-        continue
-      }
-
-      if (status === 403) {
-        logger.error('Permission denied (403). Check GitHub App permissions or installation scope.')
-      }
-
-      throw err
-    }
-  }
-  throw new Error('Unreachable')
-}
-
-export async function runGitHubIngestion(): Promise<void> {
+export async function runGitHubIngestion(weekStart: Date): Promise<void> {
   const syncJob = await db.syncJob.create({
     data: { type: 'GITHUB', status: 'RUNNING', startedAt: new Date() },
   })
 
   try {
-    const weekStart = getWeekStart()
     const repos = await db.gitHubRepository.findMany()
     let totalProcessed = 0
 
@@ -67,12 +22,14 @@ export async function runGitHubIngestion(): Promise<void> {
       }
 
       try {
-        const commitCount = await ingestRepoCommits(repo)
+        const commitCount = await ingestRepoCommits(repo, weekStart)
         totalProcessed += commitCount
       } catch (err) {
         logger.error(`Failed to ingest commits for ${repo.owner}/${repo.name}: ${err}`)
       }
     }
+
+    await computeWeeklyGitHubMetrics(weekStart)
 
     await db.syncJob.update({
       where: { id: syncJob.id },
@@ -86,117 +43,4 @@ export async function runGitHubIngestion(): Promise<void> {
     })
     throw err
   }
-}
-
-async function ingestRepoMergedPRs(
-  repo: { id: string; owner: string; name: string; installationId: string },
-  weekStart: Date
-): Promise<number> {
-  logger.info(`Fetching merged PRs for ${repo.owner}/${repo.name} since ${weekStart.toISOString()}`)
-
-  const octokit = await getInstallationOctokit(repo.installationId)
-
-  const since = weekStart.toISOString().split('T')[0] // YYYY-MM-DD
-  const mergedThisWeek = await withRateLimit(() =>
-    octokit.paginate('GET /search/issues', {
-      q: `repo:${repo.owner}/${repo.name} is:pr is:merged merged:>=${since}`,
-      per_page: 100,
-    })
-  )
-
-  if (mergedThisWeek.length === 0) {
-    logger.info(`No merged PRs found for ${repo.owner}/${repo.name} this week.`)
-    return 0
-  }
-
-  let count = 0
-  for (const pr of mergedThisWeek) {
-    // Fetch full PR details to get additions/deletions
-    const { data: fullPr } = await withRateLimit(() =>
-      octokit.request('GET /repos/{owner}/{repo}/pulls/{pull_number}', {
-        owner: repo.owner,
-        repo: repo.name,
-        pull_number: pr.number,
-      })
-    )
-
-    const [authorIdentityId, mergedByIdentityId] = await Promise.all([
-      fullPr.user ? resolveIdentity({ id: fullPr.user.id, login: fullPr.user.login }, repo) : null,
-      fullPr.merged_by
-        ? resolveIdentity({ id: fullPr.merged_by.id, login: fullPr.merged_by.login }, repo)
-        : null,
-    ])
-
-    await db.pRFact.upsert({
-      where: { repoId_number: { repoId: repo.id, number: fullPr.number } },
-      create: {
-        repoId: repo.id,
-        number: fullPr.number,
-        authorIdentityId,
-        mergedByIdentityId,
-        title: fullPr.title,
-        body: fullPr.body ?? null,
-        url: fullPr.html_url,
-        labels: fullPr.labels.map((l) => l.name),
-        createdAt: new Date(fullPr.created_at),
-        mergedAt: fullPr.merged_at ? new Date(fullPr.merged_at) : null,
-        closedAt: fullPr.closed_at ? new Date(fullPr.closed_at) : null,
-        linesAdded: fullPr.additions,
-        linesRemoved: fullPr.deletions,
-        ingestedAt: new Date(),
-      },
-      update: {
-        mergedAt: fullPr.merged_at ? new Date(fullPr.merged_at) : null,
-        closedAt: fullPr.closed_at ? new Date(fullPr.closed_at) : null,
-        linesAdded: fullPr.additions,
-        linesRemoved: fullPr.deletions,
-        ingestedAt: new Date(),
-      },
-    })
-    count++
-  }
-
-  logger.info(`Saved ${count} merged PRs for ${repo.owner}/${repo.name}.`)
-  return count
-}
-
-export async function resolveIdentity(
-  user: { id: number; login: string } | null,
-  repo?: { id: string; owner: string; name: string } | null
-): Promise<string | null> {
-  if (!user) return null
-
-  const existing = await db.personIdentity.findUnique({
-    where: { provider_externalId: { provider: 'GITHUB', externalId: String(user.id) } },
-  })
-  if (existing) return existing.id
-
-  await db.unmatchedIdentity.upsert({
-    where: { provider_externalId: { provider: 'GITHUB', externalId: String(user.id) } },
-    create: {
-      provider: 'GITHUB',
-      externalId: String(user.id),
-      username: user.login,
-      firstSeenAt: new Date(),
-      lastSeenAt: new Date(),
-      sampleRepoName: repo ? `${repo.owner}/${repo.name}` : undefined,
-    },
-    update: {
-      lastSeenAt: new Date(),
-      username: user.login,
-      sampleRepoName: repo ? `${repo.owner}/${repo.name}` : undefined,
-    },
-  })
-
-  return null
-}
-
-export function getWeekStart(): Date {
-  const now = new Date()
-  const day = now.getUTCDay() // 0=Sun, 1=Mon...
-  const diff = day === 0 ? 6 : day - 1 // days since Monday
-  const monday = new Date(now)
-  monday.setUTCDate(now.getUTCDate() - diff)
-  monday.setUTCHours(0, 0, 0, 0)
-  return monday
 }

--- a/apps/worker/src/lib/github-PR-tracker.ts
+++ b/apps/worker/src/lib/github-PR-tracker.ts
@@ -1,0 +1,79 @@
+// Fetches merged PRs for the week and stores them in the database.
+
+import { db } from '@repo/db'
+import { getInstallationOctokit } from '../lib/github-auth'
+import { logger } from '../lib/logger'
+import { resolveIdentity } from './github-utils'
+import { withRateLimit } from './github-utils'
+
+export async function ingestRepoMergedPRs(
+  repo: { id: string; owner: string; name: string; installationId: string },
+  weekStart: Date
+): Promise<number> {
+  logger.info(`Fetching merged PRs for ${repo.owner}/${repo.name} since ${weekStart.toISOString()}`)
+
+  const octokit = await getInstallationOctokit(repo.installationId)
+
+  const since = weekStart.toISOString().split('T')[0] // YYYY-MM-DD
+  const mergedThisWeek = await withRateLimit(() =>
+    octokit.paginate('GET /search/issues', {
+      q: `repo:${repo.owner}/${repo.name} is:pr is:merged merged:>=${since}`,
+      per_page: 100,
+    })
+  )
+
+  if (mergedThisWeek.length === 0) {
+    logger.info(`No merged PRs found for ${repo.owner}/${repo.name} this week.`)
+    return 0
+  }
+
+  let count = 0
+  for (const pr of mergedThisWeek) {
+    // Fetch full PR details to get additions/deletions
+    const { data: fullPr } = await withRateLimit(() =>
+      octokit.request('GET /repos/{owner}/{repo}/pulls/{pull_number}', {
+        owner: repo.owner,
+        repo: repo.name,
+        pull_number: pr.number,
+      })
+    )
+
+    const [authorIdentityId, mergedByIdentityId] = await Promise.all([
+      fullPr.user ? resolveIdentity({ id: fullPr.user.id, login: fullPr.user.login }, repo) : null,
+      fullPr.merged_by
+        ? resolveIdentity({ id: fullPr.merged_by.id, login: fullPr.merged_by.login }, repo)
+        : null,
+    ])
+
+    await db.pRFact.upsert({
+      where: { repoId_number: { repoId: repo.id, number: fullPr.number } },
+      create: {
+        repoId: repo.id,
+        number: fullPr.number,
+        authorIdentityId,
+        mergedByIdentityId,
+        title: fullPr.title,
+        body: fullPr.body ?? null,
+        url: fullPr.html_url,
+        labels: fullPr.labels.map((l) => l.name),
+        createdAt: new Date(fullPr.created_at),
+        mergedAt: fullPr.merged_at ? new Date(fullPr.merged_at) : null,
+        closedAt: fullPr.closed_at ? new Date(fullPr.closed_at) : null,
+        linesAdded: fullPr.additions,
+        linesRemoved: fullPr.deletions,
+        ingestedAt: new Date(),
+      },
+      update: {
+        mergedAt: fullPr.merged_at ? new Date(fullPr.merged_at) : null,
+        closedAt: fullPr.closed_at ? new Date(fullPr.closed_at) : null,
+        linesAdded: fullPr.additions,
+        linesRemoved: fullPr.deletions,
+        ingestedAt: new Date(),
+      },
+    })
+    count++
+  }
+
+  logger.info(`Saved ${count} merged PRs for ${repo.owner}/${repo.name}.`)
+  return count
+}

--- a/apps/worker/src/lib/github-auth.ts
+++ b/apps/worker/src/lib/github-auth.ts
@@ -1,8 +1,4 @@
-type InstallationOctokit = Awaited<
-  ReturnType<
-    import('octokit', { with: { 'resolution-mode': 'import' } }).App['getInstallationOctokit']
-  >
->
+type InstallationOctokit = import('octokit', { with: { 'resolution-mode': 'import' } }).Octokit
 
 // Kept intentionally minimal to avoid CJS/ESM type import issues with octokit.
 type GitHubAppClient = {

--- a/apps/worker/src/lib/github-commit-tracker.ts
+++ b/apps/worker/src/lib/github-commit-tracker.ts
@@ -3,16 +3,18 @@
 import { db } from '@repo/db'
 import { getInstallationOctokit } from '../lib/github-auth'
 import { logger } from '../lib/logger'
-import { resolveIdentity } from '../jobs/github'
-import { withRateLimit } from '../jobs/github'
-import { getWeekStart } from '../jobs/github'
+import { resolveIdentity } from './github-utils'
+import { withRateLimit } from './github-utils'
 
-export async function ingestRepoCommits(repo: {
-  id: string
-  owner: string
-  name: string
-  installationId: string
-}): Promise<number> {
+export async function ingestRepoCommits(
+  repo: {
+    id: string
+    owner: string
+    name: string
+    installationId: string
+  },
+  weekStart: Date
+): Promise<number> {
   logger.info(`Fetching commits for ${repo.owner}/${repo.name}`)
 
   const octokit = await getInstallationOctokit(repo.installationId)
@@ -28,7 +30,7 @@ export async function ingestRepoCommits(repo: {
   let totalCommits = 0
 
   for (const branch of branches) {
-    if (branch.name === 'main') {
+    if (branch.name === 'main' || branch.name === 'master') {
       continue
     }
 
@@ -39,7 +41,7 @@ export async function ingestRepoCommits(repo: {
         owner: repo.owner,
         repo: repo.name,
         sha: branch.name,
-        since: getWeekStart().toISOString(),
+        since: weekStart.toISOString(),
         per_page: 100,
       })
     )
@@ -52,6 +54,14 @@ export async function ingestRepoCommits(repo: {
         repo
       )
 
+      const stats = await withRateLimit(() =>
+        octokit.request('GET /repos/{owner}/{repo}/commits/{sha}', {
+          owner: repo.owner,
+          repo: repo.name,
+          sha: commit.sha,
+        })
+      ).then((res) => res.data.stats)
+
       await db.commitFact.upsert({
         // compound key to avoid duplicate entries for the same commit
         where: { repoId_sha: { repoId: repo.id, sha: commit.sha } },
@@ -61,8 +71,8 @@ export async function ingestRepoCommits(repo: {
           authorIdentityId: authorIdentityId,
           message: commit.commit.message,
           branch: branch.name,
-          linesAdded: commit.stats?.additions || 0,
-          linesRemoved: commit.stats?.deletions || 0,
+          linesAdded: stats.additions || 0,
+          linesRemoved: stats.deletions || 0,
           committedAt: new Date(commit.commit.author?.date || Date.now()),
           ingestedAt: new Date(Date.now()),
         },
@@ -70,8 +80,8 @@ export async function ingestRepoCommits(repo: {
           authorIdentityId: authorIdentityId,
           message: commit.commit.message,
           branch: branch.name,
-          linesAdded: commit.stats?.additions || 0,
-          linesRemoved: commit.stats?.deletions || 0,
+          linesAdded: stats.additions || 0,
+          linesRemoved: stats.deletions || 0,
           committedAt: new Date(commit.commit.author?.date || Date.now()),
           ingestedAt: new Date(Date.now()),
         },

--- a/apps/worker/src/lib/github-commit-tracker.ts
+++ b/apps/worker/src/lib/github-commit-tracker.ts
@@ -1,0 +1,87 @@
+// Finds the commits for each non-main branch in a repo and stores it in a database.
+
+import { db } from '@repo/db'
+import { getInstallationOctokit } from '../lib/github-auth'
+import { logger } from '../lib/logger'
+import { resolveIdentity } from '../jobs/github'
+import { withRateLimit } from '../jobs/github'
+import { getWeekStart } from '../jobs/github'
+
+export async function ingestRepoCommits(repo: {
+  id: string
+  owner: string
+  name: string
+  installationId: string
+}): Promise<number> {
+  logger.info(`Fetching commits for ${repo.owner}/${repo.name}`)
+
+  const octokit = await getInstallationOctokit(repo.installationId)
+
+  const branches = await withRateLimit(() =>
+    octokit.paginate('GET /repos/{owner}/{repo}/branches', {
+      owner: repo.owner,
+      repo: repo.name,
+      per_page: 100,
+    })
+  )
+
+  let totalCommits = 0
+
+  for (const branch of branches) {
+    if (branch.name === 'main') {
+      continue
+    }
+
+    logger.info(`Fetching commits for branch ${branch.name} of ${repo.owner}/${repo.name}`)
+
+    const commits = await withRateLimit(() =>
+      octokit.paginate('GET /repos/{owner}/{repo}/commits', {
+        owner: repo.owner,
+        repo: repo.name,
+        sha: branch.name,
+        since: getWeekStart().toISOString(),
+        per_page: 100,
+      })
+    )
+
+    if (commits.length === 0) {
+      logger.info(`No commits found for ${repo.owner}/${repo.name} this week.`)
+      return 0
+    }
+
+    totalCommits += commits.length
+
+    for (const commit of commits) {
+      const authorIdentityId = await resolveIdentity(
+        commit.author ? { id: commit.author.id, login: commit.author.login } : null
+      )
+
+      await db.commitFact.upsert({
+        // compound key to avoid duplicate entries for the same commit
+        where: { repoId_sha: { repoId: repo.id, sha: commit.sha } },
+        create: {
+          repoId: repo.id,
+          sha: commit.sha,
+          authorIdentityId: authorIdentityId,
+          message: commit.commit.message,
+          branch: branch.name,
+          linesAdded: commit.stats?.additions || 0,
+          linesRemoved: commit.stats?.deletions || 0,
+          committedAt: new Date(commit.commit.author?.date || Date.now()),
+          ingestedAt: new Date(Date.now()),
+        },
+        update: {
+          authorIdentityId: authorIdentityId,
+          message: commit.commit.message,
+          branch: branch.name,
+          linesAdded: commit.stats?.additions || 0,
+          linesRemoved: commit.stats?.deletions || 0,
+          committedAt: new Date(commit.commit.author?.date || Date.now()),
+          ingestedAt: new Date(Date.now()),
+        },
+      })
+    }
+  }
+
+  return totalCommits
+}

--- a/apps/worker/src/lib/github-commit-tracker.ts
+++ b/apps/worker/src/lib/github-commit-tracker.ts
@@ -44,16 +44,12 @@ export async function ingestRepoCommits(repo: {
       })
     )
 
-    if (commits.length === 0) {
-      logger.info(`No commits found for ${repo.owner}/${repo.name} this week.`)
-      return 0
-    }
-
     totalCommits += commits.length
 
     for (const commit of commits) {
       const authorIdentityId = await resolveIdentity(
-        commit.author ? { id: commit.author.id, login: commit.author.login } : null
+        commit.author ? { id: commit.author.id, login: commit.author.login } : null,
+        repo
       )
 
       await db.commitFact.upsert({
@@ -81,6 +77,10 @@ export async function ingestRepoCommits(repo: {
         },
       })
     }
+  }
+
+  if (totalCommits === 0) {
+    logger.info(`No commits found for ${repo.owner}/${repo.name} in the past week.`)
   }
 
   return totalCommits

--- a/apps/worker/src/lib/github-utils.ts
+++ b/apps/worker/src/lib/github-utils.ts
@@ -1,0 +1,80 @@
+// Utility functions for GitHub integration, including rate limit handling and identity resolution.
+
+import { db } from '@repo/db'
+import { logger } from '../lib/logger'
+
+export async function withRateLimit<T>(fn: () => Promise<T>, retries = 3): Promise<T> {
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    try {
+      return await fn()
+    } catch (err: unknown) {
+      const status = (err as { status?: number })?.status
+      const headers = (err as { response?: { headers?: Record<string, string> } })?.response
+        ?.headers
+
+      const isPrimaryRateLimit =
+        status === 429 || (status === 403 && headers?.['x-ratelimit-remaining'] === '0')
+      const isSecondaryRateLimit =
+        status === 403 && !isPrimaryRateLimit && headers?.['retry-after'] !== undefined
+
+      const rateLimitReset = headers?.['x-ratelimit-reset']
+      const retryAfter = headers?.['retry-after']
+
+      let retryAfterSeconds = 60 // default retry after 60 seconds if not specified
+
+      if (isPrimaryRateLimit && rateLimitReset) {
+        const resetTime = parseInt(rateLimitReset, 10) * 1000
+        const currentTime = Date.now()
+        retryAfterSeconds = Math.max(Math.ceil((resetTime - currentTime) / 1000), 10)
+      } else if (isSecondaryRateLimit && retryAfter) {
+        retryAfterSeconds = Math.max(parseInt(retryAfter, 10), 10)
+      }
+
+      if ((isPrimaryRateLimit || isSecondaryRateLimit) && attempt < retries) {
+        logger.warn(
+          `Rate limit hit. Retrying after ${retryAfterSeconds}s (attempt ${attempt + 1}/${retries})`
+        )
+        await new Promise((r) => setTimeout(r, retryAfterSeconds * 1000))
+        continue
+      }
+
+      if (status === 403) {
+        logger.error('Permission denied (403). Check GitHub App permissions or installation scope.')
+      }
+
+      throw err
+    }
+  }
+  throw new Error('Unreachable')
+}
+
+export async function resolveIdentity(
+  user: { id: number; login: string } | null,
+  repo?: { id: string; owner: string; name: string } | null
+): Promise<string | null> {
+  if (!user) return null
+
+  const existing = await db.personIdentity.findUnique({
+    where: { provider_externalId: { provider: 'GITHUB', externalId: String(user.id) } },
+  })
+  if (existing) return existing.id
+
+  await db.unmatchedIdentity.upsert({
+    where: { provider_externalId: { provider: 'GITHUB', externalId: String(user.id) } },
+    create: {
+      provider: 'GITHUB',
+      externalId: String(user.id),
+      username: user.login,
+      firstSeenAt: new Date(),
+      lastSeenAt: new Date(),
+      sampleRepoName: repo ? `${repo.owner}/${repo.name}` : undefined,
+    },
+    update: {
+      lastSeenAt: new Date(),
+      username: user.login,
+      sampleRepoName: repo ? `${repo.owner}/${repo.name}` : undefined,
+    },
+  })
+
+  return null
+}

--- a/apps/worker/src/lib/github-weekly-stats.ts
+++ b/apps/worker/src/lib/github-weekly-stats.ts
@@ -1,0 +1,204 @@
+// Computes weekly GitHub metrics for each project and stores them in the database.
+
+import { db } from '@repo/db'
+import { logger } from '../lib/logger'
+
+export async function computeWeeklyGitHubMetrics(weekStart: Date): Promise<void> {
+  logger.info(`Starting weekly metrics computation for week starting ${weekStart.toISOString()}`)
+  const projects = await db.project.findMany({
+    select: {
+      id: true,
+      repositories: { select: { id: true } },
+    },
+  })
+
+  for (const project of projects) {
+    const repoIds = project.repositories.map((repository) => repository.id)
+
+    if (repoIds.length === 0) {
+      continue
+    }
+
+    const [commitFacts, mergedPrFacts] = await Promise.all([
+      db.commitFact.findMany({
+        where: {
+          repoId: { in: repoIds },
+          committedAt: { gte: weekStart },
+        },
+        select: {
+          authorIdentityId: true,
+          linesAdded: true,
+          linesRemoved: true,
+        },
+      }),
+      db.pRFact.findMany({
+        where: {
+          repoId: { in: repoIds },
+          mergedAt: { gte: weekStart },
+        },
+        select: {
+          authorIdentityId: true,
+        },
+      }),
+    ])
+
+    const commits = commitFacts.length
+    const prsMerged = mergedPrFacts.length
+    let linesAdded = 0
+    let linesRemoved = 0
+    for (const commit of commitFacts) {
+      linesAdded += commit.linesAdded
+      linesRemoved += commit.linesRemoved
+    }
+
+    logger.info(
+      `Project ${project.id}: fetched ${commits} commits and ${prsMerged} merged PRs; linesAdded=${linesAdded}, linesRemoved=${linesRemoved}`
+    )
+
+    const identityIds = new Set<string>()
+    for (const commitFact of commitFacts) {
+      if (commitFact.authorIdentityId) identityIds.add(commitFact.authorIdentityId)
+    }
+    for (const mergedPrFact of mergedPrFacts) {
+      if (mergedPrFact.authorIdentityId) identityIds.add(mergedPrFact.authorIdentityId)
+    }
+
+    const personIdentities = identityIds.size
+      ? await db.personIdentity.findMany({
+          where: { id: { in: Array.from(identityIds) } },
+          select: { id: true, personId: true },
+        })
+      : []
+
+    const identityToPersonId = new Map(
+      personIdentities.map((identity) => [identity.id, identity.personId])
+    )
+    const personIds = Array.from(new Set(personIdentities.map((identity) => identity.personId)))
+    const projectMembers = personIds.length
+      ? await db.projectMember.findMany({
+          where: { projectId: project.id, personId: { in: personIds } },
+          select: { id: true, personId: true },
+        })
+      : []
+
+    const personToProjectMember = new Map(
+      projectMembers.map((projectMember) => [projectMember.personId, projectMember.id])
+    )
+
+    const memberContrib = new Map<
+      string,
+      {
+        projectMemberId: string
+        personId: string
+        commits: number
+        prsMerged: number
+        linesAdded: number
+        linesRemoved: number
+      }
+    >()
+
+    for (const commitFact of commitFacts) {
+      if (!commitFact.authorIdentityId) continue
+      const personId = identityToPersonId.get(commitFact.authorIdentityId)
+      if (!personId) continue
+      const projectMemberId = personToProjectMember.get(personId)
+      if (!projectMemberId) continue
+
+      const current = memberContrib.get(projectMemberId) ?? {
+        projectMemberId,
+        personId,
+        commits: 0,
+        prsMerged: 0,
+        linesAdded: 0,
+        linesRemoved: 0,
+      }
+
+      current.commits += 1
+      current.linesAdded += commitFact.linesAdded
+      current.linesRemoved += commitFact.linesRemoved
+      memberContrib.set(projectMemberId, current)
+    }
+
+    for (const mergedPrFact of mergedPrFacts) {
+      if (!mergedPrFact.authorIdentityId) continue
+      const personId = identityToPersonId.get(mergedPrFact.authorIdentityId)
+      if (!personId) continue
+      const projectMemberId = personToProjectMember.get(personId)
+      if (!projectMemberId) continue
+
+      const current = memberContrib.get(projectMemberId) ?? {
+        projectMemberId,
+        personId,
+        commits: 0,
+        prsMerged: 0,
+        linesAdded: 0,
+        linesRemoved: 0,
+      }
+
+      current.prsMerged += 1
+      memberContrib.set(projectMemberId, current)
+    }
+
+    logger.info(
+      `Project ${project.id}: adding weeklyStats and ${memberContrib.size} member contributions`
+    )
+    try {
+      await db.$transaction(async (tx) => {
+        await tx.weeklyStats.upsert({
+          where: {
+            projectId_weekStart: {
+              projectId: project.id,
+              weekStart,
+            },
+          },
+          create: {
+            projectId: project.id,
+            weekStart,
+            commits,
+            prsMerged,
+            linesAdded,
+            linesRemoved,
+            computedAt: new Date(),
+          },
+          update: {
+            commits,
+            prsMerged,
+            linesAdded,
+            linesRemoved,
+            computedAt: new Date(),
+          },
+        })
+
+        for (const contrib of memberContrib.values()) {
+          await tx.memberWeeklyContribution.upsert({
+            where: {
+              projectMemberId_weekStart: {
+                projectMemberId: contrib.projectMemberId,
+                weekStart,
+              },
+            },
+            create: {
+              projectMemberId: contrib.projectMemberId,
+              personId: contrib.personId,
+              weekStart,
+              commits: contrib.commits,
+              prsMerged: contrib.prsMerged,
+              linesAdded: contrib.linesAdded,
+              linesRemoved: contrib.linesRemoved,
+            },
+            update: {
+              commits: contrib.commits,
+              prsMerged: contrib.prsMerged,
+              linesAdded: contrib.linesAdded,
+              linesRemoved: contrib.linesRemoved,
+            },
+          })
+        }
+      })
+      logger.info(`Project ${project.id}: successfully added weekly stats and member contributions`)
+    } catch (err) {
+      logger.error(`Project ${project.id}: failed to added weekly metrics: ${err}`)
+      throw err
+    }
+  }
+}


### PR DESCRIPTION
## Description

- Goes through all the non-main branches in all the repos and stores all the commits in the database.
- Handles unmatched identities and rate errors.


## Solution

- I went through all the repos in the database, then fetched all the branches in the repo.
- I then fetched all the commits for the branch and then stored them in the database.
- I used Grace's helper functions for detecting GitHub rate limit issues, getting the start of the week, and for dealing with unmatched identities.
- I improved the rate limit and unmatched identities functions to match Oshan's requirements.



## Notes
There is a circular import issue, since I am using the github.ts file for the helper functions and github.ts is calling my file.
I could move these functions to a utils file or something if necessary.