### PR TITLE
[#0] Fix deployment

### DIFF
--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -1,5 +1,6 @@
 generator client {
-  provider = "prisma-client-js"
+  provider      = "prisma-client-js"
+  binaryTargets = ["native", "linux-musl", "linux-musl-openssl-3.0.x"]
 }
 
 datasource db {


### PR DESCRIPTION
## Description

Production deploy on Fly (node:18-alpine base) started failing with 'Prisma Client could not locate the Query Engine for runtime linux-musl' after a routine redeploy, despite no code changes since the previous working release. The schema relied on Prisma's 'native' auto-detection, which became unstable when the floating node:18-alpine tag updated to a newer Alpine/OpenSSL combination than the standalone bundle expected.

Explicitly generating both linux-musl and linux-musl-openssl-3.0.x engines ensures the runtime can resolve whichever variant Prisma detects, regardless of base-image drift.

## Solution

<!-- Explain how this change solves the problem or implements the feature -->

## Notes

<!-- Add any notes you think are needed -->
