### PR TITLE
[#127] Use real GitHub installation ID

### DIFF
--- a/apps/web/src/app/api/project/route.ts
+++ b/apps/web/src/app/api/project/route.ts
@@ -83,8 +83,7 @@ export async function POST(request: Request) {
             create: {
               owner: githubLink.split('/')[3],
               name: githubLink.split('/')[4],
-              // placeholder value
-              installationId: '0',
+              installationId: process.env.GITHUB_APP_INSTALLATION_ID ?? '0',
             },
           },
           channels: {


### PR DESCRIPTION
## Description

Use the actual GitHub installation ID instead of the placeholder

## Solution

<!-- Explain how this change solves the problem or implements the feature -->

## Notes

<!-- Add any notes you think are needed -->
