### PR TITLE
[#154] Fix member edit page API issues

### DIFF
--- a/apps/web/src/app/(admin)/projects/[slug]/members/[memberId]/edit/page.tsx
+++ b/apps/web/src/app/(admin)/projects/[slug]/members/[memberId]/edit/page.tsx
@@ -63,18 +63,20 @@ export default function EditMemberPage({
     setTimeout(() => router.push(`/projects/${slug}`), 1200)
   }
 
-  // TO BE IMPLEMENTED
   const handleUnlink = async () => {
     setError(null)
-    // const res = await fetch(`/api/people/${membership?.personId}/memberships/${memberId}`, {
-    //   method: 'DELETE',
-    // })
-    // if (!res.ok) {
-    //   const data = await res.json().catch(() => ({}))
-    //   setError(data?.error ?? 'Failed to unlink member')
-    //   setConfirmUnlink(false)
-    //   return
-    // }
+
+    const res = await fetch(`/api/people/${membership?.personId}/memberships/${memberId}`, {
+      method: 'DELETE',
+    })
+
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({}))
+      setError(data?.error ?? 'Failed to unlink member')
+      setConfirmUnlink(false)
+      return
+    }
+
     router.push(`/projects/${slug}`)
   }
 
@@ -294,8 +296,8 @@ export default function EditMemberPage({
               <p className="font-mono text-[11px] text-wdcc-grey-light mt-1">
                 Removes{' '}
                 <span className="text-wdcc-oshan">{membership.displayName ?? memberId}</span> from{' '}
-                <span className="text-wdcc-oshan">{slug}</span>. Their person record and identities
-                are preserved.
+                <span className="text-wdcc-oshan">{slug}</span>. If this is their only project,
+                their person record and identities will also be deleted.
               </p>
             </div>
 

--- a/apps/web/src/app/(admin)/projects/[slug]/members/[memberId]/edit/page.tsx
+++ b/apps/web/src/app/(admin)/projects/[slug]/members/[memberId]/edit/page.tsx
@@ -27,16 +27,14 @@ export default function EditMemberPage({
   const [success, setSuccess] = useState(false)
   const [confirmUnlink, setConfirmUnlink] = useState(false)
 
-  // TODO: Implement new API route to fetch single member/membership
   useEffect(() => {
-    fetch(`/api/project/${slug}/members`)
-      .then((res) => (res.ok ? res.json() : []))
-      .then((data: ProjectMember[]) => {
-        const found = data.find((m) => m.id === memberId)
-        if (found) {
-          setMembership(found)
-          setDisplayName(found.displayName ?? '')
-          setIsActive(found.isActive)
+    fetch(`/api/projects/${slug}/members/${memberId}`)
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data: ProjectMember | null) => {
+        if (data) {
+          setMembership(data)
+          setDisplayName(data.displayName ?? '')
+          setIsActive(data.isActive)
         }
         setLoading(false)
       })

--- a/apps/web/src/app/(admin)/projects/[slug]/members/[memberId]/edit/page.tsx
+++ b/apps/web/src/app/(admin)/projects/[slug]/members/[memberId]/edit/page.tsx
@@ -28,22 +28,30 @@ export default function EditMemberPage({
   const [confirmUnlink, setConfirmUnlink] = useState(false)
 
   useEffect(() => {
-    fetch(`/api/projects/${slug}/members/${memberId}`)
-      .then((res) => (res.ok ? res.json() : null))
+    fetch(`/api/project/${slug}/members/${memberId}`)
+      .then((res) => {
+        if (!res.ok) {
+          setError('Failed to load membership')
+          return null
+        }
+
+        return res.json()
+      })
       .then((data: ProjectMember | null) => {
         if (data) {
           setMembership(data)
           setDisplayName(data.displayName ?? '')
           setIsActive(data.isActive)
         }
-        setLoading(false)
       })
-      .catch(() => setLoading(false))
+      .catch(() => setError('Failed to load membership'))
+      .finally(() => setLoading(false))
   }, [slug, memberId])
 
   const handleSave = async (e: FormEvent) => {
     e.preventDefault()
     setError(null)
+
     const res = await fetch(`/api/people/${membership?.personId}/memberships/${memberId}`, {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
@@ -52,11 +60,13 @@ export default function EditMemberPage({
         isActive,
       }),
     })
+
     if (!res.ok) {
       const data = await res.json()
       setError(data?.error ?? 'Failed to update membership')
       return
     }
+
     setSuccess(true)
     setTimeout(() => router.push(`/projects/${slug}`), 1200)
   }

--- a/apps/web/src/app/api/people/[personId]/memberships/[membershipId]/route.ts
+++ b/apps/web/src/app/api/people/[personId]/memberships/[membershipId]/route.ts
@@ -66,19 +66,21 @@ export async function DELETE(
       )
     }
 
-    await db.projectMember.delete({
-      where: { id: membershipId },
-    })
-
-    const remainingMemberships = await db.projectMember.count({
-      where: { personId },
-    })
-
-    if (remainingMemberships === 0) {
-      await db.person.delete({
-        where: { id: personId },
+    await db.$transaction(async (tx) => {
+      await tx.projectMember.delete({
+        where: { id: membershipId },
       })
-    }
+
+      const remainingMemberships = await tx.projectMember.count({
+        where: { personId },
+      })
+
+      if (remainingMemberships === 0) {
+        await tx.person.delete({
+          where: { id: personId },
+        })
+      }
+    })
 
     return new Response(null, { status: 204 })
   } catch (error) {

--- a/apps/web/src/app/api/people/[personId]/memberships/[membershipId]/route.ts
+++ b/apps/web/src/app/api/people/[personId]/memberships/[membershipId]/route.ts
@@ -43,3 +43,46 @@ export async function PATCH(
     return Response.json({ error: 'Failed to update membership' }, { status: 500 })
   }
 }
+
+export async function DELETE(
+  _: Request,
+  { params }: { params: Promise<{ personId: string; membershipId: string }> }
+) {
+  if (!(await hasRole('ADMIN'))) {
+    return Response.json({ error: 'Unauthorized. Admin access required.' }, { status: 403 })
+  }
+
+  try {
+    const { personId, membershipId } = await params
+
+    const membership = await db.projectMember.findUnique({
+      where: { id: membershipId },
+    })
+
+    if (!membership || membership.personId !== personId) {
+      return Response.json(
+        { error: 'Membership not found or does not belong to this person' },
+        { status: 404 }
+      )
+    }
+
+    await db.projectMember.delete({
+      where: { id: membershipId },
+    })
+
+    const remainingMemberships = await db.projectMember.count({
+      where: { personId },
+    })
+
+    if (remainingMemberships === 0) {
+      await db.person.delete({
+        where: { id: personId },
+      })
+    }
+
+    return new Response(null, { status: 204 })
+  } catch (error) {
+    console.error('Error deleting membership:', error)
+    return Response.json({ error: 'Failed to delete membership' }, { status: 500 })
+  }
+}

--- a/apps/web/src/app/api/project/[slug]/members/[membershipId]/route.ts
+++ b/apps/web/src/app/api/project/[slug]/members/[membershipId]/route.ts
@@ -1,0 +1,31 @@
+import { db } from '@repo/db'
+import { hasRole } from '@/lib/auth'
+
+export async function GET(
+  _: Request,
+  { params }: { params: Promise<{ slug: string; membershipId: string }> }
+) {
+  if (!(await hasRole('ADMIN'))) {
+    return Response.json({ error: 'Unauthorized. Admin access required.' }, { status: 403 })
+  }
+
+  try {
+    const { slug, membershipId } = await params
+
+    const membership = await db.projectMember.findFirst({
+      where: {
+        id: membershipId,
+        project: { slug },
+      },
+    })
+
+    if (!membership) {
+      return Response.json({ error: 'Membership not found' }, { status: 404 })
+    }
+
+    return Response.json(membership, { status: 200 })
+  } catch (error) {
+    console.error('Error fetching membership:', error)
+    return Response.json({ error: 'Failed to fetch membership' }, { status: 500 })
+  }
+}


### PR DESCRIPTION
## Description
Implements member unlinking from the edit member page, including cleanup of orphaned person records and a dedicated API route for fetching a single membership.

## Solution
- Added `DELETE /api/people/[personId]/memberships/[membershipId]` - deletes the `ProjectMember` row, then checks if the person has any remaining memberships; if not, deletes the `Person` record entirely (cascading to `PersonIdentity`, and nullifying `CommitFact`/`PRFact` author references via `onDelete: SetNull`)
- Added `GET /api/projects/[slug]/members/[membershipId]` - fetches a single membership scoped to a project slug in one query, replacing the previous approach of fetching all members and finding a match client-side
- Wired up `handleUnlink` in `EditMemberPage` to call the DELETE endpoint
- Replaced the `useEffect` in `EditMemberPage` to use the new single-membership route, removing the `TODO`
- Updated the danger zone description to accurately reflect that the person record and identities are also deleted if this is their last project

## Notes
- Deleting a `ProjectMember` cascades to `MemberWeeklyContribution`; `WeeklyStats.mvpMemberId` is set to null via `onDelete: SetNull` - historical stat rows are preserved
- If a person should be temporarily removed from a project without losing their record, prefer toggling `isActive: false` on the membership instead of unlinking