### PR TITLE
[#0] OAuth fix

### DIFF
--- a/apps/web/src/app/auth/callback/route.ts
+++ b/apps/web/src/app/auth/callback/route.ts
@@ -1,3 +1,4 @@
+import { resolvePublicOrigin } from '@/lib/auth-utils/origin'
 import { createClient } from '@/lib/supabase/server'
 import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
@@ -5,7 +6,8 @@ import type { NextRequest } from 'next/server'
 // OAuth callback handler
 
 export async function GET(request: NextRequest) {
-  const { searchParams, origin } = new URL(request.url)
+  const { searchParams } = new URL(request.url)
+  const origin = resolvePublicOrigin(request.headers, request.url)
   const code = searchParams.get('code')
   const next = searchParams.get('next') ?? '/'
   const providerError = searchParams.get('error') ?? searchParams.get('error_code')

--- a/apps/web/src/lib/auth-utils/oauth.ts
+++ b/apps/web/src/lib/auth-utils/oauth.ts
@@ -1,5 +1,6 @@
 'use server'
 
+import { resolvePublicOrigin } from '@/lib/auth-utils/origin'
 import { createClient } from '@/lib/supabase/server'
 import { headers } from 'next/headers'
 import { redirect } from 'next/navigation'
@@ -9,8 +10,7 @@ import { redirect } from 'next/navigation'
 export async function signInWithGoogle() {
   const supabase = await createClient()
   const headersList = await headers()
-  const origin =
-    headersList.get('origin') ?? process.env.NEXT_PUBLIC_SITE_URL ?? 'http://localhost:3000'
+  const origin = resolvePublicOrigin(headersList)
 
   const { data, error } = await supabase.auth.signInWithOAuth({
     provider: 'google',

--- a/apps/web/src/lib/auth-utils/origin.test.ts
+++ b/apps/web/src/lib/auth-utils/origin.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { resolvePublicOrigin } from './origin'
+
+function makeHeaders(init: Record<string, string>): Headers {
+  return new Headers(init)
+}
+
+describe('resolvePublicOrigin', () => {
+  const originalEnv = process.env.NEXT_PUBLIC_SITE_URL
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.NEXT_PUBLIC_SITE_URL
+    } else {
+      process.env.NEXT_PUBLIC_SITE_URL = originalEnv
+    }
+  })
+
+  it('uses x-forwarded-host and x-forwarded-proto when present (Fly proxy)', () => {
+    const headers = makeHeaders({
+      'x-forwarded-host': 'wphd-prod.fly.dev',
+      'x-forwarded-proto': 'https',
+      host: '0.0.0.0:3000',
+    })
+
+    expect(resolvePublicOrigin(headers, 'http://0.0.0.0:3000/auth/callback')).toBe(
+      'https://wphd-prod.fly.dev'
+    )
+  })
+
+  it('defaults to https for non-local x-forwarded-host without proto', () => {
+    const headers = makeHeaders({ 'x-forwarded-host': 'wphd-prod.fly.dev' })
+    expect(resolvePublicOrigin(headers)).toBe('https://wphd-prod.fly.dev')
+  })
+
+  it('uses host header for local dev with http default', () => {
+    const headers = makeHeaders({ host: 'localhost:3000' })
+    expect(resolvePublicOrigin(headers)).toBe('http://localhost:3000')
+  })
+
+  it('respects x-forwarded-proto on host fallback', () => {
+    const headers = makeHeaders({ host: 'wphd-prod.fly.dev', 'x-forwarded-proto': 'https' })
+    expect(resolvePublicOrigin(headers)).toBe('https://wphd-prod.fly.dev')
+  })
+
+  it('falls back to NEXT_PUBLIC_SITE_URL when no host headers exist', () => {
+    process.env.NEXT_PUBLIC_SITE_URL = 'https://wphd-prod.fly.dev/'
+    const headers = makeHeaders({})
+    expect(resolvePublicOrigin(headers)).toBe('https://wphd-prod.fly.dev')
+  })
+
+  it('falls back to the request URL origin when nothing else is available', () => {
+    delete process.env.NEXT_PUBLIC_SITE_URL
+    const headers = makeHeaders({})
+    expect(resolvePublicOrigin(headers, 'http://0.0.0.0:3000/auth/callback')).toBe(
+      'http://0.0.0.0:3000'
+    )
+  })
+})

--- a/apps/web/src/lib/auth-utils/origin.ts
+++ b/apps/web/src/lib/auth-utils/origin.ts
@@ -1,0 +1,44 @@
+// Resolves the public origin for redirects, accounting for proxies like Fly.io
+// that terminate TLS and forward to an internal port. Without this, redirects
+// derived from `request.url` leak the internal `0.0.0.0:3000` host to the browser.
+
+const LOCAL_HOSTS = new Set(['localhost', '127.0.0.1', '[::1]'])
+
+function stripTrailingSlash(url: string): string {
+  return url.endsWith('/') ? url.slice(0, -1) : url
+}
+
+function hostnameOf(host: string): string {
+  return host.split(':')[0]
+}
+
+function defaultProto(host: string): string {
+  return LOCAL_HOSTS.has(hostnameOf(host)) ? 'http' : 'https'
+}
+
+export function resolvePublicOrigin(headers: Headers, fallbackUrl?: string): string {
+  const forwardedHost = headers.get('x-forwarded-host')
+  const forwardedProto = headers.get('x-forwarded-proto')
+
+  if (forwardedHost) {
+    const proto = forwardedProto ?? defaultProto(forwardedHost)
+    return `${proto}://${forwardedHost}`
+  }
+
+  const host = headers.get('host')
+  if (host) {
+    const proto = forwardedProto ?? defaultProto(host)
+    return `${proto}://${host}`
+  }
+
+  const envOrigin = process.env.NEXT_PUBLIC_SITE_URL
+  if (envOrigin) {
+    return stripTrailingSlash(envOrigin)
+  }
+
+  if (fallbackUrl) {
+    return new URL(fallbackUrl).origin
+  }
+
+  return 'http://localhost:3000'
+}


### PR DESCRIPTION
## Description

Next standalone server in the Fly container binds to 0.0.0.0:3000, so new URL(request.url).origin leaked the internal host into the post-login redirect, sending users to https://0.0.0.0:3000/. Resolve the public origin from x-forwarded-host / x-forwarded-proto with a sane fallback chain, and reuse it from the OAuth start server action too.

## Solution

<!-- Explain how this change solves the problem or implements the feature -->

## Notes

<!-- Add any notes you think are needed -->
