### PR TITLE
[#100] Auto-apply migrations on merge to main

### DIFF
--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -8,17 +8,27 @@ on:
 jobs:
   migrate:
     runs-on: ubuntu-latest
+    concurrency:
+      group: migrate-prod
+      cancel-in-progress: false
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          fetch-depth: 2
+          fetch-depth: 0
 
       - name: Check for new migrations
         id: check
         run: |
-          CHANGED=$(git diff --name-only HEAD~1 HEAD -- packages/db/prisma/migrations/)
+          BEFORE="${{ github.event.before }}"
+          AFTER="${{ github.event.after }}"
+          if echo "$BEFORE" | grep -qE '^0+$'; then
+            BASE="HEAD~1"
+          else
+            BASE="$BEFORE"
+          fi
+          CHANGED=$(git diff --name-only "$BASE" "$AFTER" -- packages/db/prisma/migrations/)
           if [ -n "$CHANGED" ]; then
             echo "found=true" >> $GITHUB_OUTPUT
             echo "New migrations detected:"
@@ -28,15 +38,16 @@ jobs:
             echo "No new migrations, skipping."
           fi
 
+      - name: Install pnpm
+        if: steps.check.outputs.found == 'true'
+        uses: pnpm/action-setup@v4
+
       - name: Setup Node
         if: steps.check.outputs.found == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: 20
-
-      - name: Install pnpm
-        if: steps.check.outputs.found == 'true'
-        uses: pnpm/action-setup@v4
+          cache: pnpm
 
       - name: Install dependencies
         if: steps.check.outputs.found == 'true'
@@ -47,6 +58,7 @@ jobs:
         run: pnpm --filter @repo/db db:deploy
         env:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          DIRECT_URL: ${{ secrets.DIRECT_URL }}
 
       - name: Notify Discord on failure
         if: failure()

--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -1,0 +1,56 @@
+name: Auto-apply Migrations
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  migrate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Check for new migrations
+        id: check
+        run: |
+          CHANGED=$(git diff --name-only HEAD~1 HEAD -- packages/db/prisma/migrations/)
+          if [ -n "$CHANGED" ]; then
+            echo "found=true" >> $GITHUB_OUTPUT
+            echo "New migrations detected:"
+            echo "$CHANGED"
+          else
+            echo "found=false" >> $GITHUB_OUTPUT
+            echo "No new migrations, skipping."
+          fi
+
+      - name: Setup Node
+        if: steps.check.outputs.found == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install pnpm
+        if: steps.check.outputs.found == 'true'
+        uses: pnpm/action-setup@v4
+
+      - name: Install dependencies
+        if: steps.check.outputs.found == 'true'
+        run: pnpm install --frozen-lockfile
+
+      - name: Run migrations
+        if: steps.check.outputs.found == 'true'
+        run: pnpm --filter @repo/db db:deploy
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+
+      - name: Notify Discord on failure
+        if: failure()
+        uses: tsickert/discord-webhook@v5.3.0
+        with:
+          webhook-url: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          content: 'Migration failed on merge to main: ${{ github.event.head_commit.message }} | <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}>'


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/migrate.yml` that triggers on every push to `main`
- Detects whether any new migration files were added by diffing `HEAD~1` vs `HEAD` in `packages/db/prisma/migrations/`
- If migrations are found, runs `prisma migrate deploy` against prod DB using `DATABASE_URL` secret
- Skips all setup/install steps cleanly if no migrations are present
- Posts a Discord alert with a link to the failed run if the migration step errors

## Test plan
- [ ] Merge this PR — workflow should run, detect no migrations, and exit cleanly. Then merge a subsequent PR with a new migration file to confirm it applies to prod

## Notes
- Requires `DATABASE_URL` (prod Supabase direct connection, port 5432) to be added as a GitHub Actions secret
- Reuses existing `DISCORD_WEBHOOK_URL` secret for failure alerts

Closes #100