### PR TITLE
[#140] Weekly MVP data connection

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -10,10 +10,6 @@ const nextConfig: NextConfig = {
     remotePatterns: [
       {
         protocol: 'https',
-        hostname: 'ui-avatars.com',
-      },
-      {
-        protocol: 'https',
         hostname: 'github.com',
       },
       {

--- a/apps/web/public/default-avatar.svg
+++ b/apps/web/public/default-avatar.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" fill="none">
+  <circle cx="50" cy="50" r="50" fill="#C9CDD4"/>
+  <!-- Head -->
+  <circle cx="50" cy="38" r="18" fill="#8B909A"/>
+  <!-- Body / shoulders -->
+  <ellipse cx="50" cy="82" rx="28" ry="20" fill="#8B909A"/>
+</svg>

--- a/apps/web/src/app/(public)/project/[slug]/page.tsx
+++ b/apps/web/src/app/(public)/project/[slug]/page.tsx
@@ -7,7 +7,10 @@ import { notFound } from 'next/navigation'
 
 export default async function ProjectPage({ params }: { params: Promise<{ slug: string }> }) {
   const slug = (await params).slug
-  const [project, mvp] = await Promise.all([getProjectHeaderData(slug), getProjectWeeklyMvp(slug)])
+  const [project, mvp] = await Promise.all([
+    getProjectHeaderData(slug),
+    getProjectWeeklyMvp(slug).catch(() => null),
+  ])
 
   if (!project) {
     notFound()

--- a/apps/web/src/app/(public)/project/[slug]/page.tsx
+++ b/apps/web/src/app/(public)/project/[slug]/page.tsx
@@ -19,7 +19,8 @@ export default async function ProjectPage({ params }: { params: Promise<{ slug: 
     <>
       <TeamHeader project={project} />
       {mvp && mvpName && (
-        <div className="px-6 md:px-12 py-6 w-full flex justify-center">
+        <div className="px-6 md:px-12 py-6 w-full flex flex-col items-center gap-4">
+          <h2 className="text-2xl font-bold self-start">Weekly MVP</h2>
           <WeeklyMvp
             name={mvpName}
             avatarUrl={mvp.projectMember.person.imageUrl ?? undefined}

--- a/apps/web/src/app/(public)/project/[slug]/page.tsx
+++ b/apps/web/src/app/(public)/project/[slug]/page.tsx
@@ -1,19 +1,32 @@
 import TeamHeader from '@/components/headers/TeamHeader'
 import ProjectGraphs from './ProjectGraphs'
+import WeeklyMvp from '@/components/ui/WeeklyMvp'
 import { getProjectHeaderData } from '@/lib/project/projects'
+import { getProjectWeeklyMvp } from '@/lib/project/weekly-stats'
 import { notFound } from 'next/navigation'
 
 export default async function ProjectPage({ params }: { params: Promise<{ slug: string }> }) {
   const slug = (await params).slug
-  const project = await getProjectHeaderData(slug)
+  const [project, mvp] = await Promise.all([getProjectHeaderData(slug), getProjectWeeklyMvp(slug)])
 
   if (!project) {
     notFound()
   }
 
+  const mvpName = mvp?.projectMember.displayName ?? mvp?.projectMember.person.displayName
+
   return (
     <>
       <TeamHeader project={project} />
+      {mvp && mvpName && (
+        <div className="px-6 md:px-12 py-6 w-full flex justify-center">
+          <WeeklyMvp
+            name={mvpName}
+            avatarUrl={mvp.projectMember.person.imageUrl ?? undefined}
+            linesCommitted={mvp.linesAdded}
+          />
+        </div>
+      )}
       <ProjectGraphs slug={slug} />
     </>
   )

--- a/apps/web/src/components/ui/WeeklyMvp.tsx
+++ b/apps/web/src/components/ui/WeeklyMvp.tsx
@@ -12,11 +12,8 @@ interface WeeklyMvpProps {
 export default function WeeklyMvp({ name, avatarUrl, linesCommitted }: WeeklyMvpProps) {
   const [imgError, setImgError] = useState(false)
 
-  // Use a generated avatar with the user's initials if no avatarUrl is provided or if the image failed to load
-  const imgSrc =
-    avatarUrl && !imgError
-      ? avatarUrl
-      : `https://ui-avatars.com/api/?name=${encodeURIComponent(name)}&background=random`
+  // Fall back to a local default avatar — no third-party requests, no privacy concerns
+  const imgSrc = avatarUrl && !imgError ? avatarUrl : '/default-avatar.svg'
 
   return (
     <div className="w-full max-w-[1284px] flex flex-col md:flex-row items-center bg-[linear-gradient(90deg,#077CF133_24%,#E333A333_51%,#FFB05F33_83%,#FFD4A733_100%)] rounded-3xl p-6 md:p-0 md:h-[288px]">

--- a/apps/web/src/lib/project/weekly-stats.ts
+++ b/apps/web/src/lib/project/weekly-stats.ts
@@ -1,5 +1,45 @@
 import { db } from '@repo/db'
 
+export async function getProjectWeeklyMvp(slug: string) {
+  const latest = await db.memberWeeklyContribution.findFirst({
+    orderBy: { weekStart: 'desc' },
+    select: { weekStart: true },
+  })
+  if (!latest) return null
+
+  const contributions = await db.memberWeeklyContribution.findMany({
+    where: {
+      weekStart: latest.weekStart,
+      projectMember: { project: { slug } },
+    },
+    select: {
+      linesAdded: true,
+      commits: true,
+      projectMember: {
+        select: {
+          displayName: true,
+          person: { select: { displayName: true, imageUrl: true } },
+        },
+      },
+    },
+  })
+
+  if (contributions.length === 0) return null
+
+  return contributions.reduce((mvp, c) => {
+    const displayName = c.projectMember.displayName ?? c.projectMember.person.displayName
+    const mvpName = mvp.projectMember.displayName ?? mvp.projectMember.person.displayName
+    if (
+      c.linesAdded > mvp.linesAdded ||
+      (c.linesAdded === mvp.linesAdded && c.commits > mvp.commits) ||
+      (c.linesAdded === mvp.linesAdded && c.commits === mvp.commits && displayName < mvpName)
+    ) {
+      return c
+    }
+    return mvp
+  })
+}
+
 export interface ProjectWeeklyStats {
   dates: string[]
   commits: number[]


### PR DESCRIPTION
## Summary
- Added `getProjectWeeklyMvp` function to `lib/project/weekly-stats.ts` that fetches the current week's top contributor for a given project scoped by slug
- Wired `WeeklyMvp` component onto the team page with a section heading, rendered between the header and graphs with real data

## Test plan
- [ ] Visit a project team page and verify the Weekly MVP card appears with the correct member's name, avatar, and lines committed
- [ ] Visit a different project team page and verify a different MVP is shown
- [ ] Verify the page still renders correctly if no MVP data exists for the week