### PR TITLE
[#93] Import IdentityProvider from @repo/db

### DIFF
--- a/apps/web/src/app/(admin)/people/[personId]/page.tsx
+++ b/apps/web/src/app/(admin)/people/[personId]/page.tsx
@@ -3,8 +3,7 @@
 import { useEffect, useState, use, FormEvent, useCallback } from 'react'
 import Link from 'next/link'
 import Image from 'next/image'
-
-type IdentityProvider = 'GITHUB' | 'DISCORD'
+import { IdentityProvider } from '@repo/db'
 
 type PersonIdentity = {
   id: string

--- a/apps/web/src/app/(admin)/projects/[slug]/members/new/page.tsx
+++ b/apps/web/src/app/(admin)/projects/[slug]/members/new/page.tsx
@@ -11,8 +11,7 @@
 import type { FormEvent } from 'react'
 import { useRouter } from 'next/navigation'
 import { use, useState, useEffect } from 'react'
-
-type IdentityProvider = 'GITHUB' | 'DISCORD'
+import { IdentityProvider } from '@repo/db'
 
 type PersonIdentity = {
   id: string

--- a/apps/web/src/app/(admin)/projects/[slug]/page.tsx
+++ b/apps/web/src/app/(admin)/projects/[slug]/page.tsx
@@ -3,8 +3,7 @@
 import { useEffect, useState, use } from 'react'
 import { useRouter } from 'next/navigation'
 import Link from 'next/link'
-
-type IdentityProvider = 'GITHUB' | 'DISCORD'
+import { IdentityProvider } from '@repo/db'
 
 type PersonIdentity = {
   id: string


### PR DESCRIPTION
## Description
`IdentityProvider` was being manually redefined in three frontend files instead of imported from the database package.

## Solution
- Removed local `type IdentityProvider = 'GITHUB' | 'DISCORD'` from all three files
- Replaced with `import { IdentityProvider } from '@repo/db'`

## Notes
No behaviour changes.