### PR TITLE
[#98] Fail CI on schema drift between dev DB and latest migration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,12 +108,8 @@ jobs:
             CHANGED=$(echo "$DIFF_OUTPUT" | grep -Ei "^\+.*(table|column|index|constraint|sequence|type|function|alter)" | head -20 || true)
             echo ""
             echo "╔══════════════════════════════════════════════════════════════╗"
-            echo "║              ⚠️  SCHEMA DRIFT DETECTED  ⚠️                   ║"
+            echo "║              ⚠️  SCHEMA DRIFT DETECTED  ⚠️                  ║"
             echo "╚══════════════════════════════════════════════════════════════╝"
-            echo ""
-            echo "The live dev DB schema does not match the latest migration."
-            echo "Someone likely changed the schema directly in the Supabase dashboard"
-            echo "without generating a corresponding Prisma migration."
             echo ""
             echo "────────────────────────────────────────────────────────────────"
             echo "Diff (expected ← → live, capped at 200 lines):"
@@ -126,13 +122,9 @@ jobs:
               echo "$CHANGED"
               echo ""
             fi
-            echo "How to fix:"
-            echo "  1. Introspect the live DB:  prisma db pull"
-            echo "  2. Generate a migration:    prisma migrate dev --name <describe_change>"
-            echo "  3. Commit and push the new migration file."
-            exit 1  # fail fast — no point running Prisma check if SQL diff already caught drift
+            exit 1
           else
-            echo "✅ SQL diff clean."
+            echo "✓ SQL diff clean."
           fi
 
       - name: Prisma-native drift check
@@ -158,7 +150,7 @@ jobs:
             echo "  3. Commit and push the new migration file."
             exit 1
           else
-            echo "✅ Prisma drift check clean."
+            echo "✓ Prisma drift check clean."
           fi
 
       - name: Cleanup shadow DB container

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,9 @@ jobs:
 
           if [ $PRISMA_EXIT -ne 0 ]; then
             echo ""
-            echo "✘ ERROR: Schema drift detected"
+            echo "╔══════════════════════════════════════════════════════════════╗"
+            echo "║              ⚠️  SCHEMA DRIFT DETECTED  ⚠️                  ║"
+            echo "╚══════════════════════════════════════════════════════════════╝"
             echo ""
             echo "The live dev DB schema does not match the latest migration."
             echo "Someone likely changed the schema directly in the Supabase dashboard"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
             -e POSTGRES_PASSWORD=postgres \
             -e POSTGRES_DB=shadow \
             -p 5433:5432 \
-            postgres:17
+            postgres:17.6
 
           until pg_isready -h localhost -p 5433 -U postgres; do
             echo "Waiting for shadow DB..."
@@ -101,8 +101,13 @@ jobs:
 
       - name: SQL diff
         run: |
+          # Strip pg_dump header metadata that varies between instances
+          # (\restrict tokens, version strings) but isn't schema
+          grep -v "^\\\\" /tmp/live_schema.sql | grep -v "^-- Dumped" > /tmp/live_clean.sql
+          grep -v "^\\\\" /tmp/expected_schema.sql | grep -v "^-- Dumped" > /tmp/expected_clean.sql
+
           set +e
-          DIFF_OUTPUT=$(diff --unified /tmp/expected_schema.sql /tmp/live_schema.sql)
+          DIFF_OUTPUT=$(diff --unified /tmp/expected_clean.sql /tmp/live_clean.sql)
           DIFF_EXIT=$?
           set -e
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,18 +14,6 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
 
-      - name: Install PostgreSQL 17 client
-        run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y curl ca-certificates
-          curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc \
-            | sudo gpg --dearmor -o /usr/share/keyrings/postgresql.gpg
-          echo "deb [signed-by=/usr/share/keyrings/postgresql.gpg] https://apt.postgresql.org/pub/repos/apt noble-pgdg main" \
-            | sudo tee /etc/apt/sources.list.d/pgdg.list
-          sudo apt-get update -qq
-          sudo apt-get install -y postgresql-client-17
-          /usr/lib/postgresql/17/bin/pg_dump --version
-
       - uses: pnpm/action-setup@v4
 
       - uses: actions/setup-node@v4
@@ -35,108 +23,6 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install
-
-      - name: Dump live dev DB schema
-        env:
-          DIRECT_URL: ${{ secrets.DIRECT_URL }}
-        run: |
-          /usr/lib/postgresql/17/bin/pg_dump \
-            --schema-only \
-            --no-owner \
-            --no-acl \
-            --no-comments \
-            --clean \
-            --quote-all-identifiers \
-            --exclude-schema=extensions \
-            --exclude-table=_prisma_migrations \
-            "$DIRECT_URL" \
-            --schema=public \
-            -f /tmp/live_schema.sql
-
-      - name: Generate expected schema from migrations
-        run: |
-          docker run -d \
-            --name migration_db \
-            -e POSTGRES_USER=postgres \
-            -e POSTGRES_PASSWORD=postgres \
-            -e POSTGRES_DB=shadow \
-            -p 5433:5432 \
-            postgres:17.6
-
-          until pg_isready -h localhost -p 5433 -U postgres; do
-            echo "Waiting for shadow DB..."
-            sleep 1
-          done
-          sleep 2  # guard against ready-before-extensions race
-
-          # Install common Supabase extensions so migration replay doesn't fail
-          # on CREATE EXTENSION statements
-          PGPASSWORD=postgres psql -h localhost -p 5433 -U postgres -d shadow -c "
-            CREATE EXTENSION IF NOT EXISTS \"uuid-ossp\";
-            CREATE EXTENSION IF NOT EXISTS pgcrypto;
-            CREATE EXTENSION IF NOT EXISTS citext;
-          "
-
-          for f in $(find packages/db/prisma/migrations -name migration.sql | sort); do
-            echo "Applying migration: $f"
-            PGPASSWORD=postgres psql \
-              -h localhost -p 5433 \
-              -U postgres -d shadow \
-              -f "$f"
-          done
-
-          PGPASSWORD=postgres /usr/lib/postgresql/17/bin/pg_dump \
-            --schema-only \
-            --no-owner \
-            --no-acl \
-            --no-comments \
-            --clean \
-            --quote-all-identifiers \
-            --exclude-schema=extensions \
-            --exclude-table=_prisma_migrations \
-            -h localhost -p 5433 \
-            -U postgres shadow \
-            --schema=public \
-            -f /tmp/expected_schema.sql
-
-      - name: SQL diff
-        run: |
-          # Strip pg_dump header metadata that varies between instances
-          # (\restrict tokens, version strings) but isn't schema
-          grep -v "^\\\\restrict\|^\\\\unrestrict" /tmp/live_schema.sql | grep -v "^-- Dumped" > /tmp/live_clean.sql
-          grep -v "^\\\\restrict\|^\\\\unrestrict" /tmp/expected_schema.sql | grep -v "^-- Dumped" > /tmp/expected_clean.sql
-
-          set +e
-          DIFF_OUTPUT=$(diff --unified /tmp/expected_clean.sql /tmp/live_clean.sql)
-          DIFF_EXIT=$?
-          set -e
-
-          if [ $DIFF_EXIT -ne 0 ]; then
-            CHANGED=$(echo "$DIFF_OUTPUT" | grep -Ei "^\+.*(table|column|index|constraint|sequence|type|function|alter)" | head -20 || true)
-            echo ""
-            echo "╔══════════════════════════════════════════════════════════════╗"
-            echo "║              ⚠️  SCHEMA DRIFT DETECTED  ⚠️                   ║"
-            echo "╚══════════════════════════════════════════════════════════════╝"
-            echo ""
-            echo "The live dev DB schema does not match the latest migration."
-            echo "Someone likely changed the schema directly in the Supabase dashboard"
-            echo "without generating a corresponding Prisma migration."
-            echo ""
-            echo "────────────────────────────────────────────────────────────────"
-            echo "Diff (expected ← → live, capped at 200 lines):"
-            echo "────────────────────────────────────────────────────────────────"
-            echo "$DIFF_OUTPUT" | head -200
-            echo ""
-            if [ -n "$CHANGED" ]; then
-              echo "────────────────────────────────────────────────────────────────"
-              echo "Affected objects:"
-              echo "$CHANGED"
-              echo ""
-            fi
-            exit 1
-          else
-            echo "✅ SQL diff clean."
-          fi
 
       - name: Prisma-native drift check
         env:
@@ -152,21 +38,18 @@ jobs:
 
           if [ $PRISMA_EXIT -ne 0 ]; then
             echo ""
-            echo "Prisma-native drift check detected differences."
-            echo "This catches ORM-level issues that SQL diff may miss."
+            echo "╔══════════════════════════════════════════════════════════════╗"
+            echo "║              ⚠️  SCHEMA DRIFT DETECTED  ⚠️                   ║"
+            echo "╚══════════════════════════════════════════════════════════════╝"
             echo ""
-            echo "How to fix:"
-            echo "  1. Introspect the live DB:  prisma db pull"
-            echo "  2. Generate a migration:    prisma migrate dev --name <describe_change>"
-            echo "  3. Commit and push the new migration file."
+            echo "The live dev DB schema does not match the latest migration."
+            echo "Someone likely changed the schema directly in the Supabase dashboard"
+            echo "without generating a corresponding Prisma migration."
+            echo ""
             exit 1
           else
-            echo "✅ Prisma drift check clean."
+            echo "✅ No schema drift detected."
           fi
-
-      - name: Cleanup shadow DB container
-        if: always()
-        run: docker rm -f migration_db || true
 
   ci:
     name: Lint, Format, Test & Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
             | sudo tee /etc/apt/sources.list.d/pgdg.list
           sudo apt-get update -qq
           sudo apt-get install -y postgresql-client-17
+          /usr/lib/postgresql/17/bin/pg_dump --version
 
       - uses: pnpm/action-setup@v4
 
@@ -39,7 +40,7 @@ jobs:
         env:
           DIRECT_URL: ${{ secrets.DIRECT_URL }}
         run: |
-          pg_dump \
+          /usr/lib/postgresql/17/bin/pg_dump \
             --schema-only \
             --no-owner \
             --no-acl \
@@ -83,7 +84,7 @@ jobs:
               -f "$f"
           done
 
-          PGPASSWORD=postgres pg_dump \
+          PGPASSWORD=postgres /usr/lib/postgresql/17/bin/pg_dump \
             --schema-only \
             --no-owner \
             --no-acl \
@@ -131,7 +132,7 @@ jobs:
             echo "  3. Commit and push the new migration file."
             exit 1  # fail fast — no point running Prisma check if SQL diff already caught drift
           else
-            echo "✓ SQL diff clean."
+            echo "✅ SQL diff clean."
           fi
 
       - name: Prisma-native drift check
@@ -150,9 +151,14 @@ jobs:
             echo ""
             echo "Prisma-native drift check detected differences."
             echo "This catches ORM-level issues that SQL diff may miss."
+            echo ""
+            echo "How to fix:"
+            echo "  1. Introspect the live DB:  prisma db pull"
+            echo "  2. Generate a migration:    prisma migrate dev --name <describe_change>"
+            echo "  3. Commit and push the new migration file."
             exit 1
           else
-            echo "✓ Prisma drift check clean."
+            echo "✅ Prisma drift check clean."
           fi
 
       - name: Cleanup shadow DB container

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,124 @@ on:
     branches: [main]
 
 jobs:
+  schema-drift:
+    name: Detect DB Schema Drift
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Install PostgreSQL client
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y postgresql-client
+
+      - name: Dump live dev DB schema
+        env:
+          # DIRECT_URL uses the session pooler (port 5432) which pg_dump
+          # requires. DATABASE_URL uses the transaction pooler (port 6543)
+          # which does NOT support the extended query protocol pg_dump needs.
+          DIRECT_URL: ${{ secrets.DIRECT_URL }}
+        run: |
+          pg_dump \
+            --schema-only \
+            --no-owner \
+            --no-acl \
+            --no-comments \
+            "$DIRECT_URL" \
+            --schema=public \
+            -f /tmp/live_schema.sql
+
+      - name: Generate expected schema from migrations
+        run: |
+          docker run -d \
+            --name migration_db \
+            -e POSTGRES_USER=postgres \
+            -e POSTGRES_PASSWORD=postgres \
+            -e POSTGRES_DB=shadow \
+            -p 5433:5432 \
+            postgres:15
+
+          until pg_isready -h localhost -p 5433 -U postgres; do
+            echo "Waiting for shadow DB..."
+            sleep 1
+          done
+
+          for f in $(ls packages/db/prisma/migrations/*/migration.sql 2>/dev/null | sort); do
+            echo "Applying migration: $f"
+            PGPASSWORD=postgres psql \
+              -h localhost -p 5433 \
+              -U postgres -d shadow \
+              -f "$f"
+          done
+
+          PGPASSWORD=postgres pg_dump \
+            --schema-only \
+            --no-owner \
+            --no-acl \
+            --no-comments \
+            -h localhost -p 5433 \
+            -U postgres shadow \
+            --schema=public \
+            -f /tmp/expected_schema.sql
+
+      - name: Normalise schemas for comparison
+        run: |
+          grep -v "^--" /tmp/live_schema.sql \
+            | grep -v "^SET " \
+            | grep -v "^SELECT " \
+            | sed '/^$/d' \
+            | sort > /tmp/live_sorted.sql
+
+          grep -v "^--" /tmp/expected_schema.sql \
+            | grep -v "^SET " \
+            | grep -v "^SELECT " \
+            | sed '/^$/d' \
+            | sort > /tmp/expected_sorted.sql
+
+      - name: Diff schemas
+        run: |
+          set +e
+          DIFF_OUTPUT=$(diff --unified /tmp/expected_sorted.sql /tmp/live_sorted.sql)
+          DIFF_EXIT=$?
+          set -e
+
+          if [ $DIFF_EXIT -ne 0 ]; then
+            CHANGED=$(echo "$DIFF_OUTPUT" | grep -E "^\+.*(TABLE|COLUMN|INDEX|CONSTRAINT|SEQUENCE|TYPE|FUNCTION)" | head -20 || true)
+            echo ""
+            echo "╔══════════════════════════════════════════════════════════════╗"
+            echo "║              ⚠️  SCHEMA DRIFT DETECTED  ⚠️                   ║"
+            echo "╚══════════════════════════════════════════════════════════════╝"
+            echo ""
+            echo "The live dev DB schema does not match the latest migration."
+            echo "Someone likely changed the schema directly in the Supabase dashboard"
+            echo "without generating a corresponding Prisma migration."
+            echo ""
+            echo "────────────────────────────────────────────────────────────────"
+            echo "Diff (expected ← → live):"
+            echo "────────────────────────────────────────────────────────────────"
+            echo "$DIFF_OUTPUT"
+            echo ""
+            if [ -n "$CHANGED" ]; then
+              echo "────────────────────────────────────────────────────────────────"
+              echo "Affected objects:"
+              echo "$CHANGED"
+              echo ""
+            fi
+            exit 1
+          else
+            echo "✓ Schema matches latest migration. No drift detected."
+          fi
+
+      - name: Cleanup shadow DB container
+        if: always()
+        run: docker rm -f migration_db || true
+
   ci:
     name: Lint, Format, Test & Build
+    needs: schema-drift
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,16 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
 
-      - name: Install PostgreSQL client & pnpm
+      - name: Install PostgreSQL 17 client
         run: |
           sudo apt-get update -qq
-          sudo apt-get install -y postgresql-client
+          sudo apt-get install -y curl ca-certificates
+          curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc \
+            | sudo gpg --dearmor -o /usr/share/keyrings/postgresql.gpg
+          echo "deb [signed-by=/usr/share/keyrings/postgresql.gpg] https://apt.postgresql.org/pub/repos/apt noble-pgdg main" \
+            | sudo tee /etc/apt/sources.list.d/pgdg.list
+          sudo apt-get update -qq
+          sudo apt-get install -y postgresql-client-17
 
       - uses: pnpm/action-setup@v4
 
@@ -27,7 +33,7 @@ jobs:
           cache: pnpm
 
       - name: Install dependencies
-        run: pnpm --filter @repo/db install
+        run: pnpm install
 
       - name: Dump live dev DB schema
         env:
@@ -38,6 +44,7 @@ jobs:
             --no-owner \
             --no-acl \
             --no-comments \
+            --clean \
             --quote-all-identifiers \
             --exclude-schema=extensions \
             "$DIRECT_URL" \
@@ -52,7 +59,7 @@ jobs:
             -e POSTGRES_PASSWORD=postgres \
             -e POSTGRES_DB=shadow \
             -p 5433:5432 \
-            postgres:15
+            postgres:17
 
           until pg_isready -h localhost -p 5433 -U postgres; do
             echo "Waiting for shadow DB..."
@@ -81,6 +88,7 @@ jobs:
             --no-owner \
             --no-acl \
             --no-comments \
+            --clean \
             --quote-all-identifiers \
             --exclude-schema=extensions \
             -h localhost -p 5433 \
@@ -117,7 +125,11 @@ jobs:
               echo "$CHANGED"
               echo ""
             fi
-            exit 1
+            echo "How to fix:"
+            echo "  1. Introspect the live DB:  prisma db pull"
+            echo "  2. Generate a migration:    prisma migrate dev --name <describe_change>"
+            echo "  3. Commit and push the new migration file."
+            exit 1  # fail fast — no point running Prisma check if SQL diff already caught drift
           else
             echo "✓ SQL diff clean."
           fi
@@ -138,11 +150,6 @@ jobs:
             echo ""
             echo "Prisma-native drift check detected differences."
             echo "This catches ORM-level issues that SQL diff may miss."
-            echo ""
-            echo "How to fix:"
-            echo "  1. Introspect the live DB:  prisma db pull"
-            echo "  2. Generate a migration:    prisma migrate dev --name <describe_change>"
-            echo "  3. Commit and push the new migration file."
             exit 1
           else
             echo "✓ Prisma drift check clean."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,7 @@ jobs:
             --clean \
             --quote-all-identifiers \
             --exclude-schema=extensions \
+            --exclude-table=_prisma_migrations \
             "$DIRECT_URL" \
             --schema=public \
             -f /tmp/live_schema.sql
@@ -92,6 +93,7 @@ jobs:
             --clean \
             --quote-all-identifiers \
             --exclude-schema=extensions \
+            --exclude-table=_prisma_migrations \
             -h localhost -p 5433 \
             -U postgres shadow \
             --schema=public \
@@ -108,8 +110,12 @@ jobs:
             CHANGED=$(echo "$DIFF_OUTPUT" | grep -Ei "^\+.*(table|column|index|constraint|sequence|type|function|alter)" | head -20 || true)
             echo ""
             echo "╔══════════════════════════════════════════════════════════════╗"
-            echo "║              ⚠️  SCHEMA DRIFT DETECTED  ⚠️                  ║"
+            echo "║              ⚠️  SCHEMA DRIFT DETECTED  ⚠️                   ║"
             echo "╚══════════════════════════════════════════════════════════════╝"
+            echo ""
+            echo "The live dev DB schema does not match the latest migration."
+            echo "Someone likely changed the schema directly in the Supabase dashboard"
+            echo "without generating a corresponding Prisma migration."
             echo ""
             echo "────────────────────────────────────────────────────────────────"
             echo "Diff (expected ← → live, capped at 200 lines):"
@@ -124,7 +130,7 @@ jobs:
             fi
             exit 1
           else
-            echo "✓ SQL diff clean."
+            echo "✅ SQL diff clean."
           fi
 
       - name: Prisma-native drift check
@@ -150,7 +156,7 @@ jobs:
             echo "  3. Commit and push the new migration file."
             exit 1
           else
-            echo "✓ Prisma drift check clean."
+            echo "✅ Prisma drift check clean."
           fi
 
       - name: Cleanup shadow DB container

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,16 +28,14 @@ jobs:
         env:
           DIRECT_URL: ${{ secrets.DIRECT_URL }}
         run: |
-          # Print the diff first (always visible in logs)
           pnpm --filter @repo/db exec prisma migrate diff \
             --from-url "$DIRECT_URL" \
-            --to-migrations packages/db/prisma/migrations
+            --to-migrations prisma/migrations
 
-          # Now exit with correct code — non-zero if drift exists
           set +e
           pnpm --filter @repo/db exec prisma migrate diff \
             --from-url "$DIRECT_URL" \
-            --to-migrations packages/db/prisma/migrations \
+            --to-migrations prisma/migrations \
             --exit-code > /dev/null 2>&1
           PRISMA_EXIT=$?
           set -e
@@ -52,10 +50,6 @@ jobs:
             echo "Someone likely changed the schema directly in the Supabase dashboard"
             echo "without generating a corresponding Prisma migration."
             echo ""
-            echo "How to fix:"
-            echo "  1. Introspect the live DB:  prisma db pull"
-            echo "  2. Generate a migration:    prisma migrate dev --name <describe_change>"
-            echo "  3. Commit and push the new migration file."
             exit 1
           else
             echo "✅ No schema drift detected."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,11 +28,17 @@ jobs:
         env:
           DIRECT_URL: ${{ secrets.DIRECT_URL }}
         run: |
+          # Print the diff first (always visible in logs)
+          pnpm --filter @repo/db exec prisma migrate diff \
+            --from-url "$DIRECT_URL" \
+            --to-migrations packages/db/prisma/migrations
+
+          # Now exit with correct code — non-zero if drift exists
           set +e
           pnpm --filter @repo/db exec prisma migrate diff \
             --from-url "$DIRECT_URL" \
             --to-migrations packages/db/prisma/migrations \
-            --exit-code
+            --exit-code > /dev/null 2>&1
           PRISMA_EXIT=$?
           set -e
 
@@ -46,6 +52,10 @@ jobs:
             echo "Someone likely changed the schema directly in the Supabase dashboard"
             echo "without generating a corresponding Prisma migration."
             echo ""
+            echo "How to fix:"
+            echo "  1. Introspect the live DB:  prisma db pull"
+            echo "  2. Generate a migration:    prisma migrate dev --name <describe_change>"
+            echo "  3. Commit and push the new migration file."
             exit 1
           else
             echo "✅ No schema drift detected."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,18 +24,37 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
+      - name: Start shadow DB
+        run: |
+          docker run -d \
+            --name shadow_db \
+            -e POSTGRES_USER=postgres \
+            -e POSTGRES_PASSWORD=postgres \
+            -e POSTGRES_DB=shadow \
+            -p 5433:5432 \
+            postgres:17.6
+
+          until pg_isready -h localhost -p 5433 -U postgres; do
+            echo "Waiting for shadow DB..."
+            sleep 1
+          done
+          sleep 2
+
       - name: Prisma-native drift check
         env:
           DIRECT_URL: ${{ secrets.DIRECT_URL }}
+          SHADOW_DATABASE_URL: postgresql://postgres:postgres@localhost:5433/shadow
         run: |
           pnpm --filter @repo/db exec prisma migrate diff \
             --from-url "$DIRECT_URL" \
-            --to-migrations prisma/migrations
+            --to-migrations prisma/migrations \
+            --shadow-database-url "$SHADOW_DATABASE_URL"
 
           set +e
           pnpm --filter @repo/db exec prisma migrate diff \
             --from-url "$DIRECT_URL" \
             --to-migrations prisma/migrations \
+            --shadow-database-url "$SHADOW_DATABASE_URL" \
             --exit-code > /dev/null 2>&1
           PRISMA_EXIT=$?
           set -e
@@ -54,6 +73,10 @@ jobs:
           else
             echo "✅ No schema drift detected."
           fi
+
+      - name: Cleanup shadow DB
+        if: always()
+        run: docker rm -f shadow_db || true
 
   ci:
     name: Lint, Format, Test & Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,16 +14,23 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
 
-      - name: Install PostgreSQL client
+      - name: Install PostgreSQL client & pnpm
         run: |
           sudo apt-get update -qq
           sudo apt-get install -y postgresql-client
 
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm --filter @repo/db install
+
       - name: Dump live dev DB schema
         env:
-          # DIRECT_URL uses the session pooler (port 5432) which pg_dump
-          # requires. DATABASE_URL uses the transaction pooler (port 6543)
-          # which does NOT support the extended query protocol pg_dump needs.
           DIRECT_URL: ${{ secrets.DIRECT_URL }}
         run: |
           pg_dump \
@@ -31,6 +38,8 @@ jobs:
             --no-owner \
             --no-acl \
             --no-comments \
+            --quote-all-identifiers \
+            --exclude-schema=extensions \
             "$DIRECT_URL" \
             --schema=public \
             -f /tmp/live_schema.sql
@@ -49,8 +58,17 @@ jobs:
             echo "Waiting for shadow DB..."
             sleep 1
           done
+          sleep 2  # guard against ready-before-extensions race
 
-          for f in $(ls packages/db/prisma/migrations/*/migration.sql 2>/dev/null | sort); do
+          # Install common Supabase extensions so migration replay doesn't fail
+          # on CREATE EXTENSION statements
+          PGPASSWORD=postgres psql -h localhost -p 5433 -U postgres -d shadow -c "
+            CREATE EXTENSION IF NOT EXISTS \"uuid-ossp\";
+            CREATE EXTENSION IF NOT EXISTS pgcrypto;
+            CREATE EXTENSION IF NOT EXISTS citext;
+          "
+
+          for f in $(find packages/db/prisma/migrations -name migration.sql | sort); do
             echo "Applying migration: $f"
             PGPASSWORD=postgres psql \
               -h localhost -p 5433 \
@@ -63,34 +81,22 @@ jobs:
             --no-owner \
             --no-acl \
             --no-comments \
+            --quote-all-identifiers \
+            --exclude-schema=extensions \
             -h localhost -p 5433 \
             -U postgres shadow \
             --schema=public \
             -f /tmp/expected_schema.sql
 
-      - name: Normalise schemas for comparison
-        run: |
-          grep -v "^--" /tmp/live_schema.sql \
-            | grep -v "^SET " \
-            | grep -v "^SELECT " \
-            | sed '/^$/d' \
-            | sort > /tmp/live_sorted.sql
-
-          grep -v "^--" /tmp/expected_schema.sql \
-            | grep -v "^SET " \
-            | grep -v "^SELECT " \
-            | sed '/^$/d' \
-            | sort > /tmp/expected_sorted.sql
-
-      - name: Diff schemas
+      - name: SQL diff
         run: |
           set +e
-          DIFF_OUTPUT=$(diff --unified /tmp/expected_sorted.sql /tmp/live_sorted.sql)
+          DIFF_OUTPUT=$(diff --unified /tmp/expected_schema.sql /tmp/live_schema.sql)
           DIFF_EXIT=$?
           set -e
 
           if [ $DIFF_EXIT -ne 0 ]; then
-            CHANGED=$(echo "$DIFF_OUTPUT" | grep -E "^\+.*(TABLE|COLUMN|INDEX|CONSTRAINT|SEQUENCE|TYPE|FUNCTION)" | head -20 || true)
+            CHANGED=$(echo "$DIFF_OUTPUT" | grep -Ei "^\+.*(table|column|index|constraint|sequence|type|function|alter)" | head -20 || true)
             echo ""
             echo "╔══════════════════════════════════════════════════════════════╗"
             echo "║              ⚠️  SCHEMA DRIFT DETECTED  ⚠️                   ║"
@@ -101,9 +107,9 @@ jobs:
             echo "without generating a corresponding Prisma migration."
             echo ""
             echo "────────────────────────────────────────────────────────────────"
-            echo "Diff (expected ← → live):"
+            echo "Diff (expected ← → live, capped at 200 lines):"
             echo "────────────────────────────────────────────────────────────────"
-            echo "$DIFF_OUTPUT"
+            echo "$DIFF_OUTPUT" | head -200
             echo ""
             if [ -n "$CHANGED" ]; then
               echo "────────────────────────────────────────────────────────────────"
@@ -113,7 +119,33 @@ jobs:
             fi
             exit 1
           else
-            echo "✓ Schema matches latest migration. No drift detected."
+            echo "✓ SQL diff clean."
+          fi
+
+      - name: Prisma-native drift check
+        env:
+          DIRECT_URL: ${{ secrets.DIRECT_URL }}
+        run: |
+          set +e
+          pnpm --filter @repo/db exec prisma migrate diff \
+            --from-url "$DIRECT_URL" \
+            --to-migrations packages/db/prisma/migrations \
+            --exit-code
+          PRISMA_EXIT=$?
+          set -e
+
+          if [ $PRISMA_EXIT -ne 0 ]; then
+            echo ""
+            echo "Prisma-native drift check detected differences."
+            echo "This catches ORM-level issues that SQL diff may miss."
+            echo ""
+            echo "How to fix:"
+            echo "  1. Introspect the live DB:  prisma db pull"
+            echo "  2. Generate a migration:    prisma migrate dev --name <describe_change>"
+            echo "  3. Commit and push the new migration file."
+            exit 1
+          else
+            echo "✓ Prisma drift check clean."
           fi
 
       - name: Cleanup shadow DB container

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,11 +45,6 @@ jobs:
           DIRECT_URL: ${{ secrets.DIRECT_URL }}
           SHADOW_DATABASE_URL: postgresql://postgres:postgres@localhost:5433/shadow
         run: |
-          pnpm --filter @repo/db exec prisma migrate diff \
-            --from-url "$DIRECT_URL" \
-            --to-migrations prisma/migrations \
-            --shadow-database-url "$SHADOW_DATABASE_URL"
-
           set +e
           pnpm --filter @repo/db exec prisma migrate diff \
             --from-url "$DIRECT_URL" \
@@ -61,17 +56,23 @@ jobs:
 
           if [ $PRISMA_EXIT -ne 0 ]; then
             echo ""
-            echo "╔══════════════════════════════════════════════════════════════╗"
-            echo "║              ⚠️  SCHEMA DRIFT DETECTED  ⚠️                   ║"
-            echo "╚══════════════════════════════════════════════════════════════╝"
+            echo "✘ ERROR: Schema drift detected"
             echo ""
             echo "The live dev DB schema does not match the latest migration."
             echo "Someone likely changed the schema directly in the Supabase dashboard"
             echo "without generating a corresponding Prisma migration."
             echo ""
+            echo "────────────────────────────────────────────────────────────────"
+            echo "Diff:"
+            echo "────────────────────────────────────────────────────────────────"
+            pnpm --filter @repo/db exec prisma migrate diff \
+              --from-url "$DIRECT_URL" \
+              --to-migrations prisma/migrations \
+              --shadow-database-url "$SHADOW_DATABASE_URL"
+            echo ""
             exit 1
           else
-            echo "✅ No schema drift detected."
+            echo "✓ No schema drift detected."
           fi
 
       - name: Cleanup shadow DB

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,8 +103,8 @@ jobs:
         run: |
           # Strip pg_dump header metadata that varies between instances
           # (\restrict tokens, version strings) but isn't schema
-          grep -v "^\\\\" /tmp/live_schema.sql | grep -v "^-- Dumped" > /tmp/live_clean.sql
-          grep -v "^\\\\" /tmp/expected_schema.sql | grep -v "^-- Dumped" > /tmp/expected_clean.sql
+          grep -v "^\\\\restrict\|^\\\\unrestrict" /tmp/live_schema.sql | grep -v "^-- Dumped" > /tmp/live_clean.sql
+          grep -v "^\\\\restrict\|^\\\\unrestrict" /tmp/expected_schema.sql | grep -v "^-- Dumped" > /tmp/expected_clean.sql
 
           set +e
           DIFF_OUTPUT=$(diff --unified /tmp/expected_clean.sql /tmp/live_clean.sql)


### PR DESCRIPTION
## Description
Adds a CI check that catches schema drift between the live dev database and the migration history in the repo.

## Solution
- Added a `schema-drift` job to `ci.yml` that runs before the main CI job on every PR. 
- Dumps the live dev DB schema using `pg_dump` (read-only, via `DIRECT_URL`), replays all migrations from `packages/db/prisma/migrations/` into a local shadow Postgres container, and diffs the two. 
- If they diverge, CI fails with a clear error message naming the affected tables/columns
- The main `ci` job has a `needs: schema-drift` dependency, so lint, tests, and build are blocked until the schema check passes.

## Notes
- Requires `DIRECT_URL` to be added as a GitHub Actions secret (session pooler, port 5432 - `pg_dump` doesn't work with the transaction pooler on port 6543)
- The job uses read-only credentials - no writes to the dev DB at any point
- The shadow DB is a throwaway local Docker container, cleaned up after every run