### PR TITLE
[#188] feat: unify PR ingestion to cover all statuses over 2-week window

### DIFF
--- a/apps/worker/src/jobs/github.ts
+++ b/apps/worker/src/jobs/github.ts
@@ -1,8 +1,9 @@
 import { db } from '@repo/db'
 import { logger } from '../lib/logger'
 import { ingestRepoCommits } from '../lib/github-commit-tracker'
-import { ingestRepoMergedPRs } from '../lib/github-PR-tracker'
+import { ingestRepoPRs } from '../lib/github-PR-tracker'
 import { computeWeeklyGitHubMetrics } from '../lib/github-weekly-stats'
+import { getCollectionWindow } from '../lib/date-utils'
 
 export async function runGitHubIngestion(weekStart: Date, weekEnd: Date): Promise<void> {
   const projects = await db.project.findMany({
@@ -16,6 +17,12 @@ export async function runGitHubIngestion(weekStart: Date, weekEnd: Date): Promis
   const projectsWithRepos = projects.filter((p) => p.repositories.length > 0)
   let grandTotal = 0
 
+  // Previous week window — stats are recomputed for both weeks so late-arriving
+  // commits from the lookback period are reflected correctly.
+  const [prevWeekStart, prevWeekEnd] = getCollectionWindow(
+    new Date(weekEnd.getTime() - 7 * 24 * 60 * 60 * 1000)
+  )
+
   for (const project of projectsWithRepos) {
     const syncJob = await db.syncJob.create({
       data: { type: 'GITHUB', projectId: project.id, status: 'RUNNING', startedAt: new Date() },
@@ -25,7 +32,7 @@ export async function runGitHubIngestion(weekStart: Date, weekEnd: Date): Promis
     try {
       for (const repo of project.repositories) {
         try {
-          const PRcount = await ingestRepoMergedPRs(repo, weekStart, weekEnd)
+          const PRcount = await ingestRepoPRs(repo, weekStart, weekEnd)
           totalProcessed += PRcount
         } catch (err) {
           logger.error(`Failed to ingest PRs for ${repo.owner}/${repo.name}: ${err}`)
@@ -39,6 +46,7 @@ export async function runGitHubIngestion(weekStart: Date, weekEnd: Date): Promis
         }
       }
 
+      await computeWeeklyGitHubMetrics(project, prevWeekStart, prevWeekEnd)
       await computeWeeklyGitHubMetrics(project, weekStart, weekEnd)
 
       await db.syncJob.update({

--- a/apps/worker/src/lib/github-PR-tracker.integration.test.ts
+++ b/apps/worker/src/lib/github-PR-tracker.integration.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { db } from '@repo/db'
 import { getInstallationOctokit } from '@repo/github'
-import { ingestRepoMergedPRs } from './github-PR-tracker'
+import { ingestRepoPRs } from './github-PR-tracker'
+import { upsertCommit } from './github-commit-tracker'
 import { seedRepo, seedIdentity } from '../test-config/integration.helpers.js'
 
 vi.mock('@repo/github', () => ({
@@ -20,8 +21,10 @@ vi.mock('./github-commit-tracker', () => ({
   upsertCommit: vi.fn().mockResolvedValue(undefined),
 }))
 
+// current week: Mon 28 Apr – Sun 4 May 2026
 const weekStart = new Date('2026-04-28T00:00:00Z')
 const weekEnd = new Date('2026-05-04T23:59:59Z')
+// lookback start = Mon 21 Apr (Monday of the previous week)
 
 function makeFullPr(overrides: Record<string, unknown> = {}) {
   return {
@@ -31,7 +34,7 @@ function makeFullPr(overrides: Record<string, unknown> = {}) {
     html_url: 'https://github.com/org/project/pull/1',
     labels: [{ name: 'feature' }],
     created_at: '2026-04-29T10:00:00Z',
-    merged_at: '2026-04-30T10:00:00Z',
+    merged_at: '2026-04-30T10:00:00Z', // within weekStart..weekEnd by default
     closed_at: '2026-04-30T10:00:00Z',
     additions: 10,
     deletions: 5,
@@ -57,8 +60,9 @@ function setupOctokit(paginateResponses: unknown[][], requestResponses: unknown[
   return { mockPaginate, mockRequest }
 }
 
-describe('ingestRepoMergedPRs (integration)', () => {
+describe('ingestRepoPRs (integration)', () => {
   beforeEach(async () => {
+    vi.clearAllMocks()
     await db.pRFact.deleteMany()
     await db.unmatchedIdentity.deleteMany()
     await db.personIdentity.deleteMany()
@@ -67,21 +71,21 @@ describe('ingestRepoMergedPRs (integration)', () => {
     await db.project.deleteMany()
   })
 
-  it('returns 0 and writes nothing to the DB when no PRs are merged in window', async () => {
+  it('returns 0 and writes nothing when no PRs are found in the 2-week window', async () => {
     const repo = await seedRepo()
     setupOctokit([[]], [])
 
-    const count = await ingestRepoMergedPRs(repo, weekStart, weekEnd)
+    const count = await ingestRepoPRs(repo, weekStart, weekEnd)
 
     expect(count).toBe(0)
     expect(await db.pRFact.count()).toBe(0)
   })
 
-  it('writes the PR to the DB with correct fields', async () => {
+  it('writes PRFact for a PR merged within the current week', async () => {
     const repo = await seedRepo()
-    setupOctokit([[{ number: 1 }]], [makeFullPr()])
+    setupOctokit([[{ number: 1 }], []], [makeFullPr()])
 
-    await ingestRepoMergedPRs(repo, weekStart, weekEnd)
+    await ingestRepoPRs(repo, weekStart, weekEnd)
 
     const pr = await db.pRFact.findUnique({
       where: { repoId_number: { repoId: repo.id, number: 1 } },
@@ -94,12 +98,51 @@ describe('ingestRepoMergedPRs (integration)', () => {
     expect(pr!.repoId).toBe(repo.id)
   })
 
+  it('does not write PRFact for a PR merged before the current week but still captures commits', async () => {
+    const repo = await seedRepo()
+    // merged_at is within the lookback window but before weekStart
+    setupOctokit(
+      [[{ number: 1 }], [{ sha: 'old-commit' }]],
+      [makeFullPr({ merged_at: '2026-04-22T10:00:00Z', closed_at: '2026-04-22T10:00:00Z' })]
+    )
+
+    const count = await ingestRepoPRs(repo, weekStart, weekEnd)
+
+    expect(count).toBe(0)
+    expect(await db.pRFact.count()).toBe(0)
+    expect(vi.mocked(upsertCommit)).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      'old-commit',
+      'feature-branch'
+    )
+  })
+
+  it('does not write PRFact for an open or closed-unmerged PR but still captures commits', async () => {
+    const repo = await seedRepo()
+    setupOctokit(
+      [[{ number: 1 }], [{ sha: 'open-commit' }]],
+      [makeFullPr({ merged_at: null, closed_at: null })]
+    )
+
+    const count = await ingestRepoPRs(repo, weekStart, weekEnd)
+
+    expect(count).toBe(0)
+    expect(await db.pRFact.count()).toBe(0)
+    expect(vi.mocked(upsertCommit)).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      'open-commit',
+      'feature-branch'
+    )
+  })
+
   it('resolves a known author identity and saves it on the PR', async () => {
     const repo = await seedRepo()
     const identity = await seedIdentity(42, 'author')
-    setupOctokit([[{ number: 1 }]], [makeFullPr()])
+    setupOctokit([[{ number: 1 }], []], [makeFullPr()])
 
-    await ingestRepoMergedPRs(repo, weekStart, weekEnd)
+    await ingestRepoPRs(repo, weekStart, weekEnd)
 
     const pr = await db.pRFact.findUnique({
       where: { repoId_number: { repoId: repo.id, number: 1 } },
@@ -110,9 +153,9 @@ describe('ingestRepoMergedPRs (integration)', () => {
 
   it('creates an unmatchedIdentity when author is not in the DB', async () => {
     const repo = await seedRepo()
-    setupOctokit([[{ number: 1 }]], [makeFullPr()])
+    setupOctokit([[{ number: 1 }], []], [makeFullPr()])
 
-    await ingestRepoMergedPRs(repo, weekStart, weekEnd)
+    await ingestRepoPRs(repo, weekStart, weekEnd)
 
     const unmatched = await db.unmatchedIdentity.findUnique({
       where: { provider_externalId: { provider: 'GITHUB', externalId: '42' } },
@@ -129,9 +172,9 @@ describe('ingestRepoMergedPRs (integration)', () => {
 
   it('handles a PR with no author or mergedBy without throwing', async () => {
     const repo = await seedRepo()
-    setupOctokit([[{ number: 1 }]], [makeFullPr({ user: null, merged_by: null })])
+    setupOctokit([[{ number: 1 }], []], [makeFullPr({ user: null, merged_by: null })])
 
-    await expect(ingestRepoMergedPRs(repo, weekStart, weekEnd)).resolves.toBe(1)
+    await expect(ingestRepoPRs(repo, weekStart, weekEnd)).resolves.toBe(1)
 
     const pr = await db.pRFact.findUnique({
       where: { repoId_number: { repoId: repo.id, number: 1 } },
@@ -144,11 +187,11 @@ describe('ingestRepoMergedPRs (integration)', () => {
     const repo = await seedRepo()
     const identity = await seedIdentity(42, 'author')
 
-    setupOctokit([[{ number: 1 }]], [makeFullPr()])
-    await ingestRepoMergedPRs(repo, weekStart, weekEnd)
+    setupOctokit([[{ number: 1 }], []], [makeFullPr()])
+    await ingestRepoPRs(repo, weekStart, weekEnd)
 
-    setupOctokit([[{ number: 1 }]], [makeFullPr({ title: 'Updated Title' })])
-    await ingestRepoMergedPRs(repo, weekStart, weekEnd)
+    setupOctokit([[{ number: 1 }], []], [makeFullPr({ title: 'Updated Title' })])
+    await ingestRepoPRs(repo, weekStart, weekEnd)
 
     expect(await db.pRFact.count()).toBe(1)
 

--- a/apps/worker/src/lib/github-PR-tracker.ts
+++ b/apps/worker/src/lib/github-PR-tracker.ts
@@ -1,117 +1,130 @@
-// Fetches merged PRs for the week and stores them in the database.
+// Fetches PRs across all statuses for the past 2 weeks and stores data in the database.
 
 import { db } from '@repo/db'
 import { getInstallationOctokit } from '@repo/github'
 import { logger } from '../lib/logger'
-import { resolveIdentity } from './github-utils'
-import { withRateLimit } from './github-utils'
+import { resolveIdentity, withRateLimit } from './github-utils'
 import { upsertCommit } from './github-commit-tracker'
+import { getCollectionWindow } from './date-utils'
 
-export async function ingestRepoMergedPRs(
+// Searches all PRs (open, closed, merged) updated within a 2-week lookback window.
+// PRFact rows are written only for PRs merged within the current week.
+// Commits are captured for every PR regardless of status.
+export async function ingestRepoPRs(
   repo: { id: string; owner: string; name: string; installationId: string },
   weekStart: Date,
   weekEnd: Date
 ): Promise<number> {
-  logger.info(
-    `Fetching merged PRs for ${repo.owner}/${repo.name} from ${weekStart.toISOString()} to ${weekEnd.toISOString()}`
-  )
+  // Lookback start = Monday of the previous week
+  const [lookbackStart] = getCollectionWindow(new Date(weekEnd.getTime() - 7 * 24 * 60 * 60 * 1000))
+  const lookbackSince = lookbackStart.toISOString().slice(0, 10)
+  const until = weekEnd.toISOString().slice(0, 10)
+
+  logger.info(`Fetching all PRs for ${repo.owner}/${repo.name} from ${lookbackSince} to ${until}`)
 
   const octokit = await getInstallationOctokit(repo.installationId)
 
-  // GitHub's search API only accepts YYYY-MM-DD for the merged: qualifier.
-  const since = weekStart.toISOString().slice(0, 10)
-  const until = weekEnd.toISOString().slice(0, 10)
-  const mergedThisWeek = await withRateLimit(() =>
+  const allPRs = await withRateLimit(() =>
     octokit.paginate('GET /search/issues', {
-      q: `repo:${repo.owner}/${repo.name} is:pr is:merged merged:${since}..${until}`,
+      q: `repo:${repo.owner}/${repo.name} is:pr updated:${lookbackSince}..${until}`,
       per_page: 100,
     })
   )
 
-  if (mergedThisWeek.length === 0) {
-    logger.info(`No merged PRs found for ${repo.owner}/${repo.name} this week.`)
+  if (allPRs.length === 0) {
+    logger.info(`No PRs found for ${repo.owner}/${repo.name} in the past 2 weeks.`)
     return 0
   }
 
-  let count = 0
-  for (const pr of mergedThisWeek) {
-    // Fetch full PR details to get additions/deletions
-    const { data: fullPr } = await withRateLimit(() =>
-      octokit.request('GET /repos/{owner}/{repo}/pulls/{pull_number}', {
-        owner: repo.owner,
-        repo: repo.name,
-        pull_number: pr.number,
-      })
-    )
+  let prFactCount = 0
 
-    const [authorIdentityId, mergedByIdentityId] = await Promise.all([
-      fullPr.user ? resolveIdentity({ id: fullPr.user.id, login: fullPr.user.login }, repo) : null,
-      fullPr.merged_by
-        ? resolveIdentity({ id: fullPr.merged_by.id, login: fullPr.merged_by.login }, repo)
-        : null,
-    ])
-
-    await db.pRFact.upsert({
-      where: { repoId_number: { repoId: repo.id, number: fullPr.number } },
-      create: {
-        repoId: repo.id,
-        number: fullPr.number,
-        authorIdentityId,
-        mergedByIdentityId,
-        title: fullPr.title,
-        body: fullPr.body ?? null,
-        url: fullPr.html_url,
-        labels: fullPr.labels.map((l) => l.name),
-        createdAt: new Date(fullPr.created_at),
-        mergedAt: fullPr.merged_at ? new Date(fullPr.merged_at) : null,
-        closedAt: fullPr.closed_at ? new Date(fullPr.closed_at) : null,
-        linesAdded: fullPr.additions,
-        linesRemoved: fullPr.deletions,
-        ingestedAt: new Date(),
-      },
-      update: {
-        title: fullPr.title,
-        body: fullPr.body ?? null,
-        url: fullPr.html_url,
-        labels: fullPr.labels.map((l) => l.name),
-        authorIdentityId,
-        mergedByIdentityId,
-        mergedAt: fullPr.merged_at ? new Date(fullPr.merged_at) : null,
-        closedAt: fullPr.closed_at ? new Date(fullPr.closed_at) : null,
-        linesAdded: fullPr.additions,
-        linesRemoved: fullPr.deletions,
-        ingestedAt: new Date(),
-      },
-    })
-    count++
-
-    // Pull the PR's commits and upsert each.
+  for (const pr of allPRs) {
     try {
-      const prCommits = await withRateLimit(() =>
-        octokit.paginate('GET /repos/{owner}/{repo}/pulls/{pull_number}/commits', {
+      const { data: fullPr } = await withRateLimit(() =>
+        octokit.request('GET /repos/{owner}/{repo}/pulls/{pull_number}', {
           owner: repo.owner,
           repo: repo.name,
-          pull_number: fullPr.number,
-          per_page: 100,
+          pull_number: pr.number,
         })
       )
 
-      for (const commit of prCommits) {
-        try {
-          await upsertCommit(repo, octokit, commit.sha, fullPr.head.ref)
-        } catch (err) {
-          logger.error(
-            `Failed to upsert commit ${commit.sha} from PR #${fullPr.number} in ${repo.owner}/${repo.name}: ${err}`
-          )
+      // Write PRFact only for PRs merged within the current week
+      const mergedAt = fullPr.merged_at ? new Date(fullPr.merged_at) : null
+      if (mergedAt && mergedAt >= weekStart && mergedAt <= weekEnd) {
+        const [authorIdentityId, mergedByIdentityId] = await Promise.all([
+          fullPr.user
+            ? resolveIdentity({ id: fullPr.user.id, login: fullPr.user.login }, repo)
+            : null,
+          fullPr.merged_by
+            ? resolveIdentity({ id: fullPr.merged_by.id, login: fullPr.merged_by.login }, repo)
+            : null,
+        ])
+
+        await db.pRFact.upsert({
+          where: { repoId_number: { repoId: repo.id, number: fullPr.number } },
+          create: {
+            repoId: repo.id,
+            number: fullPr.number,
+            authorIdentityId,
+            mergedByIdentityId,
+            title: fullPr.title,
+            body: fullPr.body ?? null,
+            url: fullPr.html_url,
+            labels: fullPr.labels.map((l) => l.name),
+            createdAt: new Date(fullPr.created_at),
+            mergedAt,
+            closedAt: fullPr.closed_at ? new Date(fullPr.closed_at) : null,
+            linesAdded: fullPr.additions,
+            linesRemoved: fullPr.deletions,
+            ingestedAt: new Date(),
+          },
+          update: {
+            title: fullPr.title,
+            body: fullPr.body ?? null,
+            url: fullPr.html_url,
+            labels: fullPr.labels.map((l) => l.name),
+            authorIdentityId,
+            mergedByIdentityId,
+            mergedAt,
+            closedAt: fullPr.closed_at ? new Date(fullPr.closed_at) : null,
+            linesAdded: fullPr.additions,
+            linesRemoved: fullPr.deletions,
+            ingestedAt: new Date(),
+          },
+        })
+        prFactCount++
+      }
+
+      // Capture commits for all PRs regardless of status
+      try {
+        const prCommits = await withRateLimit(() =>
+          octokit.paginate('GET /repos/{owner}/{repo}/pulls/{pull_number}/commits', {
+            owner: repo.owner,
+            repo: repo.name,
+            pull_number: fullPr.number,
+            per_page: 100,
+          })
+        )
+
+        for (const commit of prCommits) {
+          try {
+            await upsertCommit(repo, octokit, commit.sha, fullPr.head.ref)
+          } catch (err) {
+            logger.error(
+              `Failed to upsert commit ${commit.sha} from PR #${fullPr.number} in ${repo.owner}/${repo.name}: ${err}`
+            )
+          }
         }
+      } catch (err) {
+        logger.error(
+          `Failed to ingest commits for PR #${fullPr.number} in ${repo.owner}/${repo.name}: ${err}`
+        )
       }
     } catch (err) {
-      logger.error(
-        `Failed to ingest commits for PR #${fullPr.number} in ${repo.owner}/${repo.name}: ${err}`
-      )
+      logger.error(`Failed to process PR #${pr.number} in ${repo.owner}/${repo.name}: ${err}`)
     }
   }
 
-  logger.info(`Saved ${count} merged PRs for ${repo.owner}/${repo.name}.`)
-  return count
+  logger.info(`Saved ${prFactCount} PRFacts for ${repo.owner}/${repo.name}.`)
+  return prFactCount
 }


### PR DESCRIPTION
## Description

unify PR ingestion to cover all statuses over 2-week window

## Solution

- PR ingestion now searches for all PRs (open, closed, merged) updated within the past 2 weeks, with the lookback start anchored to the Monday of the previous week
- Commits are captured for all PRs regardless of their merge status
- `PRFact` rows are only written for PRs merged within the current week; for unmerged PRs, only commit data is stored
- After ingestion, weekly stats are recomputed for both the current week and the previous week to catch any late-arriving commits
- `ingestClosedBranchCommits` is deleted as it is fully subsumed by this approach
## Notes

<!-- Add any notes you think are needed -->
