### PR TITLE
[#121] Add get project weekly stats lib function

### DIFF
--- a/apps/web/src/app/(public)/project/[slug]/ProjectGraphs.tsx
+++ b/apps/web/src/app/(public)/project/[slug]/ProjectGraphs.tsx
@@ -19,7 +19,7 @@ export default function ProjectGraphs({ slug }: { slug: string }) {
   return (
     <div className="grid grid-cols-2 gap-6 mx-4 mt-6">
       <LineGraph title="Weekly Commits" dates={dates} dataPoints={stats?.commits ?? []} />
-      <LineGraph title="Weekly PR's" dates={dates} dataPoints={stats?.prs ?? []} />
+      <LineGraph title="Weekly PRs" dates={dates} dataPoints={stats?.prs ?? []} />
       <LineGraph
         title="Weekly Lines Changed"
         dates={dates}

--- a/apps/web/src/app/(public)/project/[slug]/ProjectGraphs.tsx
+++ b/apps/web/src/app/(public)/project/[slug]/ProjectGraphs.tsx
@@ -1,0 +1,35 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import LineGraph from '@/components/ui/LineGraph'
+import type { ProjectWeeklyStats } from '@/lib/project/weekly-stats'
+
+export default function ProjectGraphs({ slug }: { slug: string }) {
+  const [stats, setStats] = useState<ProjectWeeklyStats | null>(null)
+
+  useEffect(() => {
+    fetch(`/api/project/${slug}/weekly-stats`)
+      .then((res) => res.json())
+      .then(setStats)
+      .catch((err) => console.error('Failed to fetch weekly stats:', err))
+  }, [slug])
+
+  const dates = stats?.dates ?? []
+
+  return (
+    <div className="grid grid-cols-2 gap-6 mx-4 mt-6">
+      <LineGraph title="Weekly Commits" dates={dates} dataPoints={stats?.commits ?? []} />
+      <LineGraph title="Weekly PR's" dates={dates} dataPoints={stats?.prs ?? []} />
+      <LineGraph
+        title="Weekly Lines Changed"
+        dates={dates}
+        dataPoints={stats?.linesChanged ?? []}
+      />
+      <LineGraph
+        title="Weekly Discord Messages"
+        dates={dates}
+        dataPoints={stats?.discordMessages ?? []}
+      />
+    </div>
+  )
+}

--- a/apps/web/src/app/(public)/project/[slug]/page.tsx
+++ b/apps/web/src/app/(public)/project/[slug]/page.tsx
@@ -1,4 +1,5 @@
 import TeamHeader from '@/components/headers/TeamHeader'
+import ProjectGraphs from './ProjectGraphs'
 import { getProjectHeaderData } from '@/lib/project/projects'
 import { notFound } from 'next/navigation'
 
@@ -10,5 +11,10 @@ export default async function ProjectPage({ params }: { params: Promise<{ slug: 
     notFound()
   }
 
-  return <TeamHeader project={project} />
+  return (
+    <>
+      <TeamHeader project={project} />
+      <ProjectGraphs slug={slug} />
+    </>
+  )
 }

--- a/apps/web/src/app/api/project/[slug]/weekly-stats/route.ts
+++ b/apps/web/src/app/api/project/[slug]/weekly-stats/route.ts
@@ -1,0 +1,23 @@
+import { db } from '@repo/db'
+import { getProjectWeeklyStats } from '@/lib/project/weekly-stats'
+
+export async function GET(_: Request, { params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params
+
+  try {
+    const project = await db.project.findUnique({
+      where: { slug },
+      select: { id: true },
+    })
+
+    if (!project) {
+      return Response.json({ error: 'Project not found' }, { status: 404 })
+    }
+
+    const stats = await getProjectWeeklyStats(project.id)
+    return Response.json(stats, { status: 200 })
+  } catch (error) {
+    console.error('Error fetching weekly stats:', error)
+    return Response.json({ error: 'Failed to fetch weekly stats' }, { status: 500 })
+  }
+}

--- a/apps/web/src/components/ui/LineGraph.tsx
+++ b/apps/web/src/components/ui/LineGraph.tsx
@@ -28,36 +28,33 @@ export default function LineGraph({ title, dates, dataPoints }: LineGraphProps) 
         <h3 className="font-mono text-xl font-bold text-wdcc-oshan">{title}</h3>
       </div>
 
-      {/* Chart area */}
-      <div className="bg-white mx-0 px-2 pt-4 pb-2 overflow-x-auto">
-        <div style={{ minWidth: `${Math.max(data.length * 60, 400)}px`, height: '280px' }}>
-          <ResponsiveContainer width="100%" height="100%">
-            <LineChart data={data} margin={{ top: 8, right: 24, bottom: 8, left: 8 }}>
-              <CartesianGrid vertical={false} stroke="#E0E0E0" />
-              <XAxis
-                dataKey="date"
-                tick={{ fontFamily: 'var(--font-mono)', fontSize: 12, fill: '#5A5E7A' }}
-                axisLine={false}
-                tickLine={false}
-                interval={0}
-              />
-              <YAxis
-                tick={{ fontFamily: 'var(--font-mono)', fontSize: 12, fill: '#5A5E7A' }}
-                axisLine={false}
-                tickLine={false}
-                width={40}
-              />
-              <Line
-                type="linear"
-                dataKey="value"
-                stroke="#077CF1"
-                strokeWidth={2}
-                dot={false}
-                activeDot={{ r: 4, fill: '#077CF1' }}
-              />
-            </LineChart>
-          </ResponsiveContainer>
-        </div>
+      {/* Chart area — fixed height, data points spread evenly across full width */}
+      <div className="bg-white px-2 pt-4 pb-2" style={{ height: '280px' }}>
+        <ResponsiveContainer width="100%" height="100%">
+          <LineChart data={data} margin={{ top: 8, right: 24, bottom: 8, left: 8 }}>
+            <CartesianGrid vertical={false} stroke="#E0E0E0" />
+            <XAxis
+              dataKey="date"
+              tick={{ fontFamily: 'var(--font-mono)', fontSize: 12, fill: '#5A5E7A' }}
+              axisLine={false}
+              tickLine={false}
+            />
+            <YAxis
+              tick={{ fontFamily: 'var(--font-mono)', fontSize: 12, fill: '#5A5E7A' }}
+              axisLine={false}
+              tickLine={false}
+              width={40}
+            />
+            <Line
+              type="linear"
+              dataKey="value"
+              stroke="#077CF1"
+              strokeWidth={2}
+              dot={false}
+              activeDot={{ r: 4, fill: '#077CF1' }}
+            />
+          </LineChart>
+        </ResponsiveContainer>
       </div>
     </div>
   )

--- a/apps/web/src/lib/project/weekly-stats.ts
+++ b/apps/web/src/lib/project/weekly-stats.ts
@@ -9,7 +9,7 @@ export interface ProjectWeeklyStats {
 }
 
 export async function getProjectWeeklyStats(projectId: string): Promise<ProjectWeeklyStats> {
-  const yearStart = new Date(new Date().getFullYear(), 0, 1)
+  const yearStart = new Date(Date.UTC(new Date().getUTCFullYear(), 0, 1))
 
   const rows = await db.weeklyStats.findMany({
     where: {

--- a/apps/web/src/lib/project/weekly-stats.ts
+++ b/apps/web/src/lib/project/weekly-stats.ts
@@ -1,0 +1,37 @@
+import { db } from '@repo/db'
+
+export interface ProjectWeeklyStats {
+  dates: string[]
+  commits: number[]
+  prs: number[]
+  linesChanged: number[]
+  discordMessages: number[]
+}
+
+export async function getProjectWeeklyStats(projectId: string): Promise<ProjectWeeklyStats> {
+  const yearStart = new Date(new Date().getFullYear(), 0, 1)
+
+  const rows = await db.weeklyStats.findMany({
+    where: {
+      projectId,
+      weekStart: { gte: yearStart },
+    },
+    orderBy: { weekStart: 'asc' },
+    select: {
+      weekStart: true,
+      commits: true,
+      prsMerged: true,
+      linesAdded: true,
+      linesRemoved: true,
+      discordMessages: true,
+    },
+  })
+
+  return {
+    dates: rows.map((r) => r.weekStart.toISOString().split('T')[0]),
+    commits: rows.map((r) => r.commits),
+    prs: rows.map((r) => r.prsMerged),
+    linesChanged: rows.map((r) => r.linesAdded + r.linesRemoved),
+    discordMessages: rows.map((r) => r.discordMessages),
+  }
+}


### PR DESCRIPTION
## Description

Build a new lib function that returns weekly stats for a single project for the current year

## Solution
- Added `getProjectWeeklyStats()` in `apps/web/src/lib/project/weekly-stats.ts`
- Added API route at `apps/web/src/app/api/projects/[slug]/weekly-stats/route.ts`
- Updated project page to fetch and render four `LineGraph` components
- Added empty-state UI for graphs with no data

## Notes

<!-- Add any notes you think are needed -->
