### PR TITLE
[#75] Use Project Slug Instead of Project ID

### DIFF
--- a/apps/web/src/app/(admin)/admin-dashboard/page.tsx
+++ b/apps/web/src/app/(admin)/admin-dashboard/page.tsx
@@ -49,7 +49,7 @@ export default function AdminDashboardPage() {
         {projects.map((project) => (
           <li key={project.id}>
             <strong style={{ textDecoration: 'underline' }}>
-              <Link href={`/projects/${project.id}`}>{project.name}</Link>
+              <Link href={`/projects/${project.slug}`}>{project.name}</Link>
             </strong>
             <p>{project.description}</p>
             <p>Slug: {project.slug}</p>

--- a/apps/web/src/app/(admin)/people/[personId]/page.tsx
+++ b/apps/web/src/app/(admin)/people/[personId]/page.tsx
@@ -17,6 +17,7 @@ type PersonIdentity = {
 type Project = {
   id: string
   name: string
+  slug: string
 }
 
 type ProjectMember = {
@@ -451,7 +452,7 @@ export default function PersonPage({ params }: { params: Promise<{ personId: str
                 <div>
                   <p style={{ margin: '0 0 8px 0' }}>
                     <strong>Project:</strong>{' '}
-                    <Link href={`/projects/${membership.projectId}`}>
+                    <Link href={`/projects/${membership.project.slug}`}>
                       {membership.project?.name || membership.projectId}
                     </Link>
                   </p>

--- a/apps/web/src/app/(admin)/projects/[slug]/members/new/page.tsx
+++ b/apps/web/src/app/(admin)/projects/[slug]/members/new/page.tsx
@@ -27,10 +27,10 @@ type Person = {
   identities: PersonIdentity[]
 }
 
-export default function CreateMemberPage({ params }: { params: Promise<{ id: string }> }) {
+export default function CreateMemberPage({ params }: { params: Promise<{ slug: string }> }) {
   const router = useRouter()
-  // Extract projectId from the url
-  const { id: projectId } = use(params)
+  // Extract slug from the url
+  const { slug } = use(params)
 
   const [existingPeople, setExistingPeople] = useState<Person[]>([])
   const [selectedPersonId, setSelectedPersonId] = useState<string>('NEW')
@@ -60,7 +60,7 @@ export default function CreateMemberPage({ params }: { params: Promise<{ id: str
     }
 
     // Dynamically inject the correct URL
-    const response = await fetch(`/api/project/${projectId}/members`, {
+    const response = await fetch(`/api/project/${slug}/members`, {
       method: 'POST',
       body: formData,
     })
@@ -79,7 +79,7 @@ export default function CreateMemberPage({ params }: { params: Promise<{ id: str
     }
 
     // Redirect back to the specific project view
-    router.push(`/projects/${projectId}`)
+    router.push(`/projects/${slug}`)
   }
 
   const isExistingMember = selectedPersonId !== 'NEW'

--- a/apps/web/src/app/(admin)/projects/[slug]/page.tsx
+++ b/apps/web/src/app/(admin)/projects/[slug]/page.tsx
@@ -32,9 +32,9 @@ type ProjectMember = {
   person: Person
 }
 
-const fetchMembers = async (projectId: string): Promise<ProjectMember[]> => {
+const fetchMembers = async (slug: string): Promise<ProjectMember[]> => {
   try {
-    const response = await fetch(`/api/project/${projectId}/members`)
+    const response = await fetch(`/api/project/${slug}/members`)
     if (!response.ok) {
       throw new Error('Failed to fetch members')
     }
@@ -45,24 +45,24 @@ const fetchMembers = async (projectId: string): Promise<ProjectMember[]> => {
   }
 }
 
-export default function ProjectPage({ params }: { params: Promise<{ id: string }> }) {
+export default function ProjectPage({ params }: { params: Promise<{ slug: string }> }) {
   // 1. Unwrap the Next.js 15 Async Params using the React `use` hook in a Client Component
-  const { id: projectId } = use(params)
+  const { slug } = use(params)
   const [members, setMembers] = useState<ProjectMember[]>([])
   const router = useRouter()
 
   useEffect(() => {
     const load = async () => {
-      const data = await fetchMembers(projectId)
+      const data = await fetchMembers(slug)
       setMembers(data)
     }
 
     load()
-  }, [projectId])
+  }, [slug])
 
   return (
     <div>
-      <h1>Project Details for ID: {projectId}</h1>
+      <h1>Project Details for: {slug}</h1>
 
       <h2>Active Members ({members.length})</h2>
       <ul>
@@ -83,7 +83,7 @@ export default function ProjectPage({ params }: { params: Promise<{ id: string }
         ))}
       </ul>
 
-      <button onClick={() => router.push(`/projects/${projectId}/members/new`)}>
+      <button onClick={() => router.push(`/projects/${slug}/members/new`)}>
         Add New Member (Button)
       </button>
     </div>

--- a/apps/web/src/app/api/project/[slug]/members/route.ts
+++ b/apps/web/src/app/api/project/[slug]/members/route.ts
@@ -9,20 +9,13 @@ export async function GET(_: Request, { params }: { params: Promise<{ slug: stri
 
   const { slug } = await params
 
-  const project = await db.project.findUnique({
-    where: { slug },
-    select: { id: true },
-  })
-
-  if (!project) {
-    return Response.json({ error: 'Project not found' }, { status: 404 })
-  }
-
   try {
     const members = await db.projectMember.findMany({
       where: {
         isActive: true,
-        projectId: project.id,
+        project: {
+          slug,
+        },
       },
       include: {
         person: {

--- a/apps/web/src/app/api/project/[slug]/members/route.ts
+++ b/apps/web/src/app/api/project/[slug]/members/route.ts
@@ -2,20 +2,27 @@ import { db } from '@repo/db'
 import { hasRole } from '@/lib/auth'
 
 // API route for getting all members of a project
-export async function GET(
-  request: Request,
-  { params }: { params: Promise<{ projectId: string }> }
-) {
+export async function GET(_: Request, { params }: { params: Promise<{ slug: string }> }) {
   if (!(await hasRole('ADMIN'))) {
     return Response.json({ error: 'Unauthorized. Admin access required.' }, { status: 403 })
   }
 
-  const { projectId } = await params
+  const { slug } = await params
+
+  const project = await db.project.findUnique({
+    where: { slug },
+    select: { id: true },
+  })
+
+  if (!project) {
+    return Response.json({ error: 'Project not found' }, { status: 404 })
+  }
+
   try {
     const members = await db.projectMember.findMany({
       where: {
         isActive: true,
-        projectId: projectId,
+        projectId: project.id,
       },
       include: {
         person: {
@@ -33,16 +40,13 @@ export async function GET(
 }
 
 // API route for adding a member to a project
-export async function POST(
-  request: Request,
-  { params }: { params: Promise<{ projectId: string }> }
-) {
+export async function POST(request: Request, { params }: { params: Promise<{ slug: string }> }) {
   if (!(await hasRole('ADMIN'))) {
     return Response.json({ error: 'Unauthorized. Admin access required.' }, { status: 403 })
   }
 
   try {
-    const { projectId } = await params
+    const { slug } = await params
     const formData = await request.formData()
 
     let targetPersonId = String(formData.get('personId') ?? '').trim()
@@ -100,10 +104,19 @@ export async function POST(
         targetPersonId = newPerson.id
       }
 
+      const project = await tx.project.findUnique({
+        where: { slug },
+        select: { id: true },
+      })
+
+      if (!project) {
+        throw new Error('Project not found')
+      }
+
       // Prevent adding the exact same person to the project twice
       const existingMember = await tx.projectMember.findFirst({
         where: {
-          projectId,
+          projectId: project.id,
           personId: targetPersonId,
         },
       })
@@ -129,7 +142,7 @@ export async function POST(
       // Scenario 1 & 2: Link the person to the project
       return await tx.projectMember.create({
         data: {
-          projectId: projectId,
+          projectId: project.id,
           personId: targetPersonId,
           displayName: targetDisplayName, // Explicitly overriding ProjectMember's displayName
           isActive: true,
@@ -146,7 +159,11 @@ export async function POST(
 
     const errorMessage = error instanceof Error ? error.message : 'Failed to add member'
     const status =
-      errorMessage === 'This person is already an active member of this project!' ? 409 : 500
+      errorMessage === 'This person is already an active member of this project!'
+        ? 409
+        : errorMessage === 'Project not found'
+          ? 404
+          : 500
 
     return Response.json({ error: errorMessage }, { status })
   }


### PR DESCRIPTION
## Description
Refactor project-related pages and API routes to use the project slug in URLs instead of the internal project ID, making URLs cleaner and more meaningful.

## Solution
- Rename dynamic route folders from [id] to [slug] and update all params references accordingly
- Resolve the project by slug in the API and page data fetches, then use the returned id for internal DB lookups
- Update all hrefs and router.push calls pointing to project URLs to use slug instead of ID

Notes
- The id field is unchanged in the DB and all internal relations - this change only affects URLs.