### PR TITLE
[#118] Audit and enforce auth on all API endpoints 

### DIFF
--- a/apps/web/src/app/api/project/[slug]/members/route.ts
+++ b/apps/web/src/app/api/project/[slug]/members/route.ts
@@ -3,10 +3,6 @@ import { hasRole } from '@/lib/auth'
 
 // API route for getting all members of a project
 export async function GET(_: Request, { params }: { params: Promise<{ slug: string }> }) {
-  if (!(await hasRole('ADMIN'))) {
-    return Response.json({ error: 'Unauthorized. Admin access required.' }, { status: 403 })
-  }
-
   const { slug } = await params
 
   try {

--- a/apps/web/src/app/api/project/[slug]/members/route.ts
+++ b/apps/web/src/app/api/project/[slug]/members/route.ts
@@ -3,6 +3,10 @@ import { hasRole } from '@/lib/auth'
 
 // API route for getting all members of a project
 export async function GET(_: Request, { params }: { params: Promise<{ slug: string }> }) {
+  if (!(await hasRole('ADMIN'))) {
+    return Response.json({ error: 'Unauthorized. Admin access required.' }, { status: 403 })
+  }
+
   const { slug } = await params
 
   try {

--- a/apps/web/src/app/api/project/route.ts
+++ b/apps/web/src/app/api/project/route.ts
@@ -1,3 +1,4 @@
+import { hasRole } from '@/lib/auth'
 import { db } from '@repo/db'
 import { revalidateTag } from 'next/cache'
 
@@ -23,6 +24,10 @@ function parseDate(input: string): Date | null {
 
 // API route for handling project creation
 export async function POST(request: Request) {
+  if (!(await hasRole('ADMIN'))) {
+    return Response.json({ error: 'Unauthorized. Admin access required.' }, { status: 403 })
+  }
+
   try {
     const formData = await request.formData()
     const projectName = String(formData.get('projectName') ?? '').trim()

--- a/apps/web/src/app/api/roles/route.ts
+++ b/apps/web/src/app/api/roles/route.ts
@@ -1,5 +1,6 @@
 import { db, Role } from '@repo/db'
 import { createClient } from '@/lib/supabase/server'
+import { hasRole } from '@/lib/auth'
 
 /**
  * TODO: Add authentication and authorization to ensure only admins can access these routes
@@ -12,6 +13,10 @@ function isValidEmail(email: string) {
 
 // API route for adding new admin and/or execs
 export async function POST(request: Request) {
+  if (!(await hasRole('ADMIN'))) {
+    return Response.json({ error: 'Unauthorized. Admin access required.' }, { status: 403 })
+  }
+
   try {
     const body = await request.json()
     const email = String(body.email).trim()
@@ -72,6 +77,10 @@ export async function POST(request: Request) {
 
 // API route for removing admin and/or exec roles
 export async function DELETE(request: Request) {
+  if (!(await hasRole('ADMIN'))) {
+    return Response.json({ error: 'Unauthorized. Admin access required.' }, { status: 403 })
+  }
+
   try {
     const body = await request.json()
     const email = String(body.email).trim()


### PR DESCRIPTION
## Description

- Went through each API Endpoint and made sure that the admin API routes are protected by the authentication middleware and removed all the authentication middleware in public marked routes
- Removed authentication when fetching project members
- Added admin authentication for creating projects and for assigning and removing admin access

## Solution

- Now can show the project members on the project page to the public
- Protects endpoints that only the admins should have access to.

## Notes

- I'm assuming that all the routes in the api/people folder are meant to be admin only since it is only referenced in the admin pages
- Currently there is no check for exec roles in the endpoints since there is no functionality in the exec pages
