### PR TITLE
[#29] Fix live commit trim order

### DIFF
--- a/packages/db/prisma/migrations/20260526113648_fix_live_commit_trim_order/migration.sql
+++ b/packages/db/prisma/migrations/20260526113648_fix_live_commit_trim_order/migration.sql
@@ -1,0 +1,12 @@
+CREATE OR REPLACE FUNCTION trim_live_commits()
+RETURNS TRIGGER AS $$
+BEGIN
+  DELETE FROM "LiveCommit"
+  WHERE id NOT IN (
+    SELECT id FROM "LiveCommit"
+    ORDER BY "committedAt" DESC
+    LIMIT 10
+  );
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;


### PR DESCRIPTION
## Description

Fixes a bug where the live commit table could display stale/incorrect commits when webhook events arrive out of order.

## Solution

The `trim_live_commits()` trigger function was pruning the `LiveCommit` table by `receivedAt DESC` (webhook arrival time), while the query in `live-commits.ts` fetches commits ordered by `committedAt DESC` (actual git commit timestamp). This mismatch meant backdated or delayed commits could evict newer-timestamped commits from the ring buffer.

The fix replaces the trigger function body to order by `committedAt DESC`, keeping it consistent with the query.

## Notes

The `_prisma_migrations` table was missing from the dev database (the DB was originally set up via `prisma db push` which doesn't create migration history). To unblock running `prisma migrate dev`, each existing migration was baselined manually using:

```bash
cd packages/db && dotenv -f ../../.env.dev run -- pnpm prisma migrate resolve --applied <migration_name>
```

This is a known issue that should be discussed as a team — the dev and prod databases need to be properly baselined so `prisma migrate dev` works reliably going forward.