### PR TITLE
[#160] feat: catch commits from deleted unmerged branches

### DIFF
--- a/apps/worker/src/jobs/github.ts
+++ b/apps/worker/src/jobs/github.ts
@@ -1,7 +1,7 @@
 import { db } from '@repo/db'
 import { logger } from '../lib/logger'
 import { ingestRepoCommits } from '../lib/github-commit-tracker'
-import { ingestRepoMergedPRs } from '../lib/github-PR-tracker'
+import { ingestRepoMergedPRs, ingestClosedBranchCommits } from '../lib/github-PR-tracker'
 import { computeWeeklyGitHubMetrics } from '../lib/github-weekly-stats'
 
 export async function runGitHubIngestion(weekStart: Date, weekEnd: Date): Promise<void> {
@@ -36,6 +36,15 @@ export async function runGitHubIngestion(weekStart: Date, weekEnd: Date): Promis
           totalProcessed += commitCount
         } catch (err) {
           logger.error(`Failed to ingest commits for ${repo.owner}/${repo.name}: ${err}`)
+        }
+
+        try {
+          const closedCount = await ingestClosedBranchCommits(repo, weekEnd)
+          totalProcessed += closedCount
+        } catch (err) {
+          logger.error(
+            `Failed to ingest closed branch commits for ${repo.owner}/${repo.name}: ${err}`
+          )
         }
       }
 

--- a/apps/worker/src/lib/github-PR-tracker.ts
+++ b/apps/worker/src/lib/github-PR-tracker.ts
@@ -6,6 +6,7 @@ import { logger } from '../lib/logger'
 import { resolveIdentity } from './github-utils'
 import { withRateLimit } from './github-utils'
 import { upsertCommit } from './github-commit-tracker'
+import { getCollectionWindow } from './date-utils'
 
 export async function ingestRepoMergedPRs(
   repo: { id: string; owner: string; name: string; installationId: string },
@@ -123,7 +124,7 @@ export async function ingestClosedBranchCommits(
   repo: { id: string; owner: string; name: string; installationId: string },
   weekEnd: Date
 ): Promise<number> {
-  const twoWeeksAgo = new Date(weekEnd.getTime() - 14 * 24 * 60 * 60 * 1000)
+  const [twoWeeksAgo] = getCollectionWindow(new Date(weekEnd.getTime() - 7 * 24 * 60 * 60 * 1000))
   const since = twoWeeksAgo.toISOString().slice(0, 10)
   const until = weekEnd.toISOString().slice(0, 10)
 

--- a/apps/worker/src/lib/github-PR-tracker.ts
+++ b/apps/worker/src/lib/github-PR-tracker.ts
@@ -115,3 +115,76 @@ export async function ingestRepoMergedPRs(
   logger.info(`Saved ${count} merged PRs for ${repo.owner}/${repo.name}.`)
   return count
 }
+
+// Looks back 2 weeks for closed (unmerged) PRs and ingests their commits.
+// This catches commits on branches that were force-deleted or abandoned before
+// the regular branch-scan could pick them up.
+export async function ingestClosedBranchCommits(
+  repo: { id: string; owner: string; name: string; installationId: string },
+  weekEnd: Date
+): Promise<number> {
+  const twoWeeksAgo = new Date(weekEnd.getTime() - 14 * 24 * 60 * 60 * 1000)
+  const since = twoWeeksAgo.toISOString().slice(0, 10)
+  const until = weekEnd.toISOString().slice(0, 10)
+
+  logger.info(
+    `Fetching closed unmerged PR commits for ${repo.owner}/${repo.name} from ${since} to ${until}`
+  )
+
+  const octokit = await getInstallationOctokit(repo.installationId)
+
+  const closedPRs = await withRateLimit(() =>
+    octokit.paginate('GET /search/issues', {
+      q: `repo:${repo.owner}/${repo.name} is:pr is:closed is:unmerged closed:${since}..${until}`,
+      per_page: 100,
+    })
+  )
+
+  if (closedPRs.length === 0) {
+    logger.info(`No closed unmerged PRs found for ${repo.owner}/${repo.name} in the past 2 weeks.`)
+    return 0
+  }
+
+  let commitCount = 0
+  for (const pr of closedPRs) {
+    try {
+      const { data: fullPr } = await withRateLimit(() =>
+        octokit.request('GET /repos/{owner}/{repo}/pulls/{pull_number}', {
+          owner: repo.owner,
+          repo: repo.name,
+          pull_number: pr.number,
+        })
+      )
+
+      // Guard: skip if the PR was actually merged (search qualifier should prevent this)
+      if (fullPr.merged_at) continue
+
+      const prCommits = await withRateLimit(() =>
+        octokit.paginate('GET /repos/{owner}/{repo}/pulls/{pull_number}/commits', {
+          owner: repo.owner,
+          repo: repo.name,
+          pull_number: fullPr.number,
+          per_page: 100,
+        })
+      )
+
+      for (const commit of prCommits) {
+        try {
+          await upsertCommit(repo, octokit, commit.sha, fullPr.head.ref)
+          commitCount++
+        } catch (err) {
+          logger.error(
+            `Failed to upsert commit ${commit.sha} from closed PR #${fullPr.number} in ${repo.owner}/${repo.name}: ${err}`
+          )
+        }
+      }
+    } catch (err) {
+      logger.error(
+        `Failed to ingest commits for closed PR #${pr.number} in ${repo.owner}/${repo.name}: ${err}`
+      )
+    }
+  }
+
+  logger.info(`Saved ${commitCount} commits from closed branches for ${repo.owner}/${repo.name}.`)
+  return commitCount
+}


### PR DESCRIPTION
## Description
catch commits from deleted unmerged branches

## Solution

Ingestion job looks back 2 weeks when checking for closed/deleted branches
Commits from those branches that were not merged into main/master are captured and stored
Captured commits are not double-counted against any other branch or run

## Notes

<!-- Add any notes you think are needed -->
