### PR TITLE
[#0] Fix prod leaderboard

### DIFF
--- a/apps/web/src/app/api/weekly-leaderboard/route.ts
+++ b/apps/web/src/app/api/weekly-leaderboard/route.ts
@@ -11,9 +11,14 @@ interface LeaderboardEntry {
 
 export async function GET() {
   try {
-    const today = new Date()
-    today.setHours(0, 0, 0, 0)
-    const weekStart = new Date(today.getTime() - 7 * 24 * 60 * 60 * 1000)
+    const latest = await db.weeklyStats.findFirst({
+      orderBy: { weekStart: 'desc' },
+      select: { weekStart: true },
+    })
+
+    if (!latest) {
+      return NextResponse.json({ 'lines-of-code': [], merges: [], commits: [] })
+    }
 
     const weeklyStats = await db.weeklyStats.findMany({
       select: {
@@ -23,13 +28,8 @@ export async function GET() {
         prsMerged: true,
         commits: true,
       },
-      where: {
-        weekStart: {
-          gte: weekStart,
-        },
-      },
+      where: { weekStart: latest.weekStart },
     })
-    console.log('Weekly stats:', weeklyStats)
 
     const linesOfCodeMap: Record<string, number> = {}
     weeklyStats.forEach((entry) => {


### PR DESCRIPTION
## Description

The /leaderboard API filtered WeeklyStats with `weekStart >= today - 7d`, but the worker writes weekStart as the Monday of the *previous* week (e.g. Mon 2026-05-25 cron stores 2026-05-18). The "today - 7d" window only aligned with the stored row on Mondays; every other day of the week the most recent row was excluded and the leaderboard rendered blank.

## Solution

Replace the sliding window with a lookup of the latest weekStart actually present in the table, then filter equality. This decouples the API from when the cron last ran and from any local-vs-UTC midnight skew.

## Notes

<!-- Add any notes you think are needed -->
