### PR TITLE
[#64] add leaderboard section and optimize the UI base on figma

### DIFF
--- a/apps/web/src/components/ui/LeaderboardSections.tsx
+++ b/apps/web/src/components/ui/LeaderboardSections.tsx
@@ -15,7 +15,7 @@ export default function LeaderboardSections() {
     <div className="flex justify-center gap-[21px] mt-6">
       <section className="flex flex-col gap-3 w-[415px]">
         <h2 className="flex items-center gap-3 text-lg font-semibold">
-          <span className="w-[4.9px] h-5 rounded-full bg-[#E333A3]" />
+          <span className="w-[4.9px] h-5 rounded-full bg-wdcc-kelvin" />
           Lines of Code Changed
         </h2>
         {data?.linesOfCode.map(({ entry, theme }) => (
@@ -25,7 +25,7 @@ export default function LeaderboardSections() {
 
       <section className="flex flex-col gap-3 w-[415px]">
         <h2 className="flex items-center gap-3 text-lg font-semibold">
-          <span className="w-[4.9px] h-5 rounded-full bg-[#077CF1]" />
+          <span className="w-[4.9px] h-5 rounded-full bg-wdcc-blue" />
           Commits Made
         </h2>
         {data?.commits.map(({ entry, theme }) => (
@@ -35,7 +35,7 @@ export default function LeaderboardSections() {
 
       <section className="flex flex-col gap-3 w-[415px]">
         <h2 className="flex items-center gap-3 text-lg font-semibold">
-          <span className="w-[4.9px] h-5 rounded-full bg-[#FFAC33]" />
+          <span className="w-[4.9px] h-5 rounded-full bg-wdcc-amber" />
           Pull Requests Merged
         </h2>
         {data?.merges.map(({ entry, theme }) => (

--- a/apps/web/src/components/ui/LeaderboardSections.tsx
+++ b/apps/web/src/components/ui/LeaderboardSections.tsx
@@ -14,22 +14,31 @@ export default function LeaderboardSections() {
   return (
     <div className="flex justify-center gap-[21px] mt-6">
       <section className="flex flex-col gap-3 w-[415px]">
-        <h2 className="text-lg font-semibold">Commits This Week</h2>
+        <h2 className="flex items-center gap-3 text-lg font-semibold">
+          <span className="w-[4.9px] h-5 rounded-full bg-[#E333A3]" />
+          Lines of Code Changed
+        </h2>
+        {data?.linesOfCode.map(({ entry, theme }) => (
+          <LeaderboardRow key={entry.projectId} entry={entry} theme={theme} />
+        ))}
+      </section>
+
+      <section className="flex flex-col gap-3 w-[415px]">
+        <h2 className="flex items-center gap-3 text-lg font-semibold">
+          <span className="w-[4.9px] h-5 rounded-full bg-[#077CF1]" />
+          Commits Made
+        </h2>
         {data?.commits.map(({ entry, theme }) => (
           <LeaderboardRow key={entry.projectId} entry={entry} theme={theme} />
         ))}
       </section>
 
       <section className="flex flex-col gap-3 w-[415px]">
-        <h2 className="text-lg font-semibold">Pull Requests This Week</h2>
+        <h2 className="flex items-center gap-3 text-lg font-semibold">
+          <span className="w-[4.9px] h-5 rounded-full bg-[#FFAC33]" />
+          Pull Requests Merged
+        </h2>
         {data?.merges.map(({ entry, theme }) => (
-          <LeaderboardRow key={entry.projectId} entry={entry} theme={theme} />
-        ))}
-      </section>
-
-      <section className="flex flex-col gap-3 w-[415px]">
-        <h2 className="text-lg font-semibold">Lines Changed This Week</h2>
-        {data?.linesOfCode.map(({ entry, theme }) => (
           <LeaderboardRow key={entry.projectId} entry={entry} theme={theme} />
         ))}
       </section>

--- a/apps/web/src/lib/project/leaderboard-row.ts
+++ b/apps/web/src/lib/project/leaderboard-row.ts
@@ -54,9 +54,9 @@ export async function fetchWeeklyLeaderboard(): Promise<WeeklyLeaderboard> {
     const data = await response.json()
 
     return {
-      commits: attach(data.commits ?? [], LEADERBOARD_THEMES.pink),
-      merges: attach(data.merges ?? [], LEADERBOARD_THEMES.blue),
-      linesOfCode: attach(data['lines-of-code'] ?? [], LEADERBOARD_THEMES.orange),
+      linesOfCode: attach(data['lines-of-code'] ?? [], LEADERBOARD_THEMES.pink),
+      commits: attach(data.commits ?? [], LEADERBOARD_THEMES.blue),
+      merges: attach(data.merges ?? [], LEADERBOARD_THEMES.orange),
     }
   } catch (error) {
     console.error('Error fetching weekly leaderboard:', error)

--- a/apps/web/src/lib/project/leaderboard-row.ts
+++ b/apps/web/src/lib/project/leaderboard-row.ts
@@ -1,12 +1,18 @@
+import resolveConfig from 'tailwindcss/resolveConfig'
 import tailwindConfig from '../../../tailwind.config'
 
-const wdcc = tailwindConfig.theme.extend.colors.wdcc as {
-  purple: string
-  peach: string
-  blue: { light: string; DEFAULT: string }
-  kelvin: string
-  amber: string
-}
+const fullConfig = resolveConfig(tailwindConfig)
+const wdcc = (
+  fullConfig.theme.colors as unknown as {
+    wdcc: {
+      purple: string
+      peach: string
+      blue: { light: string; DEFAULT: string }
+      amber: string
+      kelvin: string
+    }
+  }
+).wdcc
 
 export const formatStat = (value: number | string): string => {
   if (typeof value === 'string') return value

--- a/apps/web/src/lib/project/leaderboard-row.ts
+++ b/apps/web/src/lib/project/leaderboard-row.ts
@@ -1,3 +1,13 @@
+import tailwindConfig from '../../../tailwind.config'
+
+const wdcc = tailwindConfig.theme.extend.colors.wdcc as {
+  purple: string
+  peach: string
+  blue: { light: string; DEFAULT: string }
+  kelvin: string
+  amber: string
+}
+
 export const formatStat = (value: number | string): string => {
   if (typeof value === 'string') return value
   if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1).replace(/\.0$/, '')}M`
@@ -12,11 +22,11 @@ export interface LeaderboardRowTheme {
   borderColor?: string
 }
 
-// One theme per leaderboard category, matched to the Figma spec.
+// One theme per leaderboard category — colours sourced from tailwind.config.ts.
 export const LEADERBOARD_THEMES = {
-  pink: { fillColor: '#E9CFFC', borderColor: '#E333A3' },
-  blue: { fillColor: '#CFE0FD', borderColor: '#077CF1' },
-  orange: { fillColor: '#FDE6CF', borderColor: '#FFAC33' },
+  pink: { fillColor: wdcc.purple, borderColor: wdcc.kelvin },
+  blue: { fillColor: wdcc.blue.light, borderColor: wdcc.blue.DEFAULT },
+  orange: { fillColor: wdcc.peach, borderColor: wdcc.amber },
 } satisfies Record<string, LeaderboardRowTheme>
 
 // Shape returned by every leaderboard query — maps directly onto LeaderboardRowData.

--- a/apps/web/tailwind.config.ts
+++ b/apps/web/tailwind.config.ts
@@ -24,6 +24,7 @@ const config: Config = {
             DEFAULT: '#077CF1',
           },
           orange: '#FFB05F',
+          amber: '#FFAC33',
           kelvin: '#E333A3', // pink
           grey: {
             light: '#9A9EB8',


### PR DESCRIPTION
## Description
Build the leaderboard section component column of the top 5 ranked projects
<img width="2640" height="758" alt="image" src="https://github.com/user-attachments/assets/e170a854-27e9-441c-b349-7e8fada0368b" />

## Solution

- Section renders a category title with a coloured left-border accent matching the Figma
- Design follows figma with same colours and fonts used
- Top 5 projects are displayed in ranked order using the leaderboard row component
- Component calls the existing endpoint and maps the response to the leaderboard rows
- Category title, accent colour, and stat format are configurable via props

## Notes

<!-- Add any notes you think are needed -->
