### PR TITLE
[#197] Feat/leadeboard colours

### DIFF
--- a/apps/web/src/components/ui/LeaderboardRow.tsx
+++ b/apps/web/src/components/ui/LeaderboardRow.tsx
@@ -14,10 +14,10 @@ export default function LeaderboardRow({ entry, theme }: LeaderboardRowProps) {
   const isFirstPlace = rank === 1
 
   const bgBase = isFirstPlace ? fillColor : lightFillColor
-  const textColor = isFirstPlace ? '#FFFFFF' : '#000000'
   const border = isFirstPlace
     ? `2px solid ${borderColor ?? fillColor}`
     : `2px solid ${lightBorderColor}`
+  const textClass = isFirstPlace ? 'text-white' : 'text-black'
 
   return (
     <Link
@@ -35,9 +35,9 @@ export default function LeaderboardRow({ entry, theme }: LeaderboardRowProps) {
       <span
         className={cn(
           'font-mono text-2xl min-w-[28px] text-center',
-          isFirstPlace ? 'font-bold' : 'font-medium'
+          isFirstPlace ? 'font-bold' : 'font-medium',
+          textClass
         )}
-        style={{ color: textColor }}
       >
         {rank}
       </span>
@@ -54,11 +54,11 @@ export default function LeaderboardRow({ entry, theme }: LeaderboardRowProps) {
         )}
       </div>
 
-      <span className="font-sans text-2xl flex-1 truncate font-bold" style={{ color: textColor }}>
+      <span className={cn('font-sans text-2xl flex-1 truncate font-bold', textClass)}>
         {projectName}
       </span>
 
-      <span className="font-mono text-xl font-medium shrink-0" style={{ color: textColor }}>
+      <span className={cn('font-mono text-xl font-medium shrink-0', textClass)}>
         {formatStat(statValue)}
       </span>
     </Link>

--- a/apps/web/src/components/ui/LeaderboardRow.tsx
+++ b/apps/web/src/components/ui/LeaderboardRow.tsx
@@ -3,8 +3,6 @@ import { formatStat, LeaderboardEntry, LeaderboardRowTheme } from '@/lib/project
 import Image from 'next/image'
 import Link from 'next/link'
 
-const NEUTRAL = { bg: '#D9D9D9', text: '#4E4E4D' }
-
 interface LeaderboardRowProps {
   entry: LeaderboardEntry
   theme: LeaderboardRowTheme
@@ -12,12 +10,14 @@ interface LeaderboardRowProps {
 
 export default function LeaderboardRow({ entry, theme }: LeaderboardRowProps) {
   const { rank, projectSlug, projectName, thumbnailUrl, statValue } = entry
-  const { fillColor, borderColor } = theme
+  const { fillColor, borderColor, lightFillColor, lightBorderColor } = theme
   const isFirstPlace = rank === 1
 
-  const bgBase = isFirstPlace ? fillColor : NEUTRAL.bg
-  const textColor = isFirstPlace ? '#1F2031' : NEUTRAL.text
-  const border = isFirstPlace && borderColor ? `2px solid ${borderColor}` : '2px solid transparent'
+  const bgBase = isFirstPlace ? fillColor : lightFillColor
+  const textColor = isFirstPlace ? '#FFFFFF' : '#000000'
+  const border = isFirstPlace
+    ? `2px solid ${borderColor ?? fillColor}`
+    : `2px solid ${lightBorderColor}`
 
   return (
     <Link
@@ -54,13 +54,7 @@ export default function LeaderboardRow({ entry, theme }: LeaderboardRowProps) {
         )}
       </div>
 
-      <span
-        className={cn(
-          'font-sans text-2xl flex-1 truncate',
-          isFirstPlace ? 'font-bold' : 'font-medium'
-        )}
-        style={{ color: textColor }}
-      >
+      <span className="font-sans text-2xl flex-1 truncate font-bold" style={{ color: textColor }}>
         {projectName}
       </span>
 

--- a/apps/web/src/lib/project/leaderboard.ts
+++ b/apps/web/src/lib/project/leaderboard.ts
@@ -2,17 +2,12 @@ import resolveConfig from 'tailwindcss/resolveConfig'
 import tailwindConfig from '../../../tailwind.config'
 
 const fullConfig = resolveConfig(tailwindConfig)
-const wdcc = (
+type LeaderboardColumn = { fill: string; stroke: string; lightFill: string; lightStroke: string }
+const lb = (
   fullConfig.theme.colors as unknown as {
-    wdcc: {
-      purple: string
-      peach: string
-      blue: { light: string; DEFAULT: string }
-      amber: string
-      kelvin: string
-    }
+    leaderboard: { loc: LeaderboardColumn; commits: LeaderboardColumn; prs: LeaderboardColumn }
   }
-).wdcc
+).leaderboard
 
 export const formatStat = (value: number | string): string => {
   if (typeof value === 'string') return value
@@ -21,18 +16,34 @@ export const formatStat = (value: number | string): string => {
   return value.toString()
 }
 
-// Colour theme applied to a leaderboard section. fillColor is the rank-1 highlight
-// background; borderColor is the accent border shown only on the first-place row.
+// Colour theme applied to a leaderboard section. fillColor/borderColor are the rank-1
+// highlight; lightFillColor/lightBorderColor are used for ranks 2–5.
 export interface LeaderboardRowTheme {
   fillColor: string
   borderColor?: string
+  lightFillColor: string
+  lightBorderColor: string
 }
 
-// One theme per leaderboard category — colours sourced from tailwind.config.ts.
 export const LEADERBOARD_THEMES = {
-  pink: { fillColor: wdcc.purple, borderColor: wdcc.kelvin },
-  blue: { fillColor: wdcc.blue.light, borderColor: wdcc.blue.DEFAULT },
-  orange: { fillColor: wdcc.peach, borderColor: wdcc.amber },
+  pink: {
+    fillColor: lb.loc.fill,
+    borderColor: lb.loc.stroke,
+    lightFillColor: lb.loc.lightFill,
+    lightBorderColor: lb.loc.lightStroke,
+  },
+  blue: {
+    fillColor: lb.commits.fill,
+    borderColor: lb.commits.stroke,
+    lightFillColor: lb.commits.lightFill,
+    lightBorderColor: lb.commits.lightStroke,
+  },
+  orange: {
+    fillColor: lb.prs.fill,
+    borderColor: lb.prs.stroke,
+    lightFillColor: lb.prs.lightFill,
+    lightBorderColor: lb.prs.lightStroke,
+  },
 } satisfies Record<string, LeaderboardRowTheme>
 
 // Shape returned by every leaderboard query — maps directly onto LeaderboardRowData.

--- a/apps/web/tailwind.config.ts
+++ b/apps/web/tailwind.config.ts
@@ -48,6 +48,26 @@ const config: Config = {
           },
           oshan: '#1F2031', // black
         },
+        leaderboard: {
+          loc: {
+            fill: '#E333A3',
+            stroke: '#9F196E',
+            lightFill: '#EBC9DF',
+            lightStroke: '#EBA7D3',
+          },
+          commits: {
+            fill: '#077CF1',
+            stroke: '#1861AB',
+            lightFill: '#99C8F7',
+            lightStroke: '#61A3E5',
+          },
+          prs: {
+            fill: '#F4900C',
+            stroke: '#BA730C',
+            lightFill: '#FFD9A7',
+            lightStroke: '#FFBE69',
+          },
+        },
       },
     },
   },


### PR DESCRIPTION
## Description
Add themed colours for rank 1 and ranks 2-5 on leaderboard following the design on figma


## Solution

Added the colours to tailwind config & used them for leaderboard
<img width="1548" height="314" alt="image" src="https://github.com/user-attachments/assets/3992832d-6551-410e-b26a-ab51de4264e6" />
## Notes

