### PR TITLE
[#203] Fix/GitHub ingestion failure

### DIFF
--- a/apps/worker/src/index.test.ts
+++ b/apps/worker/src/index.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('./jobs/github', () => ({
+  runGitHubIngestion: vi.fn(),
+}))
+vi.mock('./jobs/discord', () => ({
+  runDiscordIngestion: vi.fn(),
+}))
+vi.mock('./lib/logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}))
+vi.mock('./lib/date-utils', () => ({
+  getCollectionWindow: vi.fn(() => [
+    new Date('2026-05-04T00:00:00Z'),
+    new Date('2026-05-10T23:59:59Z'),
+  ]),
+}))
+
+import { main } from './index'
+import { runGitHubIngestion } from './jobs/github'
+import { runDiscordIngestion } from './jobs/discord'
+import { logger } from './lib/logger'
+
+const SUCCESS_LOG = 'Weekly ingestion complete'
+
+describe('main', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(runDiscordIngestion).mockResolvedValue([])
+  })
+
+  it('logs the success completion message when both jobs succeed', async () => {
+    vi.mocked(runGitHubIngestion).mockResolvedValue(undefined)
+
+    await main()
+
+    expect(logger.info).toHaveBeenCalledWith(SUCCESS_LOG)
+  })
+
+  it('completion log reflects the failure when GitHub ingestion rejects', async () => {
+    vi.mocked(runGitHubIngestion).mockRejectedValue(new Error('boom'))
+
+    await main()
+
+    // The success completion log must not fire on a failed GitHub run...
+    expect(logger.info).not.toHaveBeenCalledWith(SUCCESS_LOG)
+    // ...and the completion log must clearly surface the failure.
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining('Weekly ingestion completed with errors')
+    )
+  })
+
+  it('still logs success when only Discord fails (completion signal is GitHub-specific)', async () => {
+    vi.mocked(runGitHubIngestion).mockResolvedValue(undefined)
+    vi.mocked(runDiscordIngestion).mockRejectedValue(new Error('discord down'))
+
+    await main()
+
+    expect(logger.info).toHaveBeenCalledWith(SUCCESS_LOG)
+    expect(logger.error).not.toHaveBeenCalledWith(
+      expect.stringContaining('Weekly ingestion completed with errors')
+    )
+  })
+})

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -19,15 +19,20 @@ import { getCollectionWindow } from './lib/date-utils'
 //      sentimentParagraph, and summaryText to WeeklySummary. Dependency enforced
 //      in code, not by wall-clock timing.
 
-async function main() {
+// Sentinel returned by the GitHub ingestion catch handler.
+export const GITHUB_INGESTION_FAILED = 'github-ingestion-failed' as const
+
+export async function main() {
   const [weekStart, weekEnd] = getCollectionWindow()
 
   logger.info(
     `Starting weekly ingestion jobs (GitHub + Discord in parallel) - week of ${weekStart.toISOString()}`
   )
-  const [, discordMessages] = await Promise.all([
+
+  const [githubResult, discordMessages] = await Promise.all([
     runGitHubIngestion(weekStart, weekEnd).catch((err: unknown) => {
       logger.error(`GitHub ingestion failed: ${err}`)
+      return GITHUB_INGESTION_FAILED
     }),
     runDiscordIngestion(weekStart, weekEnd).catch((err: unknown) => {
       logger.error(`Discord ingestion failed: ${err}`)
@@ -38,10 +43,17 @@ async function main() {
   // TODO: await runLlmAnalysis(discordMessages)
   void discordMessages // placeholder to avoid unused variable error until LLM analysis is implemented
 
-  logger.info('Weekly ingestion complete')
+  if (githubResult === GITHUB_INGESTION_FAILED) {
+    logger.error('Weekly ingestion completed with errors: GitHub ingestion failed')
+  } else {
+    logger.info('Weekly ingestion complete')
+  }
 }
 
-main().catch((err: unknown) => {
-  logger.error(`Fatal error in weekly job: ${err}`)
-  process.exit(1)
-})
+// Only bootstrap the job when run directly (e.g. `tsx src/index.ts`), not when imported by a test.
+if (typeof require !== 'undefined' && require.main === module) {
+  main().catch((err: unknown) => {
+    logger.error(`Fatal error in weekly job: ${err}`)
+    process.exit(1)
+  })
+}


### PR DESCRIPTION
## Description

Fix GitHub ingestion failure being masked by a false "Weekly ingestion complete" log

## Solution

- Completion log clearly reflects when GitHub ingestion failed

- GitHub catch returns a typed sentinel instead of implicit undefined

- Unit test added for main() with a mocked runGitHubIngestion rejection - asserts the completion log reflects the failure

