### PR TITLE
[#109] fix commits not captured in merged PRs

### DIFF
--- a/apps/worker/src/lib/github-PR-tracker.ts
+++ b/apps/worker/src/lib/github-PR-tracker.ts
@@ -87,23 +87,29 @@ export async function ingestRepoMergedPRs(
     count++
 
     // Pull the PR's commits and upsert each.
-    const prCommits = await withRateLimit(() =>
-      octokit.paginate('GET /repos/{owner}/{repo}/pulls/{pull_number}/commits', {
-        owner: repo.owner,
-        repo: repo.name,
-        pull_number: fullPr.number,
-        per_page: 100,
-      })
-    )
+    try {
+      const prCommits = await withRateLimit(() =>
+        octokit.paginate('GET /repos/{owner}/{repo}/pulls/{pull_number}/commits', {
+          owner: repo.owner,
+          repo: repo.name,
+          pull_number: fullPr.number,
+          per_page: 100,
+        })
+      )
 
-    for (const commit of prCommits) {
-      try {
-        await upsertCommit(repo, octokit, commit.sha, fullPr.head.ref)
-      } catch (err) {
-        logger.error(
-          `Failed to upsert commit ${commit.sha} from PR #${fullPr.number} in ${repo.owner}/${repo.name}: ${err}`
-        )
+      for (const commit of prCommits) {
+        try {
+          await upsertCommit(repo, octokit, commit.sha, fullPr.head.ref)
+        } catch (err) {
+          logger.error(
+            `Failed to upsert commit ${commit.sha} from PR #${fullPr.number} in ${repo.owner}/${repo.name}: ${err}`
+          )
+        }
       }
+    } catch (err) {
+      logger.error(
+        `Failed to ingest commits for PR #${fullPr.number} in ${repo.owner}/${repo.name}: ${err}`
+      )
     }
   }
 

--- a/apps/worker/src/lib/github-PR-tracker.ts
+++ b/apps/worker/src/lib/github-PR-tracker.ts
@@ -5,6 +5,7 @@ import { getInstallationOctokit } from '../lib/github-auth'
 import { logger } from '../lib/logger'
 import { resolveIdentity } from './github-utils'
 import { withRateLimit } from './github-utils'
+import { upsertCommit } from './github-commit-tracker'
 
 export async function ingestRepoMergedPRs(
   repo: { id: string; owner: string; name: string; installationId: string },
@@ -84,6 +85,26 @@ export async function ingestRepoMergedPRs(
       },
     })
     count++
+
+    // Pull the PR's commits and upsert each.
+    const prCommits = await withRateLimit(() =>
+      octokit.paginate('GET /repos/{owner}/{repo}/pulls/{pull_number}/commits', {
+        owner: repo.owner,
+        repo: repo.name,
+        pull_number: fullPr.number,
+        per_page: 100,
+      })
+    )
+
+    for (const commit of prCommits) {
+      try {
+        await upsertCommit(repo, octokit, commit.sha, fullPr.head.ref)
+      } catch (err) {
+        logger.error(
+          `Failed to upsert commit ${commit.sha} from PR #${fullPr.number} in ${repo.owner}/${repo.name}: ${err}`
+        )
+      }
+    }
   }
 
   logger.info(`Saved ${count} merged PRs for ${repo.owner}/${repo.name}.`)

--- a/apps/worker/src/lib/github-commit-tracker.ts
+++ b/apps/worker/src/lib/github-commit-tracker.ts
@@ -46,7 +46,6 @@ export async function upsertCommit(
     update: {
       authorIdentityId,
       message: data.commit.message,
-      branch,
       linesAdded: data.stats?.additions || 0,
       linesRemoved: data.stats?.deletions || 0,
       committedAt: new Date(data.commit.author?.date || Date.now()),

--- a/apps/worker/src/lib/github-commit-tracker.ts
+++ b/apps/worker/src/lib/github-commit-tracker.ts
@@ -6,6 +6,55 @@ import { logger } from '../lib/logger'
 import { resolveIdentity } from './github-utils'
 import { withRateLimit } from './github-utils'
 
+type Octokit = Awaited<ReturnType<typeof getInstallationOctokit>>
+
+// Fetches full commit details (for stats and author) and upserts a CommitFact row.
+// Dedup is handled by the (repoId, sha) unique constraint.
+export async function upsertCommit(
+  repo: { id: string; owner: string; name: string },
+  octokit: Octokit,
+  sha: string,
+  branch: string | null
+): Promise<void> {
+  const { data } = await withRateLimit(() =>
+    octokit.request('GET /repos/{owner}/{repo}/commits/{sha}', {
+      owner: repo.owner,
+      repo: repo.name,
+      sha,
+    })
+  )
+
+  const authorIdentityId = await resolveIdentity(
+    data.author ? { id: data.author.id, login: data.author.login } : null,
+    repo
+  )
+
+  await db.commitFact.upsert({
+    // compound key to avoid duplicate entries for the same commit
+    where: { repoId_sha: { repoId: repo.id, sha } },
+    create: {
+      repoId: repo.id,
+      sha,
+      authorIdentityId,
+      message: data.commit.message,
+      branch,
+      linesAdded: data.stats?.additions || 0,
+      linesRemoved: data.stats?.deletions || 0,
+      committedAt: new Date(data.commit.author?.date || Date.now()),
+      ingestedAt: new Date(Date.now()),
+    },
+    update: {
+      authorIdentityId,
+      message: data.commit.message,
+      branch,
+      linesAdded: data.stats?.additions || 0,
+      linesRemoved: data.stats?.deletions || 0,
+      committedAt: new Date(data.commit.author?.date || Date.now()),
+      ingestedAt: new Date(Date.now()),
+    },
+  })
+}
+
 export async function ingestRepoCommits(
   repo: {
     id: string
@@ -51,43 +100,7 @@ export async function ingestRepoCommits(
     totalCommits += commits.length
 
     for (const commit of commits) {
-      const authorIdentityId = await resolveIdentity(
-        commit.author ? { id: commit.author.id, login: commit.author.login } : null,
-        repo
-      )
-
-      const stats = await withRateLimit(() =>
-        octokit.request('GET /repos/{owner}/{repo}/commits/{sha}', {
-          owner: repo.owner,
-          repo: repo.name,
-          sha: commit.sha,
-        })
-      ).then((res) => res.data.stats)
-
-      await db.commitFact.upsert({
-        // compound key to avoid duplicate entries for the same commit
-        where: { repoId_sha: { repoId: repo.id, sha: commit.sha } },
-        create: {
-          repoId: repo.id,
-          sha: commit.sha,
-          authorIdentityId: authorIdentityId,
-          message: commit.commit.message,
-          branch: branch.name,
-          linesAdded: stats.additions || 0,
-          linesRemoved: stats.deletions || 0,
-          committedAt: new Date(commit.commit.author?.date || Date.now()),
-          ingestedAt: new Date(Date.now()),
-        },
-        update: {
-          authorIdentityId: authorIdentityId,
-          message: commit.commit.message,
-          branch: branch.name,
-          linesAdded: stats.additions || 0,
-          linesRemoved: stats.deletions || 0,
-          committedAt: new Date(commit.commit.author?.date || Date.now()),
-          ingestedAt: new Date(Date.now()),
-        },
-      })
+      await upsertCommit(repo, octokit, commit.sha, branch.name)
     }
   }
 


### PR DESCRIPTION
## Description
Now correctly captures commits in merged PRs

## Solution

- Moved upsert commit code in `github-commit-tracker.ts` to a function called `upsertCommit`
- For every merged PR in week, get the PR's commits and upserts it
- Deduplication is handled by the (repoId, sha) unique constraint.

