### PR TITLE
[#20] Fix GitHub Sync Job

### DIFF
--- a/apps/worker/src/jobs/github.ts
+++ b/apps/worker/src/jobs/github.ts
@@ -5,42 +5,54 @@ import { ingestRepoMergedPRs } from '../lib/github-PR-tracker'
 import { computeWeeklyGitHubMetrics } from '../lib/github-weekly-stats'
 
 export async function runGitHubIngestion(weekStart: Date, weekEnd: Date): Promise<void> {
-  const syncJob = await db.syncJob.create({
-    data: { type: 'GITHUB', status: 'RUNNING', startedAt: new Date() },
+  const projects = await db.project.findMany({
+    select: {
+      id: true,
+      repositories: true,
+    },
   })
 
-  try {
-    const repos = await db.gitHubRepository.findMany()
+  const projectsWithRepos = projects.filter((p) => p.repositories.length > 0)
+  let grandTotal = 0
+
+  for (const project of projectsWithRepos) {
+    const syncJob = await db.syncJob.create({
+      data: { type: 'GITHUB', projectId: project.id, status: 'RUNNING', startedAt: new Date() },
+    })
+
     let totalProcessed = 0
+    try {
+      for (const repo of project.repositories) {
+        try {
+          const PRcount = await ingestRepoMergedPRs(repo, weekStart, weekEnd)
+          totalProcessed += PRcount
+        } catch (err) {
+          logger.error(`Failed to ingest PRs for ${repo.owner}/${repo.name}: ${err}`)
+        }
 
-    for (const repo of repos) {
-      try {
-        const PRcount = await ingestRepoMergedPRs(repo, weekStart, weekEnd)
-        totalProcessed += PRcount
-      } catch (err) {
-        logger.error(`Failed to ingest PRs for ${repo.owner}/${repo.name}: ${err}`)
+        try {
+          const commitCount = await ingestRepoCommits(repo, weekStart, weekEnd)
+          totalProcessed += commitCount
+        } catch (err) {
+          logger.error(`Failed to ingest commits for ${repo.owner}/${repo.name}: ${err}`)
+        }
       }
 
-      try {
-        const commitCount = await ingestRepoCommits(repo, weekStart, weekEnd)
-        totalProcessed += commitCount
-      } catch (err) {
-        logger.error(`Failed to ingest commits for ${repo.owner}/${repo.name}: ${err}`)
-      }
+      await computeWeeklyGitHubMetrics(project, weekStart, weekEnd)
+
+      await db.syncJob.update({
+        where: { id: syncJob.id },
+        data: { status: 'SUCCESS', finishedAt: new Date(), itemsProcessed: totalProcessed },
+      })
+      grandTotal += totalProcessed
+    } catch (err) {
+      await db.syncJob.update({
+        where: { id: syncJob.id },
+        data: { status: 'FAILED', finishedAt: new Date(), errorMessage: String(err) },
+      })
+      throw err
     }
-
-    await computeWeeklyGitHubMetrics(weekStart, weekEnd)
-
-    await db.syncJob.update({
-      where: { id: syncJob.id },
-      data: { status: 'SUCCESS', finishedAt: new Date(), itemsProcessed: totalProcessed },
-    })
-    logger.info(`GitHub ingestion complete. ${totalProcessed} items processed.`)
-  } catch (err) {
-    await db.syncJob.update({
-      where: { id: syncJob.id },
-      data: { status: 'FAILED', finishedAt: new Date(), errorMessage: String(err) },
-    })
-    throw err
   }
+
+  logger.info(`GitHub ingestion complete. ${grandTotal} items processed.`)
 }

--- a/apps/worker/src/jobs/github.ts
+++ b/apps/worker/src/jobs/github.ts
@@ -6,6 +6,7 @@ import { computeWeeklyGitHubMetrics } from '../lib/github-weekly-stats'
 
 export async function runGitHubIngestion(weekStart: Date, weekEnd: Date): Promise<void> {
   const projects = await db.project.findMany({
+    where: { isActive: true },
     select: {
       id: true,
       repositories: true,

--- a/apps/worker/src/lib/github-weekly-stats.ts
+++ b/apps/worker/src/lib/github-weekly-stats.ts
@@ -23,7 +23,7 @@ export async function computeWeeklyGitHubMetrics(
       where: {
         repoId: { in: repoIds },
         committedAt: { gte: weekStart, lte: weekEnd },
-        branch: { notIn: ['main', 'master'], not: null }, // added just in case, I dont think there should be any data from main / master branches
+        branch: { notIn: ['main', 'master'], not: null },
       },
       select: {
         authorIdentityId: true,

--- a/apps/worker/src/lib/github-weekly-stats.ts
+++ b/apps/worker/src/lib/github-weekly-stats.ts
@@ -1,227 +1,224 @@
-// Computes weekly GitHub metrics for each project and stores them in the database.
+// Computes weekly GitHub metrics for a single project and stores them in the database.
 
 import { db } from '@repo/db'
 import { logger } from '../lib/logger'
 
-export async function computeWeeklyGitHubMetrics(weekStart: Date, weekEnd: Date): Promise<void> {
+type ProjectInput = { id: string; repositories: { id: string }[] }
+
+export async function computeWeeklyGitHubMetrics(
+  project: ProjectInput,
+  weekStart: Date,
+  weekEnd: Date
+): Promise<void> {
   logger.info(`Starting weekly metrics computation for week starting ${weekStart.toISOString()}`)
 
-  const projects = await db.project.findMany({
-    select: {
-      id: true,
-      repositories: { select: { id: true } },
-    },
-  })
+  const repoIds = project.repositories.map((repository) => repository.id)
 
-  for (const project of projects) {
-    const repoIds = project.repositories.map((repository) => repository.id)
+  if (repoIds.length === 0) {
+    return
+  }
 
-    if (repoIds.length === 0) {
-      continue
+  const [commitFacts, mergedPrFacts] = await Promise.all([
+    db.commitFact.findMany({
+      where: {
+        repoId: { in: repoIds },
+        committedAt: { gte: weekStart, lte: weekEnd },
+        branch: { notIn: ['main', 'master'], not: null }, // added just in case, I dont think there should be any data from main / master branches
+      },
+      select: {
+        authorIdentityId: true,
+        linesAdded: true,
+        linesRemoved: true,
+      },
+    }),
+    db.pRFact.findMany({
+      where: {
+        repoId: { in: repoIds },
+        mergedAt: { gte: weekStart, lte: weekEnd },
+      },
+      select: {
+        authorIdentityId: true,
+      },
+    }),
+  ])
+
+  const commits = commitFacts.length
+  const prsMerged = mergedPrFacts.length
+  let linesAdded = 0
+  let linesRemoved = 0
+  for (const commit of commitFacts) {
+    linesAdded += commit.linesAdded
+    linesRemoved += commit.linesRemoved
+  }
+
+  logger.info(
+    `Project ${project.id}: fetched ${commits} commits and ${prsMerged} merged PRs; linesAdded=${linesAdded}, linesRemoved=${linesRemoved}`
+  )
+
+  const identityIds = new Set<string>()
+  for (const commitFact of commitFacts) {
+    if (commitFact.authorIdentityId) identityIds.add(commitFact.authorIdentityId)
+  }
+  for (const mergedPrFact of mergedPrFacts) {
+    if (mergedPrFact.authorIdentityId) identityIds.add(mergedPrFact.authorIdentityId)
+  }
+
+  const personIdentities = identityIds.size
+    ? await db.personIdentity.findMany({
+        where: { id: { in: Array.from(identityIds) } },
+        select: { id: true, personId: true },
+      })
+    : []
+
+  const identityToPersonId = new Map(
+    personIdentities.map((identity) => [identity.id, identity.personId])
+  )
+  const personIds = Array.from(new Set(personIdentities.map((identity) => identity.personId)))
+  const projectMembers = personIds.length
+    ? await db.projectMember.findMany({
+        where: { projectId: project.id, personId: { in: personIds } },
+        select: { id: true, personId: true },
+      })
+    : []
+
+  const personToProjectMember = new Map(
+    projectMembers.map((projectMember) => [projectMember.personId, projectMember.id])
+  )
+
+  const memberContrib = new Map<
+    string,
+    {
+      projectMemberId: string
+      personId: string
+      commits: number
+      prsMerged: number
+      linesAdded: number
+      linesRemoved: number
+    }
+  >()
+
+  for (const commitFact of commitFacts) {
+    if (!commitFact.authorIdentityId) continue
+    const personId = identityToPersonId.get(commitFact.authorIdentityId)
+    if (!personId) continue
+    const projectMemberId = personToProjectMember.get(personId)
+    if (!projectMemberId) continue
+
+    const current = memberContrib.get(projectMemberId) ?? {
+      projectMemberId,
+      personId,
+      commits: 0,
+      prsMerged: 0,
+      linesAdded: 0,
+      linesRemoved: 0,
     }
 
-    const [commitFacts, mergedPrFacts] = await Promise.all([
-      db.commitFact.findMany({
+    current.commits += 1
+    current.linesAdded += commitFact.linesAdded
+    current.linesRemoved += commitFact.linesRemoved
+    memberContrib.set(projectMemberId, current)
+  }
+
+  for (const mergedPrFact of mergedPrFacts) {
+    if (!mergedPrFact.authorIdentityId) continue
+    const personId = identityToPersonId.get(mergedPrFact.authorIdentityId)
+    if (!personId) continue
+    const projectMemberId = personToProjectMember.get(personId)
+    if (!projectMemberId) continue
+
+    const current = memberContrib.get(projectMemberId) ?? {
+      projectMemberId,
+      personId,
+      commits: 0,
+      prsMerged: 0,
+      linesAdded: 0,
+      linesRemoved: 0,
+    }
+
+    current.prsMerged += 1
+    memberContrib.set(projectMemberId, current)
+  }
+
+  let mvpMemberId: string | null = null
+  let mvpLinesChanged = -1
+  let mvpCommits = -1
+
+  for (const contrib of memberContrib.values()) {
+    const linesChanged = contrib.linesAdded + contrib.linesRemoved
+    if (
+      linesChanged > mvpLinesChanged ||
+      (linesChanged === mvpLinesChanged && contrib.commits > mvpCommits) ||
+      (linesChanged === mvpLinesChanged &&
+        contrib.commits === mvpCommits &&
+        (mvpMemberId === null || contrib.projectMemberId < mvpMemberId))
+    ) {
+      mvpMemberId = contrib.projectMemberId
+      mvpLinesChanged = linesChanged
+      mvpCommits = contrib.commits
+    }
+  }
+
+  logger.info(
+    `Project ${project.id}: adding weeklyStats and ${memberContrib.size} member contributions`
+  )
+  try {
+    await db.$transaction(async (tx) => {
+      await tx.weeklyStats.upsert({
         where: {
-          repoId: { in: repoIds },
-          committedAt: { gte: weekStart, lte: weekEnd },
-          branch: { notIn: ['main', 'master'], not: null }, // added just in case, I dont think there should be any data from main / master branches
+          projectId_weekStart: {
+            projectId: project.id,
+            weekStart,
+          },
         },
-        select: {
-          authorIdentityId: true,
-          linesAdded: true,
-          linesRemoved: true,
+        create: {
+          projectId: project.id,
+          weekStart,
+          commits,
+          prsMerged,
+          linesAdded,
+          linesRemoved,
+          mvpMemberId,
+          computedAt: new Date(),
         },
-      }),
-      db.pRFact.findMany({
-        where: {
-          repoId: { in: repoIds },
-          mergedAt: { gte: weekStart, lte: weekEnd },
+        update: {
+          commits,
+          prsMerged,
+          linesAdded,
+          linesRemoved,
+          mvpMemberId,
+          computedAt: new Date(),
         },
-        select: {
-          authorIdentityId: true,
-        },
-      }),
-    ])
+      })
 
-    const commits = commitFacts.length
-    const prsMerged = mergedPrFacts.length
-    let linesAdded = 0
-    let linesRemoved = 0
-    for (const commit of commitFacts) {
-      linesAdded += commit.linesAdded
-      linesRemoved += commit.linesRemoved
-    }
-
-    logger.info(
-      `Project ${project.id}: fetched ${commits} commits and ${prsMerged} merged PRs; linesAdded=${linesAdded}, linesRemoved=${linesRemoved}`
-    )
-
-    const identityIds = new Set<string>()
-    for (const commitFact of commitFacts) {
-      if (commitFact.authorIdentityId) identityIds.add(commitFact.authorIdentityId)
-    }
-    for (const mergedPrFact of mergedPrFacts) {
-      if (mergedPrFact.authorIdentityId) identityIds.add(mergedPrFact.authorIdentityId)
-    }
-
-    const personIdentities = identityIds.size
-      ? await db.personIdentity.findMany({
-          where: { id: { in: Array.from(identityIds) } },
-          select: { id: true, personId: true },
-        })
-      : []
-
-    const identityToPersonId = new Map(
-      personIdentities.map((identity) => [identity.id, identity.personId])
-    )
-    const personIds = Array.from(new Set(personIdentities.map((identity) => identity.personId)))
-    const projectMembers = personIds.length
-      ? await db.projectMember.findMany({
-          where: { projectId: project.id, personId: { in: personIds } },
-          select: { id: true, personId: true },
-        })
-      : []
-
-    const personToProjectMember = new Map(
-      projectMembers.map((projectMember) => [projectMember.personId, projectMember.id])
-    )
-
-    const memberContrib = new Map<
-      string,
-      {
-        projectMemberId: string
-        personId: string
-        commits: number
-        prsMerged: number
-        linesAdded: number
-        linesRemoved: number
-      }
-    >()
-
-    for (const commitFact of commitFacts) {
-      if (!commitFact.authorIdentityId) continue
-      const personId = identityToPersonId.get(commitFact.authorIdentityId)
-      if (!personId) continue
-      const projectMemberId = personToProjectMember.get(personId)
-      if (!projectMemberId) continue
-
-      const current = memberContrib.get(projectMemberId) ?? {
-        projectMemberId,
-        personId,
-        commits: 0,
-        prsMerged: 0,
-        linesAdded: 0,
-        linesRemoved: 0,
-      }
-
-      current.commits += 1
-      current.linesAdded += commitFact.linesAdded
-      current.linesRemoved += commitFact.linesRemoved
-      memberContrib.set(projectMemberId, current)
-    }
-
-    for (const mergedPrFact of mergedPrFacts) {
-      if (!mergedPrFact.authorIdentityId) continue
-      const personId = identityToPersonId.get(mergedPrFact.authorIdentityId)
-      if (!personId) continue
-      const projectMemberId = personToProjectMember.get(personId)
-      if (!projectMemberId) continue
-
-      const current = memberContrib.get(projectMemberId) ?? {
-        projectMemberId,
-        personId,
-        commits: 0,
-        prsMerged: 0,
-        linesAdded: 0,
-        linesRemoved: 0,
-      }
-
-      current.prsMerged += 1
-      memberContrib.set(projectMemberId, current)
-    }
-
-    let mvpMemberId: string | null = null
-    let mvpLinesChanged = -1
-    let mvpCommits = -1
-
-    for (const contrib of memberContrib.values()) {
-      const linesChanged = contrib.linesAdded + contrib.linesRemoved
-      if (
-        linesChanged > mvpLinesChanged ||
-        (linesChanged === mvpLinesChanged && contrib.commits > mvpCommits) ||
-        (linesChanged === mvpLinesChanged &&
-          contrib.commits === mvpCommits &&
-          (mvpMemberId === null || contrib.projectMemberId < mvpMemberId))
-      ) {
-        mvpMemberId = contrib.projectMemberId
-        mvpLinesChanged = linesChanged
-        mvpCommits = contrib.commits
-      }
-    }
-
-    logger.info(
-      `Project ${project.id}: adding weeklyStats and ${memberContrib.size} member contributions`
-    )
-    try {
-      await db.$transaction(async (tx) => {
-        await tx.weeklyStats.upsert({
+      for (const contrib of memberContrib.values()) {
+        await tx.memberWeeklyContribution.upsert({
           where: {
-            projectId_weekStart: {
-              projectId: project.id,
+            projectMemberId_weekStart: {
+              projectMemberId: contrib.projectMemberId,
               weekStart,
             },
           },
           create: {
-            projectId: project.id,
+            projectMemberId: contrib.projectMemberId,
+            personId: contrib.personId,
             weekStart,
-            commits,
-            prsMerged,
-            linesAdded,
-            linesRemoved,
-            mvpMemberId,
-            computedAt: new Date(),
+            commits: contrib.commits,
+            prsMerged: contrib.prsMerged,
+            linesAdded: contrib.linesAdded,
+            linesRemoved: contrib.linesRemoved,
           },
           update: {
-            commits,
-            prsMerged,
-            linesAdded,
-            linesRemoved,
-            mvpMemberId,
-            computedAt: new Date(),
+            commits: contrib.commits,
+            prsMerged: contrib.prsMerged,
+            linesAdded: contrib.linesAdded,
+            linesRemoved: contrib.linesRemoved,
           },
         })
-
-        for (const contrib of memberContrib.values()) {
-          await tx.memberWeeklyContribution.upsert({
-            where: {
-              projectMemberId_weekStart: {
-                projectMemberId: contrib.projectMemberId,
-                weekStart,
-              },
-            },
-            create: {
-              projectMemberId: contrib.projectMemberId,
-              personId: contrib.personId,
-              weekStart,
-              commits: contrib.commits,
-              prsMerged: contrib.prsMerged,
-              linesAdded: contrib.linesAdded,
-              linesRemoved: contrib.linesRemoved,
-            },
-            update: {
-              commits: contrib.commits,
-              prsMerged: contrib.prsMerged,
-              linesAdded: contrib.linesAdded,
-              linesRemoved: contrib.linesRemoved,
-            },
-          })
-        }
-      })
-      logger.info(`Project ${project.id}: successfully added weekly stats and member contributions`)
-    } catch (err) {
-      logger.error(`Project ${project.id}: failed to added weekly metrics: ${err}`)
-      throw err
-    }
+      }
+    })
+    logger.info(`Project ${project.id}: successfully added weekly stats and member contributions`)
+  } catch (err) {
+    logger.error(`Project ${project.id}: failed to added weekly metrics: ${err}`)
+    throw err
   }
 }


### PR DESCRIPTION
## Description

Creates a SyncJob record per project for GitHub ingestion, instead of one global job covering all repositories. Also filters ingestion to active projects only.

Previously a single SyncJob was created for the entire GitHub ingestion run, making it impossible to tell which project succeeded or failed. Now each project gets its own job with a projectId, giving per-project visibility into sync status and errors. Inactive projects are skipped entirely so they don't produce noise in the job history.

## Solution

<!-- Explain how this change solves the problem or implements the feature -->

## Notes

<!-- Add any notes you think are needed -->
