### PR TITLE
[#88] Tests for Discord ingestion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
         uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v4
+        with:
+          version: 9
 
       - uses: actions/setup-node@v4
         with:
@@ -22,7 +24,10 @@ jobs:
           cache: pnpm
 
       - name: Install dependencies
-        run: pnpm install
+        run: |
+          docker pull postgres:17.6 &
+          pnpm install
+          wait
 
       - name: Start shadow DB
         run: |
@@ -38,7 +43,6 @@ jobs:
             echo "Waiting for shadow DB..."
             sleep 1
           done
-          sleep 2
 
       - name: Prisma-native drift check
         env:
@@ -46,11 +50,10 @@ jobs:
           SHADOW_DATABASE_URL: postgresql://postgres:postgres@localhost:5433/shadow
         run: |
           set +e
-          pnpm --filter @repo/db exec prisma migrate diff \
+          DIFF_OUTPUT=$(pnpm --filter @repo/db exec prisma migrate diff \
             --from-url "$DIRECT_URL" \
             --to-migrations prisma/migrations \
-            --shadow-database-url "$SHADOW_DATABASE_URL" \
-            --exit-code > /dev/null 2>&1
+            --shadow-database-url "$SHADOW_DATABASE_URL" 2>&1)
           PRISMA_EXIT=$?
           set -e
 
@@ -67,10 +70,7 @@ jobs:
             echo "────────────────────────────────────────────────────────────────"
             echo "Diff:"
             echo "────────────────────────────────────────────────────────────────"
-            pnpm --filter @repo/db exec prisma migrate diff \
-              --from-url "$DIRECT_URL" \
-              --to-migrations prisma/migrations \
-              --shadow-database-url "$SHADOW_DATABASE_URL"
+            echo "$DIFF_OUTPUT"
             echo ""
             exit 1
           else

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
             -p 5433:5432 \
             postgres:17.6
 
-          until pg_isready -h localhost -p 5433 -U postgres; do
+          until psql -h localhost -p 5433 -U postgres -c '\q' 2>/dev/null; do
             echo "Waiting for shadow DB..."
             sleep 1
           done
@@ -51,7 +51,8 @@ jobs:
           DIFF_OUTPUT=$(pnpm --filter @repo/db exec prisma migrate diff \
             --from-url "$DIRECT_URL" \
             --to-migrations prisma/migrations \
-            --shadow-database-url "$SHADOW_DATABASE_URL" 2>&1)
+            --shadow-database-url "$SHADOW_DATABASE_URL" \
+            --exit-code 2>&1)
           PRISMA_EXIT=$?
           set -e
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
             -p 5433:5432 \
             postgres:17.6
 
-          until psql -h localhost -p 5433 -U postgres -c '\q' 2>/dev/null; do
+          until PGPASSWORD=postgres psql -h localhost -p 5433 -U postgres -c '\q' 2>/dev/null; do
             echo "Waiting for shadow DB..."
             sleep 1
           done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,6 @@ jobs:
         uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - uses: actions/setup-node@v4
         with:

