### PR TITLE
[#0] Fix worker cannot find module

### DIFF
--- a/apps/worker/tsup.config.ts
+++ b/apps/worker/tsup.config.ts
@@ -4,5 +4,5 @@ export default defineConfig({
   entry: ['src/index.ts'],
   format: ['cjs'],
   outDir: 'dist',
-  noExternal: ['@repo/db'],
+  noExternal: ['@repo/db', '@repo/github'],
 })


### PR DESCRIPTION
## Description

@repo/github was extracted from apps/worker/src/lib/github-auth.ts in c9493d8 but tsup.config.ts was never updated to bundle it. The deployed image has no packages/github in the runner stage, so every Fly start crashed immediately with Cannot find module '@repo/github'.

## Solution

<!-- Explain how this change solves the problem or implements the feature -->

## Notes

<!-- Add any notes you think are needed -->
