### PR TITLE
[#168]  Bulk add project members via CSV upload

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -20,11 +20,12 @@
     "clsx": "^2.1.1",
     "lucide-react": "^1.7.0",
     "next": "^15.1.0",
+    "octokit": "^5.0.5",
+    "papaparse": "5.5.3",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "recharts": "2.15.4",
     "tailwind-merge": "^3.5.0",
-    "octokit": "^5.0.5",
     "zod": "^4.4.3"
   },
   "devDependencies": {
@@ -32,6 +33,7 @@
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.2",
     "@types/node": "^22.0.0",
+    "@types/papaparse": "5.5.2",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@vitest/coverage-v8": "^2.1.9",

--- a/apps/web/src/app/(admin)/projects/[slug]/members/new/page.tsx
+++ b/apps/web/src/app/(admin)/projects/[slug]/members/new/page.tsx
@@ -17,6 +17,7 @@ import { BORDER_DEFAULT, BORDER_HOVER, inputClass, inputErrorClass } from '@/lib
 import { z } from 'zod'
 import { addMemberSchema } from '@/lib/schemas/admin'
 import FieldError from '@/components/utils/FieldError'
+import type { AddProjectMemberResponse } from '@/lib/project-members/types'
 
 type PersonIdentity = {
   id: string
@@ -93,6 +94,13 @@ export default function CreateMemberPage({ params }: { params: Promise<{ slug: s
       } catch {
         setError(text)
       }
+      return
+    }
+
+    const result = (await response.json()) as AddProjectMemberResponse
+    if (result.outcome === 'already_member') {
+      setError(result.message)
+      setSuccess(false)
       return
     }
 

--- a/apps/web/src/app/(admin)/projects/[slug]/page.tsx
+++ b/apps/web/src/app/(admin)/projects/[slug]/page.tsx
@@ -1,11 +1,12 @@
 'use client'
 
-import { useEffect, useState, use } from 'react'
+import { useCallback, useEffect, useState, use } from 'react'
 import { useRouter } from 'next/navigation'
 import Link from 'next/link'
 import Image from 'next/image'
 import { IdentityProvider } from '@repo/db'
 import { BORDER_DEFAULT, BORDER_HOVER } from '@/lib/admin/layout'
+import CSVUploader from '@/components/ui/CSVUploader'
 
 type PersonIdentity = {
   id: string
@@ -53,14 +54,19 @@ export default function ProjectPage({ params }: { params: Promise<{ slug: string
   const { slug } = use(params)
   const [members, setMembers] = useState<ProjectMember[]>([])
   const [loading, setLoading] = useState(true)
+  const [showCsvUploader, setShowCsvUploader] = useState(false)
   const router = useRouter()
 
-  useEffect(() => {
-    fetchMembers(slug).then((data) => {
-      setMembers(data)
-      setLoading(false)
-    })
+  const refreshMembers = useCallback(async () => {
+    setLoading(true)
+    const data = await fetchMembers(slug)
+    setMembers(data)
+    setLoading(false)
   }, [slug])
+
+  useEffect(() => {
+    refreshMembers()
+  }, [refreshMembers])
 
   return (
     <>
@@ -105,14 +111,24 @@ export default function ProjectPage({ params }: { params: Promise<{ slug: string
               {loading ? '—' : members.length} member{members.length !== 1 ? 's' : ''}
             </p>
           </div>
-          <button
-            onClick={() => router.push(`/projects/${slug}/members/new`)}
-            className="flex items-center gap-2 bg-wdcc-oshan text-white font-mono text-sm font-medium px-4 py-2.5 rounded-xl hover:bg-wdcc-oshan/80 transition-colors duration-150"
-          >
-            <span className="text-base leading-none">+</span>
-            Add member
-          </button>
+          <div className="flex items-center gap-3">
+            <button
+              onClick={() => setShowCsvUploader((prev) => !prev)}
+              className="flex items-center gap-2 bg-wdcc-oshan text-white font-mono text-sm font-medium px-4 py-2.5 rounded-xl hover:bg-wdcc-oshan/80 transition-colors duration-150"
+            >
+              {showCsvUploader ? 'Hide CSV uploader' : 'Add members via CSV'}
+            </button>
+            <button
+              onClick={() => router.push(`/projects/${slug}/members/new`)}
+              className="flex items-center gap-2 bg-wdcc-oshan text-white font-mono text-sm font-medium px-4 py-2.5 rounded-xl hover:bg-wdcc-oshan/80 transition-colors duration-150"
+            >
+              <span className="text-base leading-none">+</span>
+              Add member
+            </button>
+          </div>
         </div>
+
+        {showCsvUploader && <CSVUploader slug={slug} onComplete={refreshMembers} />}
 
         {/* Members grid */}
         {loading ? (

--- a/apps/web/src/app/api/project/[slug]/members/route.ts
+++ b/apps/web/src/app/api/project/[slug]/members/route.ts
@@ -189,6 +189,21 @@ export async function POST(request: Request, { params }: { params: Promise<{ slu
       targetDisplayName = existingPerson.displayName
     }
 
+    // for looking up existing identities when adding through CSV with no personID
+    if (githubId || discordId) {
+      const existingIdentity = await db.personIdentity.findFirst({
+        where: {
+          OR: [
+            { provider: 'GITHUB' as const, username: githubId },
+            { provider: 'DISCORD' as const, username: discordId },
+          ],
+        },
+      })
+      if (existingIdentity) {
+        targetPersonId = existingIdentity.personId
+      }
+    }
+
     const { githubExternalId, githubUsername, discordSnowflake, discordUsername } =
       await resolveIdentities(githubId, discordId)
 

--- a/apps/web/src/app/api/project/[slug]/members/route.ts
+++ b/apps/web/src/app/api/project/[slug]/members/route.ts
@@ -130,7 +130,6 @@ async function linkPersonToProject(
     if (existingMember.isActive) {
       return {
         outcome: 'already_member',
-        skipped: true,
         message: 'This person is already an active member of this project',
       }
     }

--- a/apps/web/src/app/api/project/[slug]/members/route.ts
+++ b/apps/web/src/app/api/project/[slug]/members/route.ts
@@ -6,6 +6,7 @@ import {
   IdentityResolutionError,
 } from '@/lib/identity/resolve'
 import { addMemberSchema } from '@/lib/schemas/admin'
+import type { AddProjectMemberResponse } from '@/lib/project-members/types'
 
 // API route for getting all members of a project
 export async function GET(_: Request, { params }: { params: Promise<{ slug: string }> }) {
@@ -113,7 +114,7 @@ async function linkPersonToProject(
   slug: string,
   personId: string,
   displayName: string
-) {
+): Promise<AddProjectMemberResponse> {
   const project = await tx.project.findUnique({
     where: { slug },
     select: { id: true },
@@ -127,23 +128,40 @@ async function linkPersonToProject(
 
   if (existingMember) {
     if (existingMember.isActive) {
-      throw new Error('This person is already an active member of this project!')
+      return {
+        outcome: 'already_member',
+        skipped: true,
+        message: 'This person is already an active member of this project',
+      }
     }
-    return tx.projectMember.update({
+    const member = await tx.projectMember.update({
       where: { id: existingMember.id },
       data: { isActive: true, displayName },
       include: { person: true },
     })
+    return { outcome: 'member_linked', member }
   }
 
-  return tx.projectMember.create({
+  const member = await tx.projectMember.create({
     data: { projectId: project.id, personId, displayName, isActive: true },
     include: { person: true },
+  })
+  return { outcome: 'member_linked', member }
+}
+
+function getFormString(formData: FormData, key: string): string {
+  const value = formData.get(key)
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function findExistingIdentity(provider: 'DISCORD' | 'GITHUB', username: string) {
+  return db.personIdentity.findFirst({
+    where: { provider, username: { equals: username, mode: 'insensitive' } },
+    select: { personId: true },
   })
 }
 
 function errorToStatus(message: string): number {
-  if (message === 'This person is already an active member of this project!') return 409
   if (message === 'Project not found') return 404
   return 500
 }
@@ -187,27 +205,39 @@ export async function POST(request: Request, { params }: { params: Promise<{ slu
         )
       }
       targetDisplayName = existingPerson.displayName
-    }
+    } else if (!targetDisplayName) {
+      return Response.json({ error: 'Display name is required for a new person' }, { status: 400 })
+    } else {
+      // for looking up existing identities when adding through CSV with no personId
+      const [existingGithubIdentity, existingDiscordIdentity] = await Promise.all([
+        githubId ? findExistingIdentity('GITHUB', githubId) : null,
+        discordId ? findExistingIdentity('DISCORD', discordId) : null,
+      ])
 
-    // for looking up existing identities when adding through CSV with no personID
-    if (githubId || discordId) {
-      const existingIdentity = await db.personIdentity.findFirst({
-        where: {
-          OR: [
-            { provider: 'GITHUB' as const, username: githubId },
-            { provider: 'DISCORD' as const, username: discordId },
-          ],
-        },
-      })
-      if (existingIdentity) {
-        targetPersonId = existingIdentity.personId
+      if (
+        existingGithubIdentity &&
+        existingDiscordIdentity &&
+        existingGithubIdentity.personId !== existingDiscordIdentity.personId
+      ) {
+        return Response.json(
+          {
+            error: 'The provided GitHub and Discord accounts belong to different existing people.',
+          },
+          { status: 409 }
+        )
+      }
+
+      if (existingGithubIdentity) {
+        targetPersonId = existingGithubIdentity.personId
+      } else if (existingDiscordIdentity) {
+        targetPersonId = existingDiscordIdentity.personId
       }
     }
 
     const { githubExternalId, githubUsername, discordSnowflake, discordUsername } =
       await resolveIdentities(githubId, discordId)
 
-    const newMember = await db.$transaction(async (tx) => {
+    const newMemberResult = await db.$transaction(async (tx) => {
       if (!targetPersonId) {
         targetPersonId = await createPersonWithIdentities(tx, {
           displayName: targetDisplayName,
@@ -222,7 +252,9 @@ export async function POST(request: Request, { params }: { params: Promise<{ slu
       return linkPersonToProject(tx, slug, targetPersonId, targetDisplayName)
     })
 
-    return Response.json(newMember, { status: 201 })
+    return Response.json(newMemberResult, {
+      status: newMemberResult.outcome === 'already_member' ? 200 : 201,
+    })
   } catch (error) {
     console.error('Error adding member:', error)
 

--- a/apps/web/src/components/ui/CSVUploader.tsx
+++ b/apps/web/src/components/ui/CSVUploader.tsx
@@ -1,0 +1,149 @@
+'use client'
+
+import { useRef, useState } from 'react'
+import Papa from 'papaparse'
+
+interface Member {
+  name: string
+  githubId: string
+  discordId: string
+  imageUrl: string
+  rowNumber: number
+}
+
+export default function CSVUploader({
+  slug,
+  onComplete,
+}: {
+  slug: string
+  onComplete: () => void | Promise<void>
+}) {
+  const [error, setError] = useState<string>('')
+  const [isUploading, setIsUploading] = useState(false)
+  const [isSuccess, setIsSuccess] = useState(false)
+  const csvInputRef = useRef<HTMLInputElement>(null)
+  const [csvFile, setCsvFile] = useState<File | null>(null)
+
+  const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    setError('')
+    setIsSuccess(false)
+
+    // only takes first file since its for uploading a single team list
+    const file = e.target.files?.[0]
+    if (!file) return
+
+    setCsvFile(file)
+
+    if (!file.name.endsWith('.csv')) {
+      setError('Please upload a .csv file')
+      return
+    }
+
+    Papa.parse<Record<string, string>>(file, {
+      header: true,
+      skipEmptyLines: true,
+      complete: async (results) => {
+        setIsUploading(true)
+        const memberRows: Member[] = results.data.map((row, index) => ({
+          name: row['Name'],
+          githubId: row['Github Name'],
+          discordId: row['Discord Name'],
+          imageUrl: row['Image URL'],
+          rowNumber: index + 2, // +2 to account for header row and 0-indexing
+        }))
+
+        const errors: string[] = []
+
+        for (const member of memberRows) {
+          const fd = new FormData()
+          fd.append('displayName', member.name)
+          fd.append('githubId', member.githubId)
+          fd.append('discordId', member.discordId)
+          fd.append('imageUrl', member.imageUrl)
+
+          try {
+            const result = await fetch(`/api/project/${slug}/members`, {
+              method: 'POST',
+              body: fd,
+            })
+
+            if (!result.ok && result.status !== 409) {
+              const errorData = await result.json()
+              errors.push(`Error adding row ${member.rowNumber}: ${errorData.error}`)
+            }
+          } catch (err: unknown) {
+            const message = err instanceof Error ? err.message : String(err)
+            errors.push(`Error adding row ${member.rowNumber}: ${message}`)
+          }
+        }
+
+        setIsUploading(false)
+        if (errors.length === 0) {
+          setIsSuccess(true)
+          setTimeout(() => {
+            onComplete()
+          }, 1200)
+        } else {
+          setIsSuccess(false)
+          setError(errors.join('\n'))
+          await onComplete()
+        }
+      },
+      error: (err) => {
+        setIsUploading(false)
+        setIsSuccess(false)
+        setError(err.message)
+      },
+    })
+  }
+
+  return (
+    <div>
+      <div
+        onClick={() => {
+          if (!isUploading) csvInputRef.current?.click()
+        }}
+        className={`mb-4 border-[1.5px] border-dashed border-wdcc-kelvin/40 rounded-2xl p-6 text-center transition-all ${
+          isUploading
+            ? 'cursor-not-allowed opacity-70'
+            : 'cursor-pointer hover:bg-wdcc-kelvin/5 hover:border-wdcc-kelvin/70'
+        }`}
+      >
+        {csvFile ? (
+          <div className="flex items-center gap-3">
+            <div className="w-[52px] h-[52px] rounded-[14px] bg-[#d9d9d9] overflow-hidden shrink-0 flex items-center justify-center">
+              <span className="font-mono text-xs font-bold text-wdcc-grey-light">CSV</span>
+            </div>
+            <div className="text-left">
+              <p className="font-mono text-sm font-semibold text-wdcc-oshan">{csvFile.name}</p>
+              <p className="font-mono text-[11px] text-wdcc-grey-light mt-0.5">Click to change</p>
+            </div>
+          </div>
+        ) : (
+          <>
+            <p className="font-mono text-sm text-wdcc-grey-light">Click to upload member CSV</p>
+            <p className="font-mono text-[10px] text-wdcc-grey-light/60 mt-1">
+              CSV should have columns: Name, Github Name, Discord Name, Image URL and only member
+              name is required.
+            </p>
+          </>
+        )}
+        <input
+          ref={csvInputRef}
+          type="file"
+          accept=".csv"
+          className="hidden"
+          onChange={handleFileChange}
+          disabled={isUploading}
+        />
+      </div>
+      {isUploading && (
+        <div className="mt-3 mb-4 font-mono text-xs text-wdcc-grey-light">Uploading members...</div>
+      )}
+      {isSuccess && (
+        <div className="mt-3 mb-4 font-mono text-xs text-green-600">Upload complete!</div>
+      )}
+      {error && <div className="text-red-500 mb-4 whitespace-pre-wrap">{error}</div>}
+    </div>
+  )
+}

--- a/apps/web/src/components/ui/CSVUploader.tsx
+++ b/apps/web/src/components/ui/CSVUploader.tsx
@@ -67,7 +67,7 @@ export default function CSVUploader({
               body: fd,
             })
 
-            if (!result.ok && result.status !== 409) {
+            if (!result.ok) {
               const errorData = await result.json()
               errors.push(`Error adding row ${member.rowNumber}: ${errorData.error}`)
             }
@@ -77,6 +77,7 @@ export default function CSVUploader({
           }
         }
 
+        // After all rows in CSV are checked, update UI based on success/errors
         setIsUploading(false)
         if (errors.length === 0) {
           setIsSuccess(true)

--- a/apps/web/src/components/ui/CSVUploader.tsx
+++ b/apps/web/src/components/ui/CSVUploader.tsx
@@ -2,6 +2,7 @@
 
 import { useRef, useState } from 'react'
 import Papa from 'papaparse'
+import type { AddProjectMemberResponse } from '@/lib/project-members/types'
 
 interface Member {
   name: string
@@ -19,6 +20,7 @@ export default function CSVUploader({
   onComplete: () => void | Promise<void>
 }) {
   const [error, setError] = useState<string>('')
+  const [skippedInfo, setSkippedInfo] = useState<string>('')
   const [isUploading, setIsUploading] = useState(false)
   const [isSuccess, setIsSuccess] = useState(false)
   const csvInputRef = useRef<HTMLInputElement>(null)
@@ -26,6 +28,7 @@ export default function CSVUploader({
 
   const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
     setError('')
+    setSkippedInfo('')
     setIsSuccess(false)
 
     // only takes first file since its for uploading a single team list
@@ -53,6 +56,7 @@ export default function CSVUploader({
         }))
 
         const errors: string[] = []
+        const skippedRows: string[] = []
 
         for (const member of memberRows) {
           const fd = new FormData()
@@ -70,6 +74,12 @@ export default function CSVUploader({
             if (!result.ok) {
               const errorData = await result.json()
               errors.push(`Error adding row ${member.rowNumber}: ${errorData.error}`)
+              continue
+            }
+
+            const data = (await result.json()) as AddProjectMemberResponse
+            if (data.outcome === 'already_member') {
+              skippedRows.push(`Row ${member.rowNumber}: ${member.name}`)
             }
           } catch (err: unknown) {
             const message = err instanceof Error ? err.message : String(err)
@@ -79,6 +89,15 @@ export default function CSVUploader({
 
         // After all rows in CSV are checked, update UI based on success/errors
         setIsUploading(false)
+        const skippedSummary =
+          skippedRows.length > 0
+            ? `Skipped rows since members are already on the project:\n${skippedRows.join('\n')}`
+            : ''
+
+        if (skippedSummary) {
+          setSkippedInfo(skippedSummary)
+        }
+
         if (errors.length === 0) {
           setIsSuccess(true)
           setTimeout(() => {
@@ -143,6 +162,11 @@ export default function CSVUploader({
       )}
       {isSuccess && (
         <div className="mt-3 mb-4 font-mono text-xs text-green-600">Upload complete!</div>
+      )}
+      {skippedInfo && (
+        <div className="text-wdcc-blue mb-4 whitespace-pre-wrap font-mono text-xs">
+          {skippedInfo}
+        </div>
       )}
       {error && <div className="text-red-500 mb-4 whitespace-pre-wrap">{error}</div>}
     </div>

--- a/apps/web/src/lib/project-members/types.ts
+++ b/apps/web/src/lib/project-members/types.ts
@@ -22,7 +22,6 @@ export type ProjectMemberLinkedResponse = {
 
 export type ProjectMemberAlreadyExistsResponse = {
   outcome: 'already_member'
-  skipped: true
   message: string
 }
 

--- a/apps/web/src/lib/project-members/types.ts
+++ b/apps/web/src/lib/project-members/types.ts
@@ -1,0 +1,33 @@
+export type ProjectMemberPerson = {
+  id: string
+  displayName: string
+  imageUrl: string | null
+  createdAt: Date
+}
+
+export type ProjectMemberWithPerson = {
+  id: string
+  projectId: string
+  personId: string
+  displayName: string | null
+  isActive: boolean
+  joinedAt: Date
+  person: ProjectMemberPerson
+}
+
+export type ProjectMemberLinkedResponse = {
+  outcome: 'member_linked'
+  member: ProjectMemberWithPerson
+}
+
+export type ProjectMemberAlreadyExistsResponse = {
+  outcome: 'already_member'
+  skipped: true
+  message: string
+}
+
+// This type is used to handle the case where a member being added already exists as an active member of the project.
+// In that case, we skip adding them and show a message to the user when adding on new member page.
+export type AddProjectMemberResponse =
+  | ProjectMemberLinkedResponse
+  | ProjectMemberAlreadyExistsResponse

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,6 +58,9 @@ importers:
       octokit:
         specifier: ^5.0.5
         version: 5.0.5
+      papaparse:
+        specifier: 5.5.3
+        version: 5.5.3
       react:
         specifier: ^19.0.0
         version: 19.2.4
@@ -86,6 +89,9 @@ importers:
       '@types/node':
         specifier: ^22.0.0
         version: 22.19.15
+      '@types/papaparse':
+        specifier: 5.5.2
+        version: 5.5.2
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -2230,6 +2236,12 @@ packages:
     resolution:
       {
         integrity: sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==,
+      }
+
+  '@types/papaparse@5.5.2':
+    resolution:
+      {
+        integrity: sha512-gFnFp/JMzLHCwRf7tQHrNnfhN4eYBVYYI897CGX4MY1tzY9l2aLkVyx2IlKZ/SAqDbB3I1AOZW5gTMGGsqWliA==,
       }
 
   '@types/pg@8.20.0':
@@ -5530,6 +5542,12 @@ packages:
         integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==,
       }
 
+  papaparse@5.5.3:
+    resolution:
+      {
+        integrity: sha512-5QvjGxYVjxO59MGU2lHVYpRWBBtKHnlIAcSe1uNFCkkptUh63NFRj0FJQm7nR67puEruUci/ZkjmEFrjCAyP4A==,
+      }
+
   parent-module@1.0.1:
     resolution:
       {
@@ -8260,6 +8278,10 @@ snapshots:
     dependencies:
       undici-types: 7.18.2
 
+  '@types/papaparse@5.5.2':
+    dependencies:
+      '@types/node': 25.5.0
+
   '@types/pg@8.20.0':
     dependencies:
       '@types/node': 25.5.0
@@ -10469,6 +10491,8 @@ snapshots:
       p-limit: 3.1.0
 
   package-json-from-dist@1.0.1: {}
+
+  papaparse@5.5.3: {}
 
   parent-module@1.0.1:
     dependencies:


### PR DESCRIPTION
## Description

- Allows admin users to add multiple members at once through a CSV file
- Adds valid member rows of CSV file to project 
- Provides issues for each row that doesn't meet the requirements to add the member to the team

## Solution

- Use the Papaparse library to read through the csv file
- Created the CSVUploader component for the admin user to attach a csv file

## Notes

- Used the csv file example on the drive: Name, Github Name, Discord Name, and ImageUrl columns are required in the csv for it.

<img width="1867" height="252" alt="image" src="https://github.com/user-attachments/assets/19b33711-4bf0-4750-9ece-264d18a44819" />