--- a/apps/worker/src/jobs/discord.test.ts
+++ b/apps/worker/src/jobs/discord.test.ts
@@ -18,6 +18,10 @@ function mockMessagesResponse(messages: unknown[]) {
   }
 }
 
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
 describe('runDiscordIngestion - WeeklyStats.discordMessages', () => {
   it('upserts WeeklyStats.discordMessages with the fetched message count', async () => {
     const weekStart = new Date('2026-05-04T00:00:00Z')

--- a/apps/worker/src/jobs/discord.test.ts
+++ b/apps/worker/src/jobs/discord.test.ts
@@ -1,16 +1,19 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { db } from '@repo/db'
 import { mockFetch } from '../test-config/vitest.setup'
-import { runDiscordIngestion } from './discord'
+import { runDiscordIngestion, requestMessages, timestampToSnowflake } from './discord'
 
-function mockMessagesResponse(messages: unknown[]) {
+function mockMessagesResponse(
+  messages: unknown[],
+  options: { remaining?: number; resetAfter?: number } = {}
+) {
   return {
     ok: true,
     status: 200,
     headers: {
       get: (h: string) => {
-        if (h === 'X-RateLimit-Remaining') return '5'
-        if (h === 'X-RateLimit-Reset-After') return '0'
+        if (h === 'X-RateLimit-Remaining') return String(options.remaining ?? 5)
+        if (h === 'X-RateLimit-Reset-After') return String(options.resetAfter ?? 0)
         return null
       },
     },
@@ -18,102 +21,279 @@ function mockMessagesResponse(messages: unknown[]) {
   }
 }
 
-beforeEach(() => {
-  vi.clearAllMocks()
+function mockErrorResponse(status: number) {
+  return {
+    ok: false,
+    status,
+    headers: { get: () => null },
+    json: () => Promise.resolve({}),
+  }
+}
+
+function makeMessage(overrides: {
+  id: string
+  authorId?: string
+  bot?: boolean
+  timestamp?: string
+  content?: string
+  channelId?: string
+}) {
+  return {
+    id: overrides.id,
+    channel_id: overrides.channelId ?? 'channel-1',
+    author: {
+      id: overrides.authorId ?? 'u1',
+      username: 'user',
+      discriminator: '0001',
+      ...(overrides.bot ? { bot: true } : {}),
+    },
+    content: overrides.content ?? 'hello',
+    timestamp: overrides.timestamp ?? '2026-05-05T10:00:00Z',
+  }
+}
+
+const WEEK_START = new Date('2026-05-04T00:00:00Z')
+const WEEK_END = new Date('2026-05-10T23:59:59Z')
+
+describe('timestampToSnowflake', () => {
+  it('converts the discord epoch itself to zero', () => {
+    expect(timestampToSnowflake(1420070400000)).toBe('0')
+  })
+
+  it('converts a known timestamp to the correct snowflake', () => {
+    expect(timestampToSnowflake(1420070400001)).toBe('4194304')
+  })
 })
 
-describe('runDiscordIngestion - WeeklyStats.discordMessages', () => {
-  it('upserts WeeklyStats.discordMessages with the fetched message count', async () => {
-    const weekStart = new Date('2026-05-04T00:00:00Z')
-    const weekEnd = new Date('2026-05-10T23:59:59Z')
-    const projectId = 'project-1'
-    const channelId = 'channel-1'
+describe('requestMessages', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
 
-    vi.mocked(db.project.findMany).mockResolvedValue([
-      {
-        id: projectId,
-        name: 'Test Project',
-        channels: [{ externalId: channelId, name: 'general' }],
-      },
-    ] as never)
+  describe('rate limiting (429)', () => {
+    it('retries after the wait time specified in the response body', async () => {
+      vi.useFakeTimers()
 
-    vi.mocked(db.syncJob.create).mockResolvedValue({ id: 'sync-1' } as never)
-    vi.mocked(db.syncJob.update).mockResolvedValue({} as never)
-    vi.mocked(db.personIdentity.findMany).mockResolvedValue([])
+      const rateLimitResponse = {
+        ok: false,
+        status: 429,
+        headers: {
+          get: (h: string) => {
+            if (h === 'X-RateLimit-Remaining') return '0'
+            if (h === 'X-RateLimit-Reset-After') return '1'
+            return null
+          },
+        },
+        json: () => Promise.resolve({ retry_after: 2 }),
+      }
 
-    const messages = [
-      {
-        id: '1',
-        channel_id: channelId,
-        author: { id: 'u1', username: 'a', discriminator: '0001' },
-        content: 'hello',
-        timestamp: '2026-05-05T10:00:00Z',
-      },
-      {
-        id: '2',
-        channel_id: channelId,
-        author: { id: 'u2', username: 'b', discriminator: '0002' },
-        content: 'world',
-        timestamp: '2026-05-06T10:00:00Z',
-      },
-      {
-        id: '3',
-        channel_id: channelId,
-        author: { id: 'u1', username: 'a', discriminator: '0001' },
-        content: 'again',
-        timestamp: '2026-05-07T10:00:00Z',
-      },
-    ]
+      mockFetch
+        .mockResolvedValueOnce(rateLimitResponse)
+        .mockResolvedValueOnce(mockMessagesResponse([makeMessage({ id: '1' })]))
 
-    mockFetch
-      .mockResolvedValueOnce(mockMessagesResponse(messages))
-      .mockResolvedValueOnce(mockMessagesResponse([]))
+      const fetchPromise = requestMessages('/channels/channel-1/messages?after=0&limit=100')
+      await vi.runAllTimersAsync()
+      await fetchPromise
 
-    await runDiscordIngestion(weekStart, weekEnd)
+      expect(mockFetch).toHaveBeenCalledTimes(2)
 
-    expect(db.weeklyStats.upsert).toHaveBeenCalledWith({
-      where: { projectId_weekStart: { projectId, weekStart } },
-      create: { projectId, weekStart, discordMessages: 3 },
-      update: { discordMessages: 3 },
+      vi.useRealTimers()
     })
   })
 
-  it('includes weeklyStats.upsert inside the same transaction as the discord aggregate', async () => {
-    const weekStart = new Date('2026-05-04T00:00:00Z')
-    const weekEnd = new Date('2026-05-10T23:59:59Z')
+  describe('HTTP error codes', () => {
+    it.each([
+      [401, '401 Unauthorized: Invalid token provided'],
+      [403, '403 Forbidden: No access to project channel'],
+      [404, '404 Not Found: Project channel not found'],
+    ])('throws a descriptive error for %i', async (status, expectedMessage) => {
+      mockFetch.mockResolvedValueOnce(mockErrorResponse(status))
 
-    vi.mocked(db.project.findMany).mockResolvedValue([
-      {
-        id: 'project-2',
-        name: 'Other',
-        channels: [{ externalId: 'c2', name: 'general' }],
-      },
-    ] as never)
-    vi.mocked(db.syncJob.create).mockResolvedValue({ id: 'sync-2' } as never)
+      await expect(
+        requestMessages('/channels/channel-1/messages?after=0&limit=100')
+      ).rejects.toThrow(expectedMessage)
+    })
+  })
+})
+
+describe('runDiscordIngestion', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(db.syncJob.create).mockResolvedValue({ id: 'sync-1' } as never)
     vi.mocked(db.syncJob.update).mockResolvedValue({} as never)
     vi.mocked(db.personIdentity.findMany).mockResolvedValue([])
+  })
 
-    mockFetch
-      .mockResolvedValueOnce(
-        mockMessagesResponse([
-          {
-            id: '10',
-            channel_id: 'c2',
-            author: { id: 'x', username: 'x', discriminator: '0001' },
-            content: 'hi',
-            timestamp: '2026-05-05T10:00:00Z',
-          },
-        ])
+  describe('WeeklyStats.discordMessages', () => {
+    it('upserts WeeklyStats.discordMessages with the fetched message count', async () => {
+      const projectId = 'project-1'
+      const channelId = 'channel-1'
+
+      vi.mocked(db.project.findMany).mockResolvedValue([
+        {
+          id: projectId,
+          name: 'Test Project',
+          channels: [{ externalId: channelId, name: 'general' }],
+        },
+      ] as never)
+
+      mockFetch
+        .mockResolvedValueOnce(
+          mockMessagesResponse([
+            makeMessage({
+              id: '1',
+              authorId: 'u1',
+              content: 'hello',
+              timestamp: '2026-05-05T10:00:00Z',
+            }),
+            makeMessage({
+              id: '2',
+              authorId: 'u2',
+              content: 'world',
+              timestamp: '2026-05-06T10:00:00Z',
+            }),
+            makeMessage({
+              id: '3',
+              authorId: 'u1',
+              content: 'again',
+              timestamp: '2026-05-07T10:00:00Z',
+            }),
+          ])
+        )
+        .mockResolvedValueOnce(mockMessagesResponse([]))
+
+      await runDiscordIngestion(WEEK_START, WEEK_END)
+
+      expect(db.weeklyStats.upsert).toHaveBeenCalledWith({
+        where: { projectId_weekStart: { projectId, weekStart: WEEK_START } },
+        create: { projectId, weekStart: WEEK_START, discordMessages: 3 },
+        update: { discordMessages: 3 },
+      })
+    })
+
+    it('includes weeklyStats.upsert inside the same transaction as the discord aggregate', async () => {
+      vi.mocked(db.project.findMany).mockResolvedValue([
+        { id: 'project-2', name: 'Other', channels: [{ externalId: 'c2', name: 'general' }] },
+      ] as never)
+      vi.mocked(db.syncJob.create).mockResolvedValue({ id: 'sync-2' } as never)
+
+      mockFetch
+        .mockResolvedValueOnce(mockMessagesResponse([makeMessage({ id: '10', channelId: 'c2' })]))
+        .mockResolvedValueOnce(mockMessagesResponse([]))
+
+      await runDiscordIngestion(WEEK_START, WEEK_END)
+
+      expect(db.$transaction).toHaveBeenCalledTimes(1)
+      const txCallArg = vi.mocked(db.$transaction).mock.calls[0][0]
+      expect(Array.isArray(txCallArg)).toBe(true)
+      expect(db.discordWeeklyAggregate.upsert).toHaveBeenCalled()
+      expect(db.weeklyStats.upsert).toHaveBeenCalled()
+    })
+  })
+
+  describe('message filtering', () => {
+    it('filters out messages outside the weekly window', async () => {
+      vi.mocked(db.project.findMany).mockResolvedValue([
+        { id: 'project-1', name: 'Test', channels: [{ externalId: 'channel-1', name: 'general' }] },
+      ] as never)
+
+      mockFetch
+        .mockResolvedValueOnce(
+          mockMessagesResponse([
+            makeMessage({ id: '1', timestamp: '2026-05-05T10:00:00Z', content: 'inside' }),
+            makeMessage({ id: '2', timestamp: '2026-05-03T23:59:59Z', content: 'before window' }),
+            makeMessage({ id: '3', timestamp: '2026-05-11T00:00:01Z', content: 'after window' }),
+          ])
+        )
+        .mockResolvedValueOnce(mockMessagesResponse([]))
+
+      const result = await runDiscordIngestion(WEEK_START, WEEK_END)
+
+      expect(result[0].messages).toEqual(['inside'])
+    })
+
+    it('excludes bot messages', async () => {
+      vi.mocked(db.project.findMany).mockResolvedValue([
+        { id: 'project-1', name: 'Test', channels: [{ externalId: 'channel-1', name: 'general' }] },
+      ] as never)
+
+      mockFetch
+        .mockResolvedValueOnce(
+          mockMessagesResponse([
+            makeMessage({ id: '1', content: 'human message' }),
+            makeMessage({ id: '2', bot: true, content: 'bot message' }),
+          ])
+        )
+        .mockResolvedValueOnce(mockMessagesResponse([]))
+
+      const result = await runDiscordIngestion(WEEK_START, WEEK_END)
+
+      expect(result[0].messages).toEqual(['human message'])
+    })
+  })
+
+  describe('pagination', () => {
+    it('collects messages across multiple pages', async () => {
+      vi.mocked(db.project.findMany).mockResolvedValue([
+        { id: 'project-1', name: 'Test', channels: [{ externalId: 'channel-1', name: 'general' }] },
+      ] as never)
+
+      const page1 = Array.from({ length: 100 }, (_, i) =>
+        makeMessage({ id: String(i + 1), content: `msg ${i + 1}` })
       )
-      .mockResolvedValueOnce(mockMessagesResponse([]))
+      const page2 = [
+        makeMessage({ id: '101', content: 'msg 101' }),
+        makeMessage({ id: '102', content: 'msg 102' }),
+      ]
 
-    await runDiscordIngestion(weekStart, weekEnd)
+      mockFetch
+        .mockResolvedValueOnce(mockMessagesResponse(page1))
+        .mockResolvedValueOnce(mockMessagesResponse(page2))
+        .mockResolvedValueOnce(mockMessagesResponse([]))
 
-    expect(db.$transaction).toHaveBeenCalledTimes(1)
-    const txCallArg = vi.mocked(db.$transaction).mock.calls[0][0]
-    expect(Array.isArray(txCallArg)).toBe(true)
-    // Aggregate + weeklyStats upserts are both included
-    expect(db.discordWeeklyAggregate.upsert).toHaveBeenCalled()
-    expect(db.weeklyStats.upsert).toHaveBeenCalled()
+      const result = await runDiscordIngestion(WEEK_START, WEEK_END)
+
+      expect(result[0].messages).toHaveLength(102)
+      expect(mockFetch).toHaveBeenNthCalledWith(
+        2,
+        expect.stringContaining('after=100'),
+        expect.any(Object)
+      )
+    })
+  })
+
+  describe('projects with no channels', () => {
+    it('skips the project without creating a sync job', async () => {
+      vi.mocked(db.project.findMany).mockResolvedValue([
+        { id: 'project-1', name: 'No Channels Project', channels: [] },
+      ] as never)
+
+      const result = await runDiscordIngestion(WEEK_START, WEEK_END)
+
+      expect(result).toEqual([])
+      expect(db.syncJob.create).not.toHaveBeenCalled()
+      expect(mockFetch).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('failed channel fetch', () => {
+    it('marks the sync job as FAILED with the error message', async () => {
+      vi.mocked(db.project.findMany).mockResolvedValue([
+        { id: 'project-1', name: 'Test', channels: [{ externalId: 'channel-1', name: 'general' }] },
+      ] as never)
+
+      mockFetch.mockResolvedValue(mockErrorResponse(403))
+
+      await runDiscordIngestion(WEEK_START, WEEK_END)
+
+      expect(db.syncJob.update).toHaveBeenCalledWith({
+        where: { id: 'sync-1' },
+        data: expect.objectContaining({
+          status: 'FAILED',
+          errorMessage: '403 Forbidden: No access to project channel',
+          finishedAt: expect.any(Date),
+        }),
+      })
+    })
   })
 })

--- a/apps/worker/src/jobs/discord.test.ts
+++ b/apps/worker/src/jobs/discord.test.ts
@@ -3,17 +3,14 @@ import { db } from '@repo/db'
 import { mockFetch } from '../test-config/vitest.setup'
 import { runDiscordIngestion, requestMessages, timestampToSnowflake } from './discord'
 
-function mockMessagesResponse(
-  messages: unknown[],
-  options: { remaining?: number; resetAfter?: number } = {}
-) {
+function mockMessagesResponse(messages: unknown[]) {
   return {
     ok: true,
     status: 200,
     headers: {
       get: (h: string) => {
-        if (h === 'X-RateLimit-Remaining') return String(options.remaining ?? 5)
-        if (h === 'X-RateLimit-Reset-After') return String(options.resetAfter ?? 0)
+        if (h === 'X-RateLimit-Remaining') return '5'
+        if (h === 'X-RateLimit-Reset-After') return '0'
         return null
       },
     },


### PR DESCRIPTION
## Description
Adds full vitest test coverage for the Discord ingestion module.

## Solution
Tests are organised by exported function — `timestampToSnowflake`, `requestMessages`, and `runDiscordIngestion` — each as a top-level `describe` block. Covers all acceptance criteria:

- Messages outside the weekly window are filtered out
- Bot messages are excluded
- Pagination collects messages across multiple pages with correct cursor usage
- 429 responses retry after the wait time specified in the response body
- 401, 403, and 404 errors throw with descriptive messages
- Projects with no channels are skipped without creating a sync job
- Failed channel fetches mark the sync job as `FAILED` with the error message recorded

## Notes
- `vi.clearAllMocks()` runs in `beforeEach` to prevent state leaking between tests
- Fake timers are used for the 429 retry test to avoid real waits
- Shared `makeMessage`, `mockMessagesResponse`, and `mockErrorResponse` helpers keep tests concise