### PR TITLE
[#187] feat: optimise upsert commit

### DIFF
--- a/apps/worker/src/jobs/github.ts
+++ b/apps/worker/src/jobs/github.ts
@@ -32,7 +32,7 @@ export async function runGitHubIngestion(weekStart: Date, weekEnd: Date): Promis
         }
 
         try {
-          const commitCount = await ingestRepoCommits(repo, weekStart, weekEnd)
+          const commitCount = await ingestRepoCommits(repo)
           totalProcessed += commitCount
         } catch (err) {
           logger.error(`Failed to ingest commits for ${repo.owner}/${repo.name}: ${err}`)

--- a/apps/worker/src/lib/github-commit-tracker.integration.test.ts
+++ b/apps/worker/src/lib/github-commit-tracker.integration.test.ts
@@ -18,9 +18,6 @@ vi.mock('./github-utils', async (importOriginal) => {
   }
 })
 
-const weekStart = new Date('2026-05-04T00:00:00Z')
-const weekEnd = new Date('2026-05-10T23:59:59Z')
-
 function makeCommitData(overrides: Record<string, unknown> = {}) {
   return {
     sha: 'test-sha',
@@ -82,16 +79,19 @@ describe('github-commit-tracker (integration)', () => {
       const identity = await seedIdentity(789, 'dupuser')
       vi.mocked(resolveIdentity).mockResolvedValue(identity.id)
 
-      const { mockOctokit } = setupOctokit(
+      const { mockOctokit, mockRequest } = setupOctokit(
         [],
-        [
-          makeCommitData({ sha: 'duplicate-sha', author: { id: 789, login: 'dupuser' } }),
-          makeCommitData({ sha: 'duplicate-sha', author: { id: 789, login: 'dupuser' } }),
-        ]
+        [makeCommitData({ sha: 'duplicate-sha', author: { id: 789, login: 'dupuser' } })]
       )
 
       await upsertCommit(repo, mockOctokit as never, 'duplicate-sha', 'feature-1')
+      // second call finds the SHA in DB and returns early — no GitHub API call made
       await upsertCommit(repo, mockOctokit as never, 'duplicate-sha', 'feature-2')
+
+      const commitFetchCalls = mockRequest.mock.calls.filter(
+        (c: unknown[]) => c[0] === 'GET /repos/{owner}/{repo}/commits/{sha}'
+      )
+      expect(commitFetchCalls).toHaveLength(1)
 
       const committedData = await db.commitFact.findUnique({
         where: { repoId_sha: { repoId: repo.id, sha: 'duplicate-sha' } },
@@ -198,7 +198,7 @@ describe('github-commit-tracker (integration)', () => {
         ]
       )
 
-      await ingestRepoCommits(repo, weekStart, weekEnd)
+      await ingestRepoCommits(repo)
 
       expect(mockPaginate).toHaveBeenCalledTimes(2)
       const paginateCalls = mockPaginate.mock.calls
@@ -212,7 +212,7 @@ describe('github-commit-tracker (integration)', () => {
       expect(savedCommit!.message).toBe('Feature work')
     })
 
-    it('respects the weekStart/weekEnd window when filtering commits', async () => {
+    it('ingests all commits from compare endpoint regardless of author date', async () => {
       const repo = await seedRepo()
       const identity = await seedIdentity(333, 'newdev')
       vi.mocked(resolveIdentity).mockResolvedValue(identity.id)
@@ -221,14 +221,8 @@ describe('github-commit-tracker (integration)', () => {
         [
           [{ name: 'feature' }],
           [
-            {
-              sha: 'new-commit',
-              commit: { author: { date: '2026-05-07T10:00:00Z' } },
-            },
-            {
-              sha: 'old-commit',
-              commit: { author: { date: '2026-01-01T10:00:00Z' } },
-            },
+            { sha: 'new-commit', commit: { author: { date: '2026-05-07T10:00:00Z' } } },
+            { sha: 'old-commit', commit: { author: { date: '2026-01-01T10:00:00Z' } } },
           ],
         ],
         [
@@ -237,23 +231,28 @@ describe('github-commit-tracker (integration)', () => {
             author: { id: 333, login: 'newdev' },
             commit: { message: 'New commit', author: { date: '2026-05-07T10:00:00Z' } },
           }),
+          makeCommitData({
+            sha: 'old-commit',
+            author: { id: 333, login: 'newdev' },
+            commit: { message: 'Old commit', author: { date: '2026-01-01T10:00:00Z' } },
+          }),
         ]
       )
 
-      const totalCommits = await ingestRepoCommits(repo, weekStart, weekEnd)
+      const totalCommits = await ingestRepoCommits(repo)
 
-      expect(totalCommits).toBe(1)
+      expect(totalCommits).toBe(2)
 
-      const savedCommit = await db.commitFact.findUnique({
+      const savedNew = await db.commitFact.findUnique({
         where: { repoId_sha: { repoId: repo.id, sha: 'new-commit' } },
       })
-      expect(savedCommit).not.toBeNull()
-      expect(savedCommit!.authorIdentityId).toBe(identity.id)
+      expect(savedNew).not.toBeNull()
+      expect(savedNew!.authorIdentityId).toBe(identity.id)
 
-      const skippedCommit = await db.commitFact.findUnique({
+      const savedOld = await db.commitFact.findUnique({
         where: { repoId_sha: { repoId: repo.id, sha: 'old-commit' } },
       })
-      expect(skippedCommit).toBeNull()
+      expect(savedOld).not.toBeNull()
     })
 
     it('handles repos with no commits in the window', async () => {
@@ -264,7 +263,7 @@ describe('github-commit-tracker (integration)', () => {
         []
       )
 
-      const totalCommits = await ingestRepoCommits(repo, weekStart, weekEnd)
+      const totalCommits = await ingestRepoCommits(repo)
 
       expect(totalCommits).toBe(0)
       expect(mockPaginate).toHaveBeenCalledTimes(3)

--- a/apps/worker/src/lib/github-commit-tracker.test.ts
+++ b/apps/worker/src/lib/github-commit-tracker.test.ts
@@ -9,7 +9,10 @@ vi.mock('@repo/github', () => ({
 
 vi.mock('@repo/db', () => ({
   db: {
-    commitFact: { upsert: vi.fn() },
+    commitFact: {
+      findUnique: vi.fn().mockResolvedValue(null),
+      create: vi.fn(),
+    },
     personIdentity: { findUnique: vi.fn().mockResolvedValue(null) },
     unmatchedIdentity: { upsert: vi.fn() },
   },
@@ -23,9 +26,6 @@ vi.mock('./github-utils', async (importOriginal) => {
     resolveIdentity: vi.fn().mockResolvedValue(null),
   }
 })
-
-const weekStart = new Date('2026-05-04T00:00:00Z')
-const weekEnd = new Date('2026-05-10T23:59:59Z')
 
 const repo = {
   id: 'repo-id',
@@ -76,9 +76,9 @@ function mockOctokit({
 }
 
 function upsertCalls() {
-  return vi.mocked(db.commitFact.upsert).mock.calls.map((c) => {
-    const arg = c[0] as { create: { sha: string; branch: string | null } }
-    return { sha: arg.create.sha, branch: arg.create.branch }
+  return vi.mocked(db.commitFact.create).mock.calls.map((c) => {
+    const arg = c[0] as { data: { sha: string; branch: string | null } }
+    return { sha: arg.data.sha, branch: arg.data.branch }
   })
 }
 
@@ -98,7 +98,7 @@ describe('ingestRepoCommits (unit, no DB)', () => {
       },
     })
 
-    await ingestRepoCommits(repo, weekStart, weekEnd)
+    await ingestRepoCommits(repo)
 
     const routesCalled = paginate.mock.calls.map((c) => c[0])
     expect(routesCalled).toContain('GET /repos/{owner}/{repo}/compare/{basehead}')
@@ -122,7 +122,7 @@ describe('ingestRepoCommits (unit, no DB)', () => {
       },
     })
 
-    await ingestRepoCommits(repo, weekStart, weekEnd)
+    await ingestRepoCommits(repo)
 
     const shas = upsertCalls().map((c) => c.sha)
     expect(shas).toEqual(['feature-only-1', 'feature-only-2'])
@@ -143,7 +143,7 @@ describe('ingestRepoCommits (unit, no DB)', () => {
       },
     })
 
-    await ingestRepoCommits(repo, weekStart, weekEnd)
+    await ingestRepoCommits(repo)
 
     const compareBaseheads = paginate.mock.calls
       .filter((c) => c[0] === 'GET /repos/{owner}/{repo}/compare/{basehead}')
@@ -154,22 +154,26 @@ describe('ingestRepoCommits (unit, no DB)', () => {
     expect(upsertCalls().map((c) => c.branch)).toEqual(['main', 'feature'])
   })
 
-  it('filters compare results by author date to the [weekStart, weekEnd] window', async () => {
+  it('upserts all commits from the compare endpoint regardless of author date', async () => {
     mockOctokit({
       defaultBranch: 'main',
       branches: [{ name: 'main' }, { name: 'feature' }],
       compareByBasehead: {
         'main...feature': [
-          { sha: 'before-window', commit: { author: { date: '2026-04-01T10:00:00Z' } } },
-          { sha: 'in-window', commit: { author: { date: '2026-05-07T10:00:00Z' } } },
-          { sha: 'after-window', commit: { author: { date: '2026-06-01T10:00:00Z' } } },
+          { sha: 'old-commit', commit: { author: { date: '2026-04-01T10:00:00Z' } } },
+          { sha: 'current-commit', commit: { author: { date: '2026-05-07T10:00:00Z' } } },
+          { sha: 'future-commit', commit: { author: { date: '2026-06-01T10:00:00Z' } } },
         ],
       },
     })
 
-    const total = await ingestRepoCommits(repo, weekStart, weekEnd)
+    const total = await ingestRepoCommits(repo)
 
-    expect(total).toBe(1)
-    expect(upsertCalls()).toEqual([{ sha: 'in-window', branch: 'feature' }])
+    expect(total).toBe(3)
+    expect(upsertCalls()).toEqual([
+      { sha: 'old-commit', branch: 'feature' },
+      { sha: 'current-commit', branch: 'feature' },
+      { sha: 'future-commit', branch: 'feature' },
+    ])
   })
 })

--- a/apps/worker/src/lib/github-commit-tracker.ts
+++ b/apps/worker/src/lib/github-commit-tracker.ts
@@ -1,6 +1,6 @@
 // Finds the commits unique to each non-default branch in a repo and stores them in the database.
 
-import { db } from '@repo/db'
+import { db, Prisma } from '@repo/db'
 import { getInstallationOctokit } from '@repo/github'
 import { logger } from '../lib/logger'
 import { resolveIdentity, withRateLimit } from './github-utils'
@@ -10,17 +10,18 @@ type Octokit = Awaited<ReturnType<typeof getInstallationOctokit>>
 // Fetches full commit details (for stats and author) and inserts a CommitFact row.
 // Checks the DB first to skip the GitHub API call for already-known SHAs.
 // branch is set only on first insert and never overwritten.
+// Returns true if the commit was newly inserted, false if it already existed.
 export async function upsertCommit(
   repo: { id: string; owner: string; name: string },
   octokit: Octokit,
   sha: string,
   branch: string | null
-): Promise<void> {
+): Promise<boolean> {
   const existing = await db.commitFact.findUnique({
     where: { repoId_sha: { repoId: repo.id, sha } },
     select: { sha: true },
   })
-  if (existing) return
+  if (existing) return false
 
   const { data } = await withRateLimit(() =>
     octokit.request('GET /repos/{owner}/{repo}/commits/{sha}', {
@@ -35,19 +36,29 @@ export async function upsertCommit(
     repo
   )
 
-  await db.commitFact.create({
-    data: {
-      repoId: repo.id,
-      sha,
-      authorIdentityId,
-      message: data.commit.message,
-      branch,
-      linesAdded: data.stats?.additions || 0,
-      linesRemoved: data.stats?.deletions || 0,
-      committedAt: new Date(data.commit.author?.date || Date.now()),
-      ingestedAt: new Date(),
-    },
-  })
+  try {
+    await db.commitFact.create({
+      data: {
+        repoId: repo.id,
+        sha,
+        authorIdentityId,
+        message: data.commit.message,
+        branch,
+        linesAdded: data.stats?.additions || 0,
+        linesRemoved: data.stats?.deletions || 0,
+        committedAt: new Date(data.commit.author?.date || Date.now()),
+        ingestedAt: new Date(),
+      },
+    })
+    return true
+  } catch (err) {
+    // Two concurrent ingestions can both pass the findUnique check and race to insert
+    // the same SHA. Treat the unique constraint violation as a no-op.
+    if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === 'P2002') {
+      return false
+    }
+    throw err
+  }
 }
 
 export async function ingestRepoCommits(repo: {
@@ -109,10 +120,10 @@ export async function ingestRepoCommits(repo: {
       )
     }
 
-    totalCommits += commits.length
-
     for (const commit of commits) {
-      await upsertCommit(repo, octokit, commit.sha, branch.name)
+      if (await upsertCommit(repo, octokit, commit.sha, branch.name)) {
+        totalCommits++
+      }
     }
   }
 

--- a/apps/worker/src/lib/github-commit-tracker.ts
+++ b/apps/worker/src/lib/github-commit-tracker.ts
@@ -3,19 +3,25 @@
 import { db } from '@repo/db'
 import { getInstallationOctokit } from '@repo/github'
 import { logger } from '../lib/logger'
-import { resolveIdentity } from './github-utils'
-import { withRateLimit } from './github-utils'
+import { resolveIdentity, withRateLimit } from './github-utils'
 
 type Octokit = Awaited<ReturnType<typeof getInstallationOctokit>>
 
-// Fetches full commit details (for stats and author) and upserts a CommitFact row.
-// Dedup is handled by the (repoId, sha) unique constraint.
+// Fetches full commit details (for stats and author) and inserts a CommitFact row.
+// Checks the DB first to skip the GitHub API call for already-known SHAs.
+// branch is set only on first insert and never overwritten.
 export async function upsertCommit(
   repo: { id: string; owner: string; name: string },
   octokit: Octokit,
   sha: string,
   branch: string | null
 ): Promise<void> {
+  const existing = await db.commitFact.findUnique({
+    where: { repoId_sha: { repoId: repo.id, sha } },
+    select: { sha: true },
+  })
+  if (existing) return
+
   const { data } = await withRateLimit(() =>
     octokit.request('GET /repos/{owner}/{repo}/commits/{sha}', {
       owner: repo.owner,
@@ -29,10 +35,8 @@ export async function upsertCommit(
     repo
   )
 
-  await db.commitFact.upsert({
-    // compound key to avoid duplicate entries for the same commit
-    where: { repoId_sha: { repoId: repo.id, sha } },
-    create: {
+  await db.commitFact.create({
+    data: {
       repoId: repo.id,
       sha,
       authorIdentityId,
@@ -41,29 +45,17 @@ export async function upsertCommit(
       linesAdded: data.stats?.additions || 0,
       linesRemoved: data.stats?.deletions || 0,
       committedAt: new Date(data.commit.author?.date || Date.now()),
-      ingestedAt: new Date(Date.now()),
-    },
-    update: {
-      authorIdentityId,
-      message: data.commit.message,
-      linesAdded: data.stats?.additions || 0,
-      linesRemoved: data.stats?.deletions || 0,
-      committedAt: new Date(data.commit.author?.date || Date.now()),
-      ingestedAt: new Date(Date.now()),
+      ingestedAt: new Date(),
     },
   })
 }
 
-export async function ingestRepoCommits(
-  repo: {
-    id: string
-    owner: string
-    name: string
-    installationId: string
-  },
-  weekStart: Date,
-  weekEnd: Date
-): Promise<number> {
+export async function ingestRepoCommits(repo: {
+  id: string
+  owner: string
+  name: string
+  installationId: string
+}): Promise<number> {
   logger.info(`Fetching commits for ${repo.owner}/${repo.name}`)
 
   const octokit = await getInstallationOctokit(repo.installationId)
@@ -85,8 +77,6 @@ export async function ingestRepoCommits(
   )
 
   let totalCommits = 0
-  const weekStartMs = weekStart.getTime()
-  const weekEndMs = weekEnd.getTime()
 
   for (const branch of branches) {
     if (branch.name === defaultBranch) {
@@ -97,7 +87,7 @@ export async function ingestRepoCommits(
 
     // Compare endpoint returns commits reachable from head but NOT from base,
     // so commits inherited from the default branch (e.g. via merge or rebase) are excluded.
-    type CompareCommit = { sha: string; commit: { author?: { date?: string } | null } }
+    type CompareCommit = { sha: string }
     const basehead = `${defaultBranch}...${branch.name}`
     const commits = await withRateLimit<CompareCommit[]>(() =>
       octokit.paginate(
@@ -119,22 +109,15 @@ export async function ingestRepoCommits(
       )
     }
 
-    const inWindow = commits.filter((commit) => {
-      const dateStr = commit.commit?.author?.date
-      if (!dateStr) return false
-      const t = new Date(dateStr).getTime()
-      return t >= weekStartMs && t <= weekEndMs
-    })
+    totalCommits += commits.length
 
-    totalCommits += inWindow.length
-
-    for (const commit of inWindow) {
+    for (const commit of commits) {
       await upsertCommit(repo, octokit, commit.sha, branch.name)
     }
   }
 
   if (totalCommits === 0) {
-    logger.info(`No commits found for ${repo.owner}/${repo.name} in the past week.`)
+    logger.info(`No new commits found for ${repo.owner}/${repo.name}.`)
   }
 
   return totalCommits


### PR DESCRIPTION
## Description

Optimise upsert commit 
## Solution

upsert commit checks if the SHA already exists before making any GitHub API call

branch is only set when a commit is first created, never overwritten on subsequent upserts

Author date filter removed so all commits returned by the compare endpoint are upserted regardless of when they were authored

weekStart/weekEnd params removed from the function signature 

## Notes

<!-- Add any notes you think are needed -->
