### PR TITLE
[#17] fix GitHub API date

### DIFF
--- a/apps/worker/src/lib/github-PR-tracker.ts
+++ b/apps/worker/src/lib/github-PR-tracker.ts
@@ -18,10 +18,9 @@ export async function ingestRepoMergedPRs(
 
   const octokit = await getInstallationOctokit(repo.installationId)
 
-  // GitHub's search syntax supports optional time information in the format THH:MM:SS+00:00
-  // The times need to be included to ensure we capture all PRs merged until Sunday 23:59:59, not Sunday 00:00:00
-  const since = weekStart.toISOString().replace('Z', '+00:00')
-  const until = weekEnd.toISOString().replace('Z', '+00:00')
+  // GitHub's search API only accepts YYYY-MM-DD for the merged: qualifier.
+  const since = weekStart.toISOString().slice(0, 10)
+  const until = weekEnd.toISOString().slice(0, 10)
   const mergedThisWeek = await withRateLimit(() =>
     octokit.paginate('GET /search/issues', {
       q: `repo:${repo.owner}/${repo.name} is:pr is:merged merged:${since}..${until}`,


### PR DESCRIPTION
## Description

GitHub's search API silently returns 0 results when the merged: qualifier is given a timestamp with time/timezone components — only YYYY-MM-DD is accepted. This caused the worker to ingest zero PRs every week.

## Solution

<!-- Explain how this change solves the problem or implements the feature -->

## Notes

<!-- Add any notes you think are needed -->
