### PR TITLE
[#25] Persist weekly Discord message aggregate counts 

### DIFF
--- a/apps/worker/src/jobs/discord.ts
+++ b/apps/worker/src/jobs/discord.ts
@@ -252,25 +252,19 @@ export async function runDiscordIngestion(): Promise<ProjectData[]> {
       const uniqueAuthors = authorIds.length
       const messageCount = fetchedMessages.length
 
-      await db.discordWeeklyAggregate.upsert({
-        where: { projectId_weekStart: { projectId: project.id, weekStart } },
-        create: {
-          projectId: project.id,
-          weekStart,
-          messageCount,
-          uniqueAuthors,
-          unmappedMessageCount,
-        },
-        update: {
-          messageCount,
-          uniqueAuthors,
-          unmappedMessageCount,
-          computedAt: new Date(),
-        },
-      })
-
-      await Promise.all(
-        [...identityCounts].map(([authorIdentityId, count]) =>
+      await db.$transaction([
+        db.discordWeeklyAggregate.upsert({
+          where: { projectId_weekStart: { projectId: project.id, weekStart } },
+          create: {
+            projectId: project.id,
+            weekStart,
+            messageCount,
+            uniqueAuthors,
+            unmappedMessageCount,
+          },
+          update: { messageCount, uniqueAuthors, unmappedMessageCount, computedAt: new Date() },
+        }),
+        ...[...identityCounts].map(([authorIdentityId, count]) =>
           db.discordIdentityWeeklyCount.upsert({
             where: {
               projectId_weekStart_authorIdentityId: {
@@ -282,8 +276,8 @@ export async function runDiscordIngestion(): Promise<ProjectData[]> {
             create: { projectId: project.id, weekStart, authorIdentityId, messageCount: count },
             update: { messageCount: count, computedAt: new Date() },
           })
-        )
-      )
+        ),
+      ])
 
       data.push({
         projectId: project.id,

--- a/apps/worker/src/jobs/discord.ts
+++ b/apps/worker/src/jobs/discord.ts
@@ -135,11 +135,15 @@ async function requestMessages(path: string): Promise<APIMessage[]> {
  * Fetches all messages posted in a given Discord channel within the past week.
  * Handles pagination, rate limits, and filters out bot messages.
  * @param {string} channelId The ID of the Discord channel to fetch messages from.
+ * @param {Date} weekStart The start of the week to fetch messages from.
+ * @param {Date} weekEnd The end of the week to fetch messages until.
  * @returns An array of message contents posted in the past week.
  */
-async function fetchWeeklyMessages(channelId: string): Promise<FetchedMessage[]> {
-  const weekStart = startOfWeek(new Date())
-  const weekEnd = new Date()
+async function fetchWeeklyMessages(
+  channelId: string,
+  weekStart: Date,
+  weekEnd: Date
+): Promise<FetchedMessage[]> {
   const afterSnowflake = timestampToSnowflake(weekStart.getTime())
   const fetchedMessages: FetchedMessage[] = []
   let after = afterSnowflake
@@ -190,6 +194,7 @@ export async function runDiscordIngestion(): Promise<ProjectData[]> {
 
   const data: ProjectData[] = []
   const weekStart = startOfWeek(new Date())
+  const weekEnd = new Date()
 
   for (const project of projects) {
     if (project.channels.length === 0) {
@@ -211,7 +216,7 @@ export async function runDiscordIngestion(): Promise<ProjectData[]> {
 
     try {
       for (const channel of project.channels) {
-        const channelMessages = await fetchWeeklyMessages(channel.externalId)
+        const channelMessages = await fetchWeeklyMessages(channel.externalId, weekStart, weekEnd)
 
         if (channelMessages.length === 0) {
           logger.warn(`No messages found for channel ${channel.name} in project "${project.name}"`)

--- a/apps/worker/src/jobs/discord.ts
+++ b/apps/worker/src/jobs/discord.ts
@@ -1,5 +1,5 @@
 import { logger } from '../lib/logger'
-import { db, SyncJobStatus, SyncJobType } from '@repo/db'
+import { db, IdentityProvider, SyncJobStatus, SyncJobType } from '@repo/db'
 
 /**
  * 1st Jan 2015, the epoch used by Discord snowflakes.
@@ -33,6 +33,14 @@ interface APIMessage {
   }
   content: string
   timestamp: string
+}
+
+/**
+ * A simplified message structure containing only the content and author ID.
+ */
+interface FetchedMessage {
+  content: string
+  authorId: string
 }
 
 /**
@@ -129,11 +137,11 @@ async function requestMessages(path: string): Promise<APIMessage[]> {
  * @param {string} channelId The ID of the Discord channel to fetch messages from.
  * @returns An array of message contents posted in the past week.
  */
-async function fetchWeeklyMessages(channelId: string): Promise<string[]> {
+async function fetchWeeklyMessages(channelId: string): Promise<FetchedMessage[]> {
   const weekStart = startOfWeek(new Date())
   const weekEnd = new Date()
   const afterSnowflake = timestampToSnowflake(weekStart.getTime())
-  const all: string[] = []
+  const fetchedMessages: FetchedMessage[] = []
   let after = afterSnowflake
 
   while (true) {
@@ -146,15 +154,15 @@ async function fetchWeeklyMessages(channelId: string): Promise<string[]> {
         (m) =>
           !m.author.bot && new Date(m.timestamp) >= weekStart && new Date(m.timestamp) <= weekEnd
       )
-      .map((m) => m.content)
+      .map((m) => ({ content: m.content, authorId: m.author.id }))
 
-    all.push(...valid)
+    fetchedMessages.push(...valid)
 
     if (batch.length < 100) break
     after = batch[batch.length - 1].id
   }
 
-  return all
+  return fetchedMessages
 }
 
 /**
@@ -181,6 +189,7 @@ export async function runDiscordIngestion(): Promise<ProjectData[]> {
   }
 
   const data: ProjectData[] = []
+  const weekStart = startOfWeek(new Date())
 
   for (const project of projects) {
     if (project.channels.length === 0) {
@@ -198,27 +207,87 @@ export async function runDiscordIngestion(): Promise<ProjectData[]> {
     })
 
     let itemsProcessed = 0
-    const messages: string[] = []
+    const fetchedMessages: FetchedMessage[] = []
 
     try {
       for (const channel of project.channels) {
-        const fetchedMessages = await fetchWeeklyMessages(channel.externalId)
+        const channelMessages = await fetchWeeklyMessages(channel.externalId)
 
-        if (fetchedMessages.length === 0) {
+        if (channelMessages.length === 0) {
           logger.warn(`No messages found for channel ${channel.name} in project "${project.name}"`)
           continue
         }
 
-        itemsProcessed += fetchedMessages.length
-        messages.push(...fetchedMessages)
+        itemsProcessed += channelMessages.length
+        fetchedMessages.push(...channelMessages)
         logger.info(
-          `Fetched ${fetchedMessages.length} messages from channel ${channel.name} in project "${project.name}"`
+          `Fetched ${channelMessages.length} messages from channel ${channel.name} in project "${project.name}"`
         )
       }
 
+      const authorIds = [...new Set(fetchedMessages.map((m) => m.authorId))]
+
+      const knownIdentities = await db.personIdentity.findMany({
+        where: {
+          provider: IdentityProvider.DISCORD,
+          externalId: { in: authorIds },
+        },
+        select: { id: true, externalId: true },
+      })
+
+      const discordIdToIdentityId = new Map(knownIdentities.map((i) => [i.externalId, i.id]))
+
+      const identityCounts = new Map<string, number>()
+      let unmappedMessageCount = 0
+
+      for (const msg of fetchedMessages) {
+        const identityId = discordIdToIdentityId.get(msg.authorId)
+        if (identityId) {
+          identityCounts.set(identityId, (identityCounts.get(identityId) ?? 0) + 1)
+        } else {
+          unmappedMessageCount++
+        }
+      }
+
+      const uniqueAuthors = authorIds.length
+      const messageCount = fetchedMessages.length
+
+      await db.discordWeeklyAggregate.upsert({
+        where: { projectId_weekStart: { projectId: project.id, weekStart } },
+        create: {
+          projectId: project.id,
+          weekStart,
+          messageCount,
+          uniqueAuthors,
+          unmappedMessageCount,
+        },
+        update: {
+          messageCount,
+          uniqueAuthors,
+          unmappedMessageCount,
+          computedAt: new Date(),
+        },
+      })
+
+      await Promise.all(
+        [...identityCounts].map(([authorIdentityId, count]) =>
+          db.discordIdentityWeeklyCount.upsert({
+            where: {
+              projectId_weekStart_authorIdentityId: {
+                projectId: project.id,
+                weekStart,
+                authorIdentityId,
+              },
+            },
+            create: { projectId: project.id, weekStart, authorIdentityId, messageCount: count },
+            update: { messageCount: count, computedAt: new Date() },
+          })
+        )
+      )
+
       data.push({
         projectId: project.id,
-        messages,
+        messages: fetchedMessages.map((m) => m.content),
       })
 
       await db.syncJob.update({


### PR DESCRIPTION
## Description
During Discord ingestion, weekly message counts were being fetched and discarded. This PR persists those counts to `DiscordWeeklyAggregate` and `DiscordIdentityWeeklyCount` so project-level Discord activity is recorded and available for scoring and the executive view.

## Solution
`fetchWeeklyMessages` now returns `FetchedMessage` objects (content + author Discord ID) instead of raw content strings. After all channels for a project are fetched, the ingestion job:

1. Resolves author Discord IDs against `PersonIdentity` to split mapped vs unmapped authors
2. Upserts a `DiscordWeeklyAggregate` row with total message count, unique author count, and unmapped message count
3. Upserts a `DiscordIdentityWeeklyCount` row for each mapped author

Only content strings are passed forward to the LLM job - raw messages are still never persisted.

## Notes
- Weeks with zero messages write a zero-count aggregate row rather than skipping, so it can always be assumed that a row exists for any active project-week