### PR TITLE
[#198] Display last updated time in viewer's local timezone on leaderboard

### DIFF
--- a/apps/web/src/components/headers/LastUpdatedTime.tsx
+++ b/apps/web/src/components/headers/LastUpdatedTime.tsx
@@ -1,0 +1,34 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+interface LastUpdatedTimeProps {
+  /** ISO 8601 timestamp (UTC) of the last successful sync. */
+  isoDate: string
+}
+
+const FORMAT: Intl.DateTimeFormatOptions = {
+  month: 'long',
+  day: 'numeric',
+  hour: '2-digit',
+  minute: '2-digit',
+}
+
+const format = (isoDate: string): string => new Date(isoDate).toLocaleString(undefined, FORMAT)
+
+const LastUpdatedTime: React.FC<LastUpdatedTimeProps> = ({
+  isoDate,
+}: LastUpdatedTimeProps): React.JSX.Element => {
+  // The server renders this in UTC; re-format after mount so it uses the
+  // viewer's browser timezone. suppressHydrationWarning avoids a noisy
+  // mismatch warning for the expected UTC -> local difference.
+  const [formatted, setFormatted] = useState(() => format(isoDate))
+
+  useEffect(() => {
+    setFormatted(format(isoDate))
+  }, [isoDate])
+
+  return <span suppressHydrationWarning>{formatted}</span>
+}
+
+export default LastUpdatedTime

--- a/apps/web/src/components/headers/LeaderboardHeader.tsx
+++ b/apps/web/src/components/headers/LeaderboardHeader.tsx
@@ -1,3 +1,5 @@
+import LastUpdatedTime from './LastUpdatedTime'
+
 interface LeaderboardHeaderProps {
   lastUpdated: Date
 }
@@ -26,13 +28,7 @@ const LeaderboardHeader: React.FC<LeaderboardHeaderProps> = ({
           <rect width="12" height="12" rx="5.90908" fill="#16A34A" />
         </svg>
         <span className="text-wdcc-grey text-xs sm:text-sm lg:text-xl font-medium whitespace-nowrap">
-          Last updated on{' '}
-          {lastUpdated.toLocaleString(undefined, {
-            month: 'long',
-            day: 'numeric',
-            hour: '2-digit',
-            minute: '2-digit',
-          })}
+          Last updated on <LastUpdatedTime isoDate={lastUpdated.toISOString()} />
         </span>
       </div>
     </div>


### PR DESCRIPTION
## Summary

Fixes the leaderboard "Last updated" timestamp showing UTC instead of the viewer's local timezone.

The leaderboard page is a server component, so the previous `toLocaleString(undefined, ...)` call resolved "local" to the **server's** timezone (UTC in prod) rather than the user's browser.

## Changes

- Add `LastUpdatedTime` client component (`'use client'`) that formats the timestamp in the browser, so it uses the viewer's timezone.
- `LeaderboardHeader` now passes the timestamp as an ISO string to `LastUpdatedTime` instead of formatting it inline server-side.
- A post-mount `useEffect` re-formats client-side; `suppressHydrationWarning` silences the expected UTC→local hydration difference.

## Acceptance criteria

- [x] Last updated timestamp is converted to the user's local timezone before display
- [x] No timezone is hardcoded — derived from the user's browser via `toLocaleString(undefined, ...)`
- [x] Format remains consistent with the current display (same `month`/`day`/`hour`/`minute` options)

Closes #198