### PR TITLE
[#211] Create mobile view for leaderboard page

### DIFF
--- a/apps/web/src/components/ui/DesktopLeaderboardSections.tsx
+++ b/apps/web/src/components/ui/DesktopLeaderboardSections.tsx
@@ -1,0 +1,53 @@
+import LeaderboardRow from '@/components/ui/LeaderboardRow'
+import { WeeklyLeaderboard } from '@/lib/project/leaderboard'
+import ClientSuspense from '../utils/ClientSuspense'
+
+interface DesktopLeaderboardSectionsProps {
+  data: WeeklyLeaderboard | null
+  loading: boolean
+}
+
+export default function DesktopLeaderboardSections({
+  data,
+  loading,
+}: DesktopLeaderboardSectionsProps) {
+  return (
+    <div className="flex justify-between px-5 sm:px-10 lg:px-20 gap-[21px] my-20 w-full">
+      <section className="flex flex-col gap-3 w-[415px]">
+        <h2 className="flex items-center gap-3 text-lg font-semibold">
+          <span className="w-[4.9px] h-5 rounded-full bg-wdcc-kelvin" />
+          Lines of Code Changed
+        </h2>
+        <ClientSuspense loading={loading} fallback={<p>Loading...</p>}>
+          {data?.linesOfCode.map(({ entry, theme }) => (
+            <LeaderboardRow key={entry.projectId} entry={entry} theme={theme} />
+          ))}
+        </ClientSuspense>
+      </section>
+
+      <section className="flex flex-col gap-3 w-[415px]">
+        <h2 className="flex items-center gap-3 text-lg font-semibold">
+          <span className="w-[4.9px] h-5 rounded-full bg-wdcc-blue" />
+          Commits Made
+        </h2>
+        <ClientSuspense loading={loading} fallback={<p>Loading...</p>}>
+          {data?.commits.map(({ entry, theme }) => (
+            <LeaderboardRow key={entry.projectId} entry={entry} theme={theme} />
+          ))}
+        </ClientSuspense>
+      </section>
+
+      <section className="flex flex-col gap-3 w-[415px]">
+        <h2 className="flex items-center gap-3 text-lg font-semibold">
+          <span className="w-[4.9px] h-5 rounded-full bg-wdcc-amber" />
+          Pull Requests Merged
+        </h2>
+        <ClientSuspense loading={loading} fallback={<p>Loading...</p>}>
+          {data?.merges.map(({ entry, theme }) => (
+            <LeaderboardRow key={entry.projectId} entry={entry} theme={theme} />
+          ))}
+        </ClientSuspense>
+      </section>
+    </div>
+  )
+}

--- a/apps/web/src/components/ui/LeaderboardRow.tsx
+++ b/apps/web/src/components/ui/LeaderboardRow.tsx
@@ -31,7 +31,7 @@ export default function LeaderboardRow({ entry, theme }: LeaderboardRowProps) {
     >
       <span
         className={cn(
-          'font-mono text-2xl min-w-[28px] text-center',
+          'font-mono lg:text-2xl texl-lg min-w-[28px] text-center',
           isFirstPlace ? 'font-bold' : 'font-medium',
           textClass
         )}
@@ -51,11 +51,16 @@ export default function LeaderboardRow({ entry, theme }: LeaderboardRowProps) {
         )}
       </div>
 
-      <span className={cn('font-sans text-2xl flex-1 truncate font-bold', textClass)}>
+      <span
+        className={cn(
+          'lg:font-sans font-mono lg:text-2xl text-base flex-1 truncate lg:font-bold',
+          textClass
+        )}
+      >
         {projectName}
       </span>
 
-      <span className={cn('font-mono text-xl font-medium shrink-0', textClass)}>
+      <span className={cn('font-mono lg:text-xl text-sm font-medium shrink-0', textClass)}>
         {formatStat(statValue)}
       </span>
     </Link>

--- a/apps/web/src/components/ui/LeaderboardRow.tsx
+++ b/apps/web/src/components/ui/LeaderboardRow.tsx
@@ -31,7 +31,7 @@ export default function LeaderboardRow({ entry, theme }: LeaderboardRowProps) {
     >
       <span
         className={cn(
-          'font-mono lg:text-2xl texl-lg min-w-[28px] text-center',
+          'font-mono lg:text-2xl min-w-[28px] text-center',
           isFirstPlace ? 'font-bold' : 'font-medium',
           textClass
         )}

--- a/apps/web/src/components/ui/LeaderboardRow.tsx
+++ b/apps/web/src/components/ui/LeaderboardRow.tsx
@@ -22,11 +22,8 @@ export default function LeaderboardRow({ entry, theme }: LeaderboardRowProps) {
   return (
     <Link
       href={projectSlug ? `/project/${projectSlug}` : '/'}
-      className="flex flex-row items-center gap-4 px-5 w-full transition-[background-color] duration-150 ease hover:opacity-80"
+      className="flex min-h-16 w-full items-center gap-3 rounded-2xl px-3 py-3 transition-opacity duration-150 hover:opacity-80 lg:min-h-20 lg:gap-4 lg:rounded-3xl lg:px-5"
       style={{
-        maxWidth: '415px',
-        height: '84px',
-        borderRadius: '24.52px',
         backgroundColor: bgBase,
         border,
         cursor: 'pointer',
@@ -42,7 +39,7 @@ export default function LeaderboardRow({ entry, theme }: LeaderboardRowProps) {
         {rank}
       </span>
 
-      <div className="w-12 h-12 rounded-xl overflow-hidden shrink-0 bg-[#CFE8FC] flex items-center justify-center">
+      <div className="flex size-8 shrink-0 items-center justify-center overflow-hidden rounded-lg bg-[#CFE8FC] lg:size-12">
         {thumbnailUrl && (
           <Image
             src={thumbnailUrl}

--- a/apps/web/src/components/ui/LeaderboardSections.tsx
+++ b/apps/web/src/components/ui/LeaderboardSections.tsx
@@ -1,9 +1,9 @@
 'use client'
 
 import { useEffect, useState } from 'react'
-import LeaderboardRow from '@/components/ui/LeaderboardRow'
+import DesktopLeaderboardSections from '@/components/ui/DesktopLeaderboardSections'
+import MobileLeaderboardSections from '@/components/ui/MobileLeaderboardSections'
 import { fetchWeeklyLeaderboard, WeeklyLeaderboard } from '@/lib/project/leaderboard'
-import ClientSuspense from '../utils/ClientSuspense'
 
 export default function LeaderboardSections() {
   const [data, setData] = useState<WeeklyLeaderboard | null>(null)
@@ -16,42 +16,13 @@ export default function LeaderboardSections() {
   }, [])
 
   return (
-    <div className="flex justify-between px-5 sm:px-10 lg:px-20 gap-[21px] my-20 w-full">
-      <section className="flex flex-col gap-3 w-[415px]">
-        <h2 className="flex items-center gap-3 text-lg font-semibold">
-          <span className="w-[4.9px] h-5 rounded-full bg-wdcc-kelvin" />
-          Lines of Code Changed
-        </h2>
-        <ClientSuspense loading={loading} fallback={<p>Loading...</p>}>
-          {data?.linesOfCode.map(({ entry, theme }) => (
-            <LeaderboardRow key={entry.projectId} entry={entry} theme={theme} />
-          ))}
-        </ClientSuspense>
-      </section>
-
-      <section className="flex flex-col gap-3 w-[415px]">
-        <h2 className="flex items-center gap-3 text-lg font-semibold">
-          <span className="w-[4.9px] h-5 rounded-full bg-wdcc-blue" />
-          Commits Made
-        </h2>
-        <ClientSuspense loading={loading} fallback={<p>Loading...</p>}>
-          {data?.commits.map(({ entry, theme }) => (
-            <LeaderboardRow key={entry.projectId} entry={entry} theme={theme} />
-          ))}
-        </ClientSuspense>
-      </section>
-
-      <section className="flex flex-col gap-3 w-[415px]">
-        <h2 className="flex items-center gap-3 text-lg font-semibold">
-          <span className="w-[4.9px] h-5 rounded-full bg-wdcc-amber" />
-          Pull Requests Merged
-        </h2>
-        <ClientSuspense loading={loading} fallback={<p>Loading...</p>}>
-          {data?.merges.map(({ entry, theme }) => (
-            <LeaderboardRow key={entry.projectId} entry={entry} theme={theme} />
-          ))}
-        </ClientSuspense>
-      </section>
-    </div>
+    <>
+      <div className="lg:hidden">
+        <MobileLeaderboardSections data={data} loading={loading} />
+      </div>
+      <div className="hidden lg:block">
+        <DesktopLeaderboardSections data={data} loading={loading} />
+      </div>
+    </>
   )
 }

--- a/apps/web/src/components/ui/MobileLeaderboardSections.tsx
+++ b/apps/web/src/components/ui/MobileLeaderboardSections.tsx
@@ -53,7 +53,7 @@ export default function MobileLeaderboardSections({
             <button
               key={id}
               onClick={() => setActiveTab(id)}
-              className={`flex-1 rounded-lg py-2 font-mono text-xs font-medium transition-colors duration-200 ${
+              className={`flex-1 rounded-lg py-2 font-mono text-xs transition-colors duration-200 ${
                 activeTab === id ? `bg-white ${tabActiveClassName} shadow-sm` : 'text-gray-500'
               }`}
             >

--- a/apps/web/src/components/ui/MobileLeaderboardSections.tsx
+++ b/apps/web/src/components/ui/MobileLeaderboardSections.tsx
@@ -1,0 +1,81 @@
+'use client'
+
+import { useState } from 'react'
+import LeaderboardRow from '@/components/ui/LeaderboardRow'
+import { WeeklyLeaderboard } from '@/lib/project/leaderboard'
+import ClientSuspense from '../utils/ClientSuspense'
+
+interface MobileLeaderboardSectionsProps {
+  data: WeeklyLeaderboard | null
+  loading: boolean
+}
+
+const LEADERBOARD_SECTIONS = [
+  {
+    id: 'linesOfCode',
+    tabLabel: 'Lines',
+    heading: 'Lines of Code Changed',
+    accentClassName: 'bg-wdcc-kelvin',
+    tabActiveClassName: 'text-wdcc-kelvin',
+  },
+  {
+    id: 'commits',
+    tabLabel: 'Commits',
+    heading: 'Commits Made',
+    accentClassName: 'bg-wdcc-blue',
+    tabActiveClassName: 'text-wdcc-blue',
+  },
+  {
+    id: 'merges',
+    tabLabel: 'PRs',
+    heading: 'Pull Requests Merged',
+    accentClassName: 'bg-wdcc-amber',
+    tabActiveClassName: 'text-wdcc-amber',
+  },
+] as const
+
+type LeaderboardSectionId = (typeof LEADERBOARD_SECTIONS)[number]['id']
+
+export default function MobileLeaderboardSections({
+  data,
+  loading,
+}: MobileLeaderboardSectionsProps) {
+  const [activeTab, setActiveTab] = useState<LeaderboardSectionId>('linesOfCode')
+  const activeSection = LEADERBOARD_SECTIONS.find((section) => section.id === activeTab)
+
+  if (!activeSection) return null
+
+  return (
+    <>
+      <div className="px-5 sm:px-10 mt-4 mb-4">
+        <div className="flex gap-1 rounded-xl bg-gray-100 p-1">
+          {LEADERBOARD_SECTIONS.map(({ id, tabLabel, tabActiveClassName }) => (
+            <button
+              key={id}
+              onClick={() => setActiveTab(id)}
+              className={`flex-1 rounded-lg py-2 font-mono text-xs font-medium transition-colors duration-200 ${
+                activeTab === id ? `bg-white ${tabActiveClassName} shadow-sm` : 'text-gray-500'
+              }`}
+            >
+              {tabLabel}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="px-5 sm:px-10 mb-20">
+        <section className="flex flex-col gap-3">
+          <h2 className="flex items-center gap-3 text-base font-semibold">
+            <span className={`h-5 w-1 rounded-full ${activeSection.accentClassName}`} />
+            {activeSection.heading}
+          </h2>
+          <ClientSuspense loading={loading} fallback={<p>Loading...</p>}>
+            {data?.[activeSection.id].map(({ entry, theme }) => (
+              <LeaderboardRow key={entry.projectId} entry={entry} theme={theme} />
+            ))}
+          </ClientSuspense>
+        </section>
+      </div>
+    </>
+  )
+}

--- a/apps/web/src/components/ui/MobileLeaderboardSections.tsx
+++ b/apps/web/src/components/ui/MobileLeaderboardSections.tsx
@@ -34,27 +34,25 @@ const LEADERBOARD_SECTIONS = [
   },
 ] as const
 
-type LeaderboardSectionId = (typeof LEADERBOARD_SECTIONS)[number]['id']
-
 export default function MobileLeaderboardSections({
   data,
   loading,
 }: MobileLeaderboardSectionsProps) {
-  const [activeTab, setActiveTab] = useState<LeaderboardSectionId>('linesOfCode')
-  const activeSection = LEADERBOARD_SECTIONS.find((section) => section.id === activeTab)
-
-  if (!activeSection) return null
+  const [activeSectionIndex, setActiveSectionIndex] = useState(0)
+  const activeSection = LEADERBOARD_SECTIONS[activeSectionIndex]
 
   return (
     <>
       <div className="px-5 sm:px-10 mt-4 mb-4">
         <div className="flex gap-1 rounded-xl bg-gray-100 p-1">
-          {LEADERBOARD_SECTIONS.map(({ id, tabLabel, tabActiveClassName }) => (
+          {LEADERBOARD_SECTIONS.map(({ id, tabLabel, tabActiveClassName }, index) => (
             <button
               key={id}
-              onClick={() => setActiveTab(id)}
+              onClick={() => setActiveSectionIndex(index)}
               className={`flex-1 rounded-lg py-2 font-mono text-xs transition-colors duration-200 ${
-                activeTab === id ? `bg-white ${tabActiveClassName} shadow-sm` : 'text-gray-500'
+                activeSectionIndex === index
+                  ? `bg-white ${tabActiveClassName} shadow-sm`
+                  : 'text-gray-500'
               }`}
             >
               {tabLabel}


### PR DESCRIPTION
## Description

- Made the mobile view for the Leaderboard page

## Solution

- Only displays one leaderboard category at a time
- Leaderboard category can be changed via tab selector
- Active tab is clearly indicated
- No change to desktop

## Notes

<img width="432" height="934" alt="image" src="https://github.com/user-attachments/assets/50481173-048e-4d03-bbb2-7d44672c8a43" />
<img width="433" height="281" alt="image" src="https://github.com/user-attachments/assets/5e8ca19e-2fb2-4cce-a63b-a42dfec20fb9" />
<img width="436" height="275" alt="image" src="https://github.com/user-attachments/assets/06aaee52-fb71-4f84-9756-a7a7bafa4b5b" />

