### PR TITLE
[#84] Fixing data collection window

### DIFF
--- a/apps/web/src/components/ui/LeaderboardSections.tsx
+++ b/apps/web/src/components/ui/LeaderboardSections.tsx
@@ -3,24 +3,30 @@
 import { useEffect, useState } from 'react'
 import LeaderboardRow from '@/components/ui/LeaderboardRow'
 import { fetchWeeklyLeaderboard, WeeklyLeaderboard } from '@/lib/project/leaderboard-row'
+import ClientSuspense from '../utils/ClientSuspense'
 
 export default function LeaderboardSections() {
   const [data, setData] = useState<WeeklyLeaderboard | null>(null)
+  const [mounted, setMounted] = useState(false)
 
   useEffect(() => {
-    fetchWeeklyLeaderboard().then(setData)
+    fetchWeeklyLeaderboard()
+      .then(setData)
+      .finally(() => setMounted(true))
   }, [])
 
   return (
-    <div className="flex justify-center gap-[21px] mt-6">
+    <div className="flex justify-between px-5 sm:px-10 lg:px-20 gap-[21px] my-20 w-full">
       <section className="flex flex-col gap-3 w-[415px]">
         <h2 className="flex items-center gap-3 text-lg font-semibold">
           <span className="w-[4.9px] h-5 rounded-full bg-wdcc-kelvin" />
           Lines of Code Changed
         </h2>
-        {data?.linesOfCode.map(({ entry, theme }) => (
-          <LeaderboardRow key={entry.projectId} entry={entry} theme={theme} />
-        ))}
+        <ClientSuspense mounted={mounted} fallback={<p>Loading...</p>}>
+          {data?.linesOfCode.map(({ entry, theme }) => (
+            <LeaderboardRow key={entry.projectId} entry={entry} theme={theme} />
+          ))}
+        </ClientSuspense>
       </section>
 
       <section className="flex flex-col gap-3 w-[415px]">
@@ -28,9 +34,11 @@ export default function LeaderboardSections() {
           <span className="w-[4.9px] h-5 rounded-full bg-wdcc-blue" />
           Commits Made
         </h2>
-        {data?.commits.map(({ entry, theme }) => (
-          <LeaderboardRow key={entry.projectId} entry={entry} theme={theme} />
-        ))}
+        <ClientSuspense mounted={mounted} fallback={<p>Loading...</p>}>
+          {data?.commits.map(({ entry, theme }) => (
+            <LeaderboardRow key={entry.projectId} entry={entry} theme={theme} />
+          ))}
+        </ClientSuspense>
       </section>
 
       <section className="flex flex-col gap-3 w-[415px]">
@@ -38,9 +46,11 @@ export default function LeaderboardSections() {
           <span className="w-[4.9px] h-5 rounded-full bg-wdcc-amber" />
           Pull Requests Merged
         </h2>
-        {data?.merges.map(({ entry, theme }) => (
-          <LeaderboardRow key={entry.projectId} entry={entry} theme={theme} />
-        ))}
+        <ClientSuspense mounted={mounted} fallback={<p>Loading...</p>}>
+          {data?.merges.map(({ entry, theme }) => (
+            <LeaderboardRow key={entry.projectId} entry={entry} theme={theme} />
+          ))}
+        </ClientSuspense>
       </section>
     </div>
   )

--- a/apps/web/src/components/ui/LeaderboardSections.tsx
+++ b/apps/web/src/components/ui/LeaderboardSections.tsx
@@ -7,12 +7,12 @@ import ClientSuspense from '../utils/ClientSuspense'
 
 export default function LeaderboardSections() {
   const [data, setData] = useState<WeeklyLeaderboard | null>(null)
-  const [mounted, setMounted] = useState(false)
+  const [loading, setLoading] = useState(true)
 
   useEffect(() => {
     fetchWeeklyLeaderboard()
       .then(setData)
-      .finally(() => setMounted(true))
+      .finally(() => setLoading(false))
   }, [])
 
   return (
@@ -22,7 +22,7 @@ export default function LeaderboardSections() {
           <span className="w-[4.9px] h-5 rounded-full bg-wdcc-kelvin" />
           Lines of Code Changed
         </h2>
-        <ClientSuspense mounted={mounted} fallback={<p>Loading...</p>}>
+        <ClientSuspense loading={loading} fallback={<p>Loading...</p>}>
           {data?.linesOfCode.map(({ entry, theme }) => (
             <LeaderboardRow key={entry.projectId} entry={entry} theme={theme} />
           ))}
@@ -34,7 +34,7 @@ export default function LeaderboardSections() {
           <span className="w-[4.9px] h-5 rounded-full bg-wdcc-blue" />
           Commits Made
         </h2>
-        <ClientSuspense mounted={mounted} fallback={<p>Loading...</p>}>
+        <ClientSuspense loading={loading} fallback={<p>Loading...</p>}>
           {data?.commits.map(({ entry, theme }) => (
             <LeaderboardRow key={entry.projectId} entry={entry} theme={theme} />
           ))}
@@ -46,7 +46,7 @@ export default function LeaderboardSections() {
           <span className="w-[4.9px] h-5 rounded-full bg-wdcc-amber" />
           Pull Requests Merged
         </h2>
-        <ClientSuspense mounted={mounted} fallback={<p>Loading...</p>}>
+        <ClientSuspense loading={loading} fallback={<p>Loading...</p>}>
           {data?.merges.map(({ entry, theme }) => (
             <LeaderboardRow key={entry.projectId} entry={entry} theme={theme} />
           ))}

--- a/apps/web/src/components/utils/ClientSuspense.tsx
+++ b/apps/web/src/components/utils/ClientSuspense.tsx
@@ -1,0 +1,15 @@
+interface ClientSuspenseProps {
+  mounted: boolean
+  fallback: React.ReactNode
+  children: React.ReactNode
+}
+
+const ClientSuspense: React.FC<ClientSuspenseProps> = ({
+  mounted,
+  fallback,
+  children,
+}: ClientSuspenseProps) => {
+  return mounted ? children : fallback
+}
+
+export default ClientSuspense

--- a/apps/web/src/components/utils/ClientSuspense.tsx
+++ b/apps/web/src/components/utils/ClientSuspense.tsx
@@ -1,15 +1,11 @@
 interface ClientSuspenseProps {
-  mounted: boolean
+  loading: boolean
   fallback: React.ReactNode
   children: React.ReactNode
 }
 
-const ClientSuspense: React.FC<ClientSuspenseProps> = ({
-  mounted,
-  fallback,
-  children,
-}: ClientSuspenseProps) => {
-  return mounted ? children : fallback
+const ClientSuspense: React.FC<ClientSuspenseProps> = ({ loading, fallback, children }) => {
+  return loading ? fallback : children
 }
 
 export default ClientSuspense

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -3,7 +3,7 @@
 import { runGitHubIngestion } from './jobs/github'
 import { runDiscordIngestion } from './jobs/discord'
 import { logger } from './lib/logger'
-import { getWeekStart } from './lib/date-utils'
+import { getCollectionWindow } from './lib/date-utils'
 
 // ─── Cron Schedules ───────────────────────────────────────────────────────────
 // Single weekly cron at Monday 00:00 UTC. Jobs run in sequence:
@@ -20,8 +20,7 @@ import { getWeekStart } from './lib/date-utils'
 //      in code, not by wall-clock timing.
 
 async function main() {
-  const weekStart = getWeekStart()
-  const weekEnd = new Date(weekStart.getTime() + 7 * 24 * 60 * 60 * 1000)
+  const [weekStart, weekEnd] = getCollectionWindow()
 
   logger.info(
     `Starting weekly ingestion jobs (GitHub + Discord in parallel) - week of ${weekStart.toISOString()}`

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -21,14 +21,16 @@ import { getWeekStart } from './lib/date-utils'
 
 async function main() {
   const weekStart = getWeekStart()
+  const weekEnd = new Date(weekStart.getTime() + 7 * 24 * 60 * 60 * 1000)
+
   logger.info(
     `Starting weekly ingestion jobs (GitHub + Discord in parallel) - week of ${weekStart.toISOString()}`
   )
   const [, discordMessages] = await Promise.all([
-    runGitHubIngestion(weekStart).catch((err: unknown) => {
+    runGitHubIngestion(weekStart, weekEnd).catch((err: unknown) => {
       logger.error(`GitHub ingestion failed: ${err}`)
     }),
-    runDiscordIngestion().catch((err: unknown) => {
+    runDiscordIngestion(weekStart, weekEnd).catch((err: unknown) => {
       logger.error(`Discord ingestion failed: ${err}`)
       return []
     }),

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -6,7 +6,7 @@ import { logger } from './lib/logger'
 import { getWeekStart } from './lib/date-utils'
 
 // ─── Cron Schedules ───────────────────────────────────────────────────────────
-// Single weekly cron at Sunday 00:00 UTC. Jobs run in sequence:
+// Single weekly cron at Monday 00:00 UTC. Jobs run in sequence:
 //
 //   1. GitHub + Discord run in parallel:
 //      GitHub:   fetch commits and PRs for the past week; write CommitFact and PRFact

--- a/apps/worker/src/jobs/discord.ts
+++ b/apps/worker/src/jobs/discord.ts
@@ -1,6 +1,5 @@
 import { logger } from '../lib/logger'
 import { db, IdentityProvider, SyncJobStatus, SyncJobType } from '@repo/db'
-import { getWeekStart } from '../lib/date-utils'
 
 /**
  * 1st Jan 2015, the epoch used by Discord snowflakes.
@@ -163,7 +162,7 @@ async function fetchWeeklyMessages(
  * DiscordWeeklyAggregate and DiscordIdentityWeeklyCount, and returns the
  * raw messages in-memory for the LLM job. Raw messages are never persisted.
  */
-export async function runDiscordIngestion(): Promise<ProjectData[]> {
+export async function runDiscordIngestion(weekStart: Date, weekEnd: Date): Promise<ProjectData[]> {
   logger.info('Running Discord ingestion job')
 
   if (!TOKEN) {
@@ -181,8 +180,6 @@ export async function runDiscordIngestion(): Promise<ProjectData[]> {
   }
 
   const data: ProjectData[] = []
-  const weekStart = getWeekStart()
-  const weekEnd = new Date()
 
   for (const project of projects) {
     if (project.channels.length === 0) {

--- a/apps/worker/src/jobs/github.ts
+++ b/apps/worker/src/jobs/github.ts
@@ -4,7 +4,7 @@ import { ingestRepoCommits } from '../lib/github-commit-tracker'
 import { ingestRepoMergedPRs } from '../lib/github-PR-tracker'
 import { computeWeeklyGitHubMetrics } from '../lib/github-weekly-stats'
 
-export async function runGitHubIngestion(weekStart: Date): Promise<void> {
+export async function runGitHubIngestion(weekStart: Date, weekEnd: Date): Promise<void> {
   const syncJob = await db.syncJob.create({
     data: { type: 'GITHUB', status: 'RUNNING', startedAt: new Date() },
   })
@@ -15,21 +15,21 @@ export async function runGitHubIngestion(weekStart: Date): Promise<void> {
 
     for (const repo of repos) {
       try {
-        const PRcount = await ingestRepoMergedPRs(repo, weekStart)
+        const PRcount = await ingestRepoMergedPRs(repo, weekStart, weekEnd)
         totalProcessed += PRcount
       } catch (err) {
         logger.error(`Failed to ingest PRs for ${repo.owner}/${repo.name}: ${err}`)
       }
 
       try {
-        const commitCount = await ingestRepoCommits(repo, weekStart)
+        const commitCount = await ingestRepoCommits(repo, weekStart, weekEnd)
         totalProcessed += commitCount
       } catch (err) {
         logger.error(`Failed to ingest commits for ${repo.owner}/${repo.name}: ${err}`)
       }
     }
 
-    await computeWeeklyGitHubMetrics(weekStart)
+    await computeWeeklyGitHubMetrics(weekStart, weekEnd)
 
     await db.syncJob.update({
       where: { id: syncJob.id },

--- a/apps/worker/src/lib/date-utils.ts
+++ b/apps/worker/src/lib/date-utils.ts
@@ -1,7 +1,18 @@
-export function getWeekStart(date: Date = new Date()): Date {
-  const d = new Date(date)
-  const day = d.getUTCDay()
-  d.setUTCDate(d.getUTCDate() - day + (day === 0 ? -6 : 1))
-  d.setUTCHours(0, 0, 0, 0)
-  return d
+/**
+ * Returns:
+ * * `weekStart` - the Monday 00:00:00 of the previous week relative to the current date
+ * * `weekEnd` - the Sunday 23:59:59 of the previous week relative to the current date
+ * @returns Tuple of [weekStart, weekEnd] dates
+ */
+export function getCollectionWindow(): [Date, Date] {
+  const weekStart = new Date()
+
+  const day = weekStart.getUTCDay()
+  weekStart.setUTCDate(weekStart.getUTCDate() - day + (day === 0 ? -6 : 1))
+  weekStart.setUTCHours(0, 0, 0, 0)
+  weekStart.setUTCDate(weekStart.getUTCDate() - 7)
+
+  const weekEnd = new Date(weekStart.getTime() + 7 * 24 * 60 * 60 * 1000 - 1000) // Sunday 23:59:59 UTC
+
+  return [weekStart, weekEnd]
 }

--- a/apps/worker/src/lib/github-PR-tracker.ts
+++ b/apps/worker/src/lib/github-PR-tracker.ts
@@ -8,16 +8,20 @@ import { withRateLimit } from './github-utils'
 
 export async function ingestRepoMergedPRs(
   repo: { id: string; owner: string; name: string; installationId: string },
-  weekStart: Date
+  weekStart: Date,
+  weekEnd: Date
 ): Promise<number> {
-  logger.info(`Fetching merged PRs for ${repo.owner}/${repo.name} since ${weekStart.toISOString()}`)
+  logger.info(
+    `Fetching merged PRs for ${repo.owner}/${repo.name} from ${weekStart.toISOString()} to ${weekEnd.toISOString()}`
+  )
 
   const octokit = await getInstallationOctokit(repo.installationId)
 
   const since = weekStart.toISOString().split('T')[0] // YYYY-MM-DD
+  const until = weekEnd.toISOString().split('T')[0]
   const mergedThisWeek = await withRateLimit(() =>
     octokit.paginate('GET /search/issues', {
-      q: `repo:${repo.owner}/${repo.name} is:pr is:merged merged:>=${since}`,
+      q: `repo:${repo.owner}/${repo.name} is:pr is:merged merged:${since}..${until}`,
       per_page: 100,
     })
   )

--- a/apps/worker/src/lib/github-PR-tracker.ts
+++ b/apps/worker/src/lib/github-PR-tracker.ts
@@ -17,8 +17,10 @@ export async function ingestRepoMergedPRs(
 
   const octokit = await getInstallationOctokit(repo.installationId)
 
-  const since = weekStart.toISOString().split('T')[0] // YYYY-MM-DD
-  const until = weekEnd.toISOString().split('T')[0]
+  // GitHub's search syntax supports optional time information in the format THH:MM:SS+00:00
+  // The times need to be included to ensure we capture all PRs merged until Sunday 23:59:59, not Sunday 00:00:00
+  const since = weekStart.toISOString().replace('Z', '+00:00')
+  const until = weekEnd.toISOString().replace('Z', '+00:00')
   const mergedThisWeek = await withRateLimit(() =>
     octokit.paginate('GET /search/issues', {
       q: `repo:${repo.owner}/${repo.name} is:pr is:merged merged:${since}..${until}`,

--- a/apps/worker/src/lib/github-commit-tracker.ts
+++ b/apps/worker/src/lib/github-commit-tracker.ts
@@ -13,7 +13,8 @@ export async function ingestRepoCommits(
     name: string
     installationId: string
   },
-  weekStart: Date
+  weekStart: Date,
+  weekEnd: Date
 ): Promise<number> {
   logger.info(`Fetching commits for ${repo.owner}/${repo.name}`)
 
@@ -42,6 +43,7 @@ export async function ingestRepoCommits(
         repo: repo.name,
         sha: branch.name,
         since: weekStart.toISOString(),
+        until: weekEnd.toISOString(),
         per_page: 100,
       })
     )

--- a/apps/worker/src/lib/github-weekly-stats.ts
+++ b/apps/worker/src/lib/github-weekly-stats.ts
@@ -24,7 +24,7 @@ export async function computeWeeklyGitHubMetrics(weekStart: Date, weekEnd: Date)
       db.commitFact.findMany({
         where: {
           repoId: { in: repoIds },
-          committedAt: { gte: weekStart, lt: weekEnd },
+          committedAt: { gte: weekStart, lte: weekEnd },
           branch: { notIn: ['main', 'master'], not: null }, // added just in case, I dont think there should be any data from main / master branches
         },
         select: {
@@ -36,7 +36,7 @@ export async function computeWeeklyGitHubMetrics(weekStart: Date, weekEnd: Date)
       db.pRFact.findMany({
         where: {
           repoId: { in: repoIds },
-          mergedAt: { gte: weekStart, lt: weekEnd },
+          mergedAt: { gte: weekStart, lte: weekEnd },
         },
         select: {
           authorIdentityId: true,

--- a/apps/worker/src/lib/github-weekly-stats.ts
+++ b/apps/worker/src/lib/github-weekly-stats.ts
@@ -3,7 +3,7 @@
 import { db } from '@repo/db'
 import { logger } from '../lib/logger'
 
-export async function computeWeeklyGitHubMetrics(weekStart: Date): Promise<void> {
+export async function computeWeeklyGitHubMetrics(weekStart: Date, weekEnd: Date): Promise<void> {
   logger.info(`Starting weekly metrics computation for week starting ${weekStart.toISOString()}`)
 
   const projects = await db.project.findMany({
@@ -24,7 +24,7 @@ export async function computeWeeklyGitHubMetrics(weekStart: Date): Promise<void>
       db.commitFact.findMany({
         where: {
           repoId: { in: repoIds },
-          committedAt: { gte: weekStart },
+          committedAt: { gte: weekStart, lt: weekEnd },
           branch: { notIn: ['main', 'master'], not: null }, // added just in case, I dont think there should be any data from main / master branches
         },
         select: {
@@ -36,7 +36,7 @@ export async function computeWeeklyGitHubMetrics(weekStart: Date): Promise<void>
       db.pRFact.findMany({
         where: {
           repoId: { in: repoIds },
-          mergedAt: { gte: weekStart },
+          mergedAt: { gte: weekStart, lt: weekEnd },
         },
         select: {
           authorIdentityId: true,


### PR DESCRIPTION
## Description
GitHub data collection had no set collection window.

## Solution
 - Added a computed `weekEnd` variable (`weekStart` + 7 days) to be passed to both Discord and GitHub ingestion functions
 - Removed the internal `weekStart` variable inside the Discord ingestion function, used the one passed to the GitHub ingestion function so the same Date object is used for both functions
 - Changed PR and commit ingestion functions to collect data until `weekEnd`

## Notes

<!-- Add any notes you think are needed -->
