### PR TITLE
[#151] Fix CommitFact double counting

### DIFF
--- a/apps/worker/src/lib/github-commit-tracker.integration.test.ts
+++ b/apps/worker/src/lib/github-commit-tracker.integration.test.ts
@@ -42,12 +42,24 @@ function makeCommitData(overrides: Record<string, unknown> = {}) {
   }
 }
 
-function setupOctokit(paginateResponses: unknown[][], commitResponses: unknown[]) {
+function setupOctokit(
+  paginateResponses: unknown[][],
+  commitResponses: unknown[],
+  defaultBranch = 'main'
+) {
   const mockPaginate = vi.fn()
   const mockRequest = vi.fn()
 
   paginateResponses.forEach((res) => mockPaginate.mockResolvedValueOnce(res))
-  commitResponses.forEach((res) => mockRequest.mockResolvedValueOnce({ data: res }))
+
+  let commitIdx = 0
+  mockRequest.mockImplementation((route: string) => {
+    if (route === 'GET /repos/{owner}/{repo}') {
+      return Promise.resolve({ data: { default_branch: defaultBranch } })
+    }
+    const res = commitResponses[commitIdx++]
+    return Promise.resolve({ data: res })
+  })
 
   const mockOctokit = {
     paginate: mockPaginate,
@@ -162,15 +174,20 @@ describe('github-commit-tracker (integration)', () => {
   })
 
   describe('ingestRepoCommits', () => {
-    it('fetches commits only from non-main/master branches', async () => {
+    it('fetches commits only from non-default branches via the compare endpoint', async () => {
       const repo = await seedRepo()
       const identity = await seedIdentity(111, 'dev1')
       vi.mocked(resolveIdentity).mockResolvedValue(identity.id)
 
       const { mockPaginate } = setupOctokit(
         [
-          [{ name: 'main' }, { name: 'master' }, { name: 'feature-branch' }],
-          [{ sha: 'feature-commit-1' }],
+          [{ name: 'main' }, { name: 'feature-branch' }],
+          [
+            {
+              sha: 'feature-commit-1',
+              commit: { author: { date: '2026-05-05T10:00:00Z' } },
+            },
+          ],
         ],
         [
           makeCommitData({
@@ -185,8 +202,8 @@ describe('github-commit-tracker (integration)', () => {
 
       expect(mockPaginate).toHaveBeenCalledTimes(2)
       const paginateCalls = mockPaginate.mock.calls
-      expect(paginateCalls[1][0]).toBe('GET /repos/{owner}/{repo}/commits')
-      expect(paginateCalls[1][1]).toMatchObject({ sha: 'feature-branch' })
+      expect(paginateCalls[1][0]).toBe('GET /repos/{owner}/{repo}/compare/{basehead}')
+      expect(paginateCalls[1][1]).toMatchObject({ basehead: 'main...feature-branch' })
 
       const savedCommit = await db.commitFact.findUnique({
         where: { repoId_sha: { repoId: repo.id, sha: 'feature-commit-1' } },
@@ -200,8 +217,20 @@ describe('github-commit-tracker (integration)', () => {
       const identity = await seedIdentity(333, 'newdev')
       vi.mocked(resolveIdentity).mockResolvedValue(identity.id)
 
-      const { mockPaginate } = setupOctokit(
-        [[{ name: 'feature' }], [{ sha: 'new-commit' }]],
+      setupOctokit(
+        [
+          [{ name: 'feature' }],
+          [
+            {
+              sha: 'new-commit',
+              commit: { author: { date: '2026-05-07T10:00:00Z' } },
+            },
+            {
+              sha: 'old-commit',
+              commit: { author: { date: '2026-01-01T10:00:00Z' } },
+            },
+          ],
+        ],
         [
           makeCommitData({
             sha: 'new-commit',
@@ -213,13 +242,6 @@ describe('github-commit-tracker (integration)', () => {
 
       const totalCommits = await ingestRepoCommits(repo, weekStart, weekEnd)
 
-      expect(mockPaginate).toHaveBeenCalledWith(
-        'GET /repos/{owner}/{repo}/commits',
-        expect.objectContaining({
-          since: weekStart.toISOString(),
-          until: weekEnd.toISOString(),
-        })
-      )
       expect(totalCommits).toBe(1)
 
       const savedCommit = await db.commitFact.findUnique({
@@ -227,6 +249,11 @@ describe('github-commit-tracker (integration)', () => {
       })
       expect(savedCommit).not.toBeNull()
       expect(savedCommit!.authorIdentityId).toBe(identity.id)
+
+      const skippedCommit = await db.commitFact.findUnique({
+        where: { repoId_sha: { repoId: repo.id, sha: 'old-commit' } },
+      })
+      expect(skippedCommit).toBeNull()
     })
 
     it('handles repos with no commits in the window', async () => {

--- a/apps/worker/src/lib/github-commit-tracker.test.ts
+++ b/apps/worker/src/lib/github-commit-tracker.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { getInstallationOctokit } from '@repo/github'
+import { db } from '@repo/db'
+import { ingestRepoCommits } from './github-commit-tracker'
+
+vi.mock('@repo/github', () => ({
+  getInstallationOctokit: vi.fn(),
+}))
+
+vi.mock('@repo/db', () => ({
+  db: {
+    commitFact: { upsert: vi.fn() },
+    personIdentity: { findUnique: vi.fn().mockResolvedValue(null) },
+    unmatchedIdentity: { upsert: vi.fn() },
+  },
+}))
+
+vi.mock('./github-utils', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./github-utils')>()
+  return {
+    ...actual,
+    withRateLimit: vi.fn(async (fn: () => unknown) => await fn()),
+    resolveIdentity: vi.fn().mockResolvedValue(null),
+  }
+})
+
+const weekStart = new Date('2026-05-04T00:00:00Z')
+const weekEnd = new Date('2026-05-10T23:59:59Z')
+
+const repo = {
+  id: 'repo-id',
+  owner: 'org',
+  name: 'project',
+  installationId: '123',
+}
+
+function makeCommitDetail(sha: string, date = '2026-05-05T10:00:00Z') {
+  return {
+    sha,
+    commit: { message: `msg ${sha}`, author: { date } },
+    author: null,
+    stats: { additions: 1, deletions: 0 },
+  }
+}
+
+function mockOctokit({
+  defaultBranch,
+  branches,
+  compareByBasehead,
+}: {
+  defaultBranch: string
+  branches: Array<{ name: string }>
+  compareByBasehead: Record<string, Array<{ sha: string; commit: { author: { date: string } } }>>
+}) {
+  const paginate = vi.fn((route: string, params: Record<string, unknown>) => {
+    if (route === 'GET /repos/{owner}/{repo}/branches') return Promise.resolve(branches)
+    if (route === 'GET /repos/{owner}/{repo}/compare/{basehead}') {
+      const basehead = params.basehead as string
+      return Promise.resolve(compareByBasehead[basehead] ?? [])
+    }
+    throw new Error(`Unexpected paginate route: ${route}`)
+  })
+
+  const request = vi.fn((route: string, params: Record<string, unknown>) => {
+    if (route === 'GET /repos/{owner}/{repo}') {
+      return Promise.resolve({ data: { default_branch: defaultBranch } })
+    }
+    if (route === 'GET /repos/{owner}/{repo}/commits/{sha}') {
+      return Promise.resolve({ data: makeCommitDetail(params.sha as string) })
+    }
+    throw new Error(`Unexpected request route: ${route}`)
+  })
+
+  vi.mocked(getInstallationOctokit).mockResolvedValue({ paginate, request } as never)
+  return { paginate, request }
+}
+
+function upsertCalls() {
+  return vi.mocked(db.commitFact.upsert).mock.calls.map((c) => {
+    const arg = c[0] as { create: { sha: string; branch: string | null } }
+    return { sha: arg.create.sha, branch: arg.create.branch }
+  })
+}
+
+describe('ingestRepoCommits (unit, no DB)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('calls the compare endpoint instead of the per-branch commits endpoint', async () => {
+    const { paginate } = mockOctokit({
+      defaultBranch: 'main',
+      branches: [{ name: 'main' }, { name: 'feature-branch' }],
+      compareByBasehead: {
+        'main...feature-branch': [
+          { sha: 'feature-only-1', commit: { author: { date: '2026-05-05T10:00:00Z' } } },
+        ],
+      },
+    })
+
+    await ingestRepoCommits(repo, weekStart, weekEnd)
+
+    const routesCalled = paginate.mock.calls.map((c) => c[0])
+    expect(routesCalled).toContain('GET /repos/{owner}/{repo}/compare/{basehead}')
+    expect(routesCalled).not.toContain('GET /repos/{owner}/{repo}/commits')
+
+    expect(upsertCalls()).toEqual([{ sha: 'feature-only-1', branch: 'feature-branch' }])
+  })
+
+  it('does not upsert commits returned only by base (inherited from default branch)', async () => {
+    // The compare endpoint's contract is that it returns commits in head but NOT in base.
+    // The mock honors that contract — so main-derived SHAs are absent from the response,
+    // and the test asserts they never reach commitFact.upsert.
+    mockOctokit({
+      defaultBranch: 'main',
+      branches: [{ name: 'main' }, { name: 'feature-branch' }],
+      compareByBasehead: {
+        'main...feature-branch': [
+          { sha: 'feature-only-1', commit: { author: { date: '2026-05-05T10:00:00Z' } } },
+          { sha: 'feature-only-2', commit: { author: { date: '2026-05-06T10:00:00Z' } } },
+        ],
+      },
+    })
+
+    await ingestRepoCommits(repo, weekStart, weekEnd)
+
+    const shas = upsertCalls().map((c) => c.sha)
+    expect(shas).toEqual(['feature-only-1', 'feature-only-2'])
+    expect(shas).not.toContain('main-derived-sha')
+  })
+
+  it('dynamically skips the default branch even when it is not main/master', async () => {
+    const { paginate } = mockOctokit({
+      defaultBranch: 'trunk',
+      branches: [{ name: 'trunk' }, { name: 'main' }, { name: 'feature' }],
+      compareByBasehead: {
+        'trunk...main': [
+          { sha: 'main-unique', commit: { author: { date: '2026-05-05T10:00:00Z' } } },
+        ],
+        'trunk...feature': [
+          { sha: 'feature-unique', commit: { author: { date: '2026-05-06T10:00:00Z' } } },
+        ],
+      },
+    })
+
+    await ingestRepoCommits(repo, weekStart, weekEnd)
+
+    const compareBaseheads = paginate.mock.calls
+      .filter((c) => c[0] === 'GET /repos/{owner}/{repo}/compare/{basehead}')
+      .map((c) => (c[1] as { basehead: string }).basehead)
+    expect(compareBaseheads).toEqual(['trunk...main', 'trunk...feature'])
+    expect(compareBaseheads).not.toContain('trunk...trunk')
+
+    expect(upsertCalls().map((c) => c.branch)).toEqual(['main', 'feature'])
+  })
+
+  it('filters compare results by author date to the [weekStart, weekEnd] window', async () => {
+    mockOctokit({
+      defaultBranch: 'main',
+      branches: [{ name: 'main' }, { name: 'feature' }],
+      compareByBasehead: {
+        'main...feature': [
+          { sha: 'before-window', commit: { author: { date: '2026-04-01T10:00:00Z' } } },
+          { sha: 'in-window', commit: { author: { date: '2026-05-07T10:00:00Z' } } },
+          { sha: 'after-window', commit: { author: { date: '2026-06-01T10:00:00Z' } } },
+        ],
+      },
+    })
+
+    const total = await ingestRepoCommits(repo, weekStart, weekEnd)
+
+    expect(total).toBe(1)
+    expect(upsertCalls()).toEqual([{ sha: 'in-window', branch: 'feature' }])
+  })
+})

--- a/apps/worker/src/lib/github-commit-tracker.ts
+++ b/apps/worker/src/lib/github-commit-tracker.ts
@@ -1,4 +1,4 @@
-// Finds the commits for each non-main branch in a repo and stores it in a database.
+// Finds the commits unique to each non-default branch in a repo and stores them in the database.
 
 import { db } from '@repo/db'
 import { getInstallationOctokit } from '@repo/github'
@@ -68,6 +68,14 @@ export async function ingestRepoCommits(
 
   const octokit = await getInstallationOctokit(repo.installationId)
 
+  const { data: repoData } = await withRateLimit(() =>
+    octokit.request('GET /repos/{owner}/{repo}', {
+      owner: repo.owner,
+      repo: repo.name,
+    })
+  )
+  const defaultBranch = repoData.default_branch
+
   const branches = await withRateLimit(() =>
     octokit.paginate('GET /repos/{owner}/{repo}/branches', {
       owner: repo.owner,
@@ -77,28 +85,44 @@ export async function ingestRepoCommits(
   )
 
   let totalCommits = 0
+  const weekStartMs = weekStart.getTime()
+  const weekEndMs = weekEnd.getTime()
 
   for (const branch of branches) {
-    if (branch.name === 'main' || branch.name === 'master') {
+    if (branch.name === defaultBranch) {
       continue
     }
 
     logger.info(`Fetching commits for branch ${branch.name} of ${repo.owner}/${repo.name}`)
 
+    // Compare endpoint returns commits reachable from head but NOT from base,
+    // so commits inherited from the default branch (e.g. via merge or rebase) are excluded.
+    const basehead = `${defaultBranch}...${branch.name}`
     const commits = await withRateLimit(() =>
-      octokit.paginate('GET /repos/{owner}/{repo}/commits', {
-        owner: repo.owner,
-        repo: repo.name,
-        sha: branch.name,
-        since: weekStart.toISOString(),
-        until: weekEnd.toISOString(),
-        per_page: 100,
-      })
+      octokit.paginate(
+        'GET /repos/{owner}/{repo}/compare/{basehead}',
+        {
+          owner: repo.owner,
+          repo: repo.name,
+          basehead,
+          per_page: 100,
+        },
+        (response: {
+          data: { commits: Array<{ sha: string; commit: { author?: { date?: string } | null } }> }
+        }) => response.data.commits
+      )
     )
 
-    totalCommits += commits.length
+    const inWindow = commits.filter((commit) => {
+      const dateStr = commit.commit?.author?.date
+      if (!dateStr) return false
+      const t = new Date(dateStr).getTime()
+      return t >= weekStartMs && t <= weekEndMs
+    })
 
-    for (const commit of commits) {
+    totalCommits += inWindow.length
+
+    for (const commit of inWindow) {
       await upsertCommit(repo, octokit, commit.sha, branch.name)
     }
   }

--- a/apps/worker/src/lib/github-commit-tracker.ts
+++ b/apps/worker/src/lib/github-commit-tracker.ts
@@ -97,8 +97,9 @@ export async function ingestRepoCommits(
 
     // Compare endpoint returns commits reachable from head but NOT from base,
     // so commits inherited from the default branch (e.g. via merge or rebase) are excluded.
+    type CompareCommit = { sha: string; commit: { author?: { date?: string } | null } }
     const basehead = `${defaultBranch}...${branch.name}`
-    const commits = await withRateLimit(() =>
+    const commits = await withRateLimit<CompareCommit[]>(() =>
       octokit.paginate(
         'GET /repos/{owner}/{repo}/compare/{basehead}',
         {
@@ -107,9 +108,7 @@ export async function ingestRepoCommits(
           basehead,
           per_page: 100,
         },
-        (response: {
-          data: { commits: Array<{ sha: string; commit: { author?: { date?: string } | null } }> }
-        }) => response.data.commits
+        (response: { data: { commits: CompareCommit[] } }) => response.data.commits
       )
     )
 

--- a/apps/worker/src/lib/github-commit-tracker.ts
+++ b/apps/worker/src/lib/github-commit-tracker.ts
@@ -112,6 +112,13 @@ export async function ingestRepoCommits(
       )
     )
 
+    // GitHub's compare endpoint caps data.commits at 250 regardless of pagination.
+    if (commits.length >= 250) {
+      logger.warn(
+        `Compare endpoint returned ${commits.length} commits for ${repo.owner}/${repo.name} ${basehead} — may be truncated at GitHub's 250-commit cap.`
+      )
+    }
+
     const inWindow = commits.filter((commit) => {
       const dateStr = commit.commit?.author?.date
       if (!dateStr) return false


### PR DESCRIPTION
## Description

When on a branch and commits are pulled in from main, those commits count as a commit on the branch. This means we add commits from main into CommitFact table. 

## Solution

Use the compare endpoint and remove commits from main

## Notes

Haven't rly tested with weekly collection, made unit and integration tests tho