### PR TITLE
[#196] Health Equation Input

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -19,6 +19,7 @@
     "@supabase/supabase-js": "^2.46.2",
     "clsx": "^2.1.1",
     "lucide-react": "^1.7.0",
+    "mathjs": "^15.2.0",
     "next": "^15.1.0",
     "octokit": "^5.0.5",
     "papaparse": "5.5.3",

--- a/apps/web/src/app/(admin)/admin-dashboard/page.tsx
+++ b/apps/web/src/app/(admin)/admin-dashboard/page.tsx
@@ -1,10 +1,6 @@
 /**
  * Admin dashboard — only should be accessible to administrators.
  * Currently should allow administrators to create projects and view their current projects.
- *
- * TODO: Implement the design
- * Make it so that it is only accessible to the admin who owns the projects once authentication is implemented.
- * Add functionality to delete projects and edit projects.
  */
 
 'use client'
@@ -16,6 +12,7 @@ import Link from 'next/link'
 import Image from 'next/image'
 import ClientSuspense from '@/components/utils/ClientSuspense'
 import { BORDER_DEFAULT, BORDER_HOVER } from '@/lib/admin/layout'
+import FormulaInput from '@/components/dashboard/FormulaInput'
 
 const fetchProjects = async (): Promise<Project[]> => {
   try {
@@ -220,6 +217,8 @@ export default function AdminDashboardPage() {
           ))}
         </ClientSuspense>
       </ul>
+
+      <FormulaInput />
     </>
   )
 }

--- a/apps/web/src/app/api/formula/route.ts
+++ b/apps/web/src/app/api/formula/route.ts
@@ -1,0 +1,15 @@
+import { hasRole } from '@/lib/auth'
+// import { db } from "@repo/db"
+
+export async function PUT(/* request: Request */) {
+  if (!(await hasRole('ADMIN'))) {
+    return Response.json({ error: 'Unauthorized. Admin access required.' }, { status: 403 })
+  }
+
+  try {
+    return Response.json({ status: 200 })
+  } catch (error) {
+    console.error('Error fetching people:', error)
+    return Response.json({ error: 'Failed' }, { status: 500 })
+  }
+}

--- a/apps/web/src/app/api/formula/route.ts
+++ b/apps/web/src/app/api/formula/route.ts
@@ -1,15 +1,53 @@
-import { hasRole } from '@/lib/auth'
-// import { db } from "@repo/db"
+import { NextResponse } from 'next/server'
+import { db } from '@repo/db'
+import { z } from 'zod'
+import { formulaSchema } from '@/lib/schemas/admin'
 
-export async function PUT(/* request: Request */) {
-  if (!(await hasRole('ADMIN'))) {
-    return Response.json({ error: 'Unauthorized. Admin access required.' }, { status: 403 })
-  }
+const FORMULA_KEY = 'healthFormula'
+const GLOBAL_SCOPE = 'GLOBAL'
 
+export async function GET() {
+  const config = await db.config.findUnique({
+    where: { scope_key: { scope: GLOBAL_SCOPE, key: FORMULA_KEY } },
+  })
+
+  return NextResponse.json({
+    formula: config ? (config.value as string) : null,
+  })
+}
+
+export async function PUT(request: Request) {
+  let body: unknown
   try {
-    return Response.json({ status: 200 })
-  } catch (error) {
-    console.error('Error fetching people:', error)
-    return Response.json({ error: 'Failed' }, { status: 500 })
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ message: 'Invalid JSON body' }, { status: 400 })
   }
+
+  const parsed = z.object({ formula: z.string() }).safeParse(body)
+  if (!parsed.success) {
+    return NextResponse.json({ message: 'Missing formula field' }, { status: 400 })
+  }
+
+  const validated = formulaSchema.safeParse(parsed.data.formula)
+  if (!validated.success) {
+    return NextResponse.json({ message: validated.error.issues[0].message }, { status: 422 })
+  }
+
+  const config = await db.config.upsert({
+    where: {
+      scope_key: { scope: GLOBAL_SCOPE, key: FORMULA_KEY },
+    },
+    update: {
+      value: validated.data,
+    },
+    create: {
+      scope: GLOBAL_SCOPE,
+      projectId: null,
+      key: FORMULA_KEY,
+      value: validated.data,
+    },
+  })
+
+  return NextResponse.json({ formula: config.value as string })
 }

--- a/apps/web/src/app/api/formula/route.ts
+++ b/apps/web/src/app/api/formula/route.ts
@@ -17,7 +17,7 @@ export async function GET() {
   })
 
   return NextResponse.json({
-    formula: config ? (config.value as string) : null,
+    formula: config?.value?.toString() ?? null,
   })
 }
 

--- a/apps/web/src/app/api/formula/route.ts
+++ b/apps/web/src/app/api/formula/route.ts
@@ -1,12 +1,17 @@
 import { NextResponse } from 'next/server'
-import { db } from '@repo/db'
+import { db, Role } from '@repo/db'
 import { z } from 'zod'
 import { formulaSchema } from '@/lib/schemas/admin'
+import { hasRole } from '@/lib/auth'
 
 const FORMULA_KEY = 'healthFormula'
 const GLOBAL_SCOPE = 'GLOBAL'
 
 export async function GET() {
+  if (!(await hasRole(Role.ADMIN))) {
+    return Response.json({ error: 'Unauthorized. Admin access required.' }, { status: 403 })
+  }
+
   const config = await db.config.findUnique({
     where: { scope_key: { scope: GLOBAL_SCOPE, key: FORMULA_KEY } },
   })
@@ -17,6 +22,10 @@ export async function GET() {
 }
 
 export async function PUT(request: Request) {
+  if (!(await hasRole(Role.ADMIN))) {
+    return Response.json({ error: 'Unauthorized. Admin access required.' }, { status: 403 })
+  }
+
   let body: unknown
   try {
     body = await request.json()

--- a/apps/web/src/components/dashboard/FormulaInput.tsx
+++ b/apps/web/src/components/dashboard/FormulaInput.tsx
@@ -1,113 +1,17 @@
 'use client'
 
 import { useState, useRef, useEffect, useCallback } from 'react'
-import { create, all } from 'mathjs'
-import { z } from 'zod'
+import { FORMULA_VARIABLES, getSampleScope, math } from '@/lib/admin/formula'
+import { formulaSchema } from '@/lib/schemas/admin'
 
-// ---------------------------------------------------------------------------
-// mathjs instance
-// ---------------------------------------------------------------------------
-const math = create(all)
+// #region Helper functions
 
-// ---------------------------------------------------------------------------
-// Variables
-// ---------------------------------------------------------------------------
-export const FORMULA_VARIABLES = [
-  {
-    key: 'prs',
-    label: 'Pull Requests',
-    description: 'Total open/merged PRs this week',
-    color: '#077CF1',
-    bg: 'rgba(7,124,241,0.10)',
-  },
-  {
-    key: 'lines_changed',
-    label: 'Lines Changed',
-    description: 'Lines added + removed across all commits',
-    color: '#E333A3',
-    bg: 'rgba(227,51,163,0.10)',
-  },
-  {
-    key: 'discord_messages',
-    label: 'Discord Messages',
-    description: 'Messages sent in linked channels',
-    color: '#5B8AF0',
-    bg: 'rgba(91,138,240,0.10)',
-  },
-  {
-    key: 'commits',
-    label: 'Commits',
-    description: 'Commits pushed this week',
-    color: '#0FAAA0',
-    bg: 'rgba(15,170,160,0.10)',
-  },
-] as const
-
-export type FormulaVariable = (typeof FORMULA_VARIABLES)[number]['key']
-
-// ---------------------------------------------------------------------------
-// Placeholder sample values (replace with real data fetching)
-// ---------------------------------------------------------------------------
-const getSampleScope = (): Record<FormulaVariable, number> => ({
-  prs: 4, // TODO: fetch from GitHub API for this project
-  lines_changed: 320, // TODO: fetch from GitHub commit stats
-  discord_messages: 47, // TODO: fetch from Discord channel stats
-  commits: 12, // TODO: fetch from GitHub commit count
-})
-
-// ---------------------------------------------------------------------------
-// Zod schema
-// ---------------------------------------------------------------------------
-const VALID_VARIABLE_KEYS = FORMULA_VARIABLES.map((v) => v.key)
-
-const getUnknownIdentifiers = (val: string): string[] => {
-  const identifiers = val.match(/[a-zA-Z_][a-zA-Z0-9_]*/g) ?? []
-  const mathBuiltins = Object.keys(math)
-  return identifiers.filter(
-    (id) => !VALID_VARIABLE_KEYS.includes(id as FormulaVariable) && !mathBuiltins.includes(id)
-  )
-}
-
-const formulaSchema = z
-  .string()
-  .min(1, 'Formula cannot be empty')
-  .superRefine((val, ctx) => {
-    const unknown = getUnknownIdentifiers(val)
-    if (unknown.length > 0) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: `Unknown variable${unknown.length > 1 ? 's' : ''}: ${unknown.join(', ')}`,
-      })
-    }
-  })
-  .refine(
-    (val) => {
-      try {
-        const scope = getSampleScope()
-        math.compile(val).evaluate(scope)
-        return true
-      } catch {
-        return false
-      }
-    },
-    { message: 'Formula has a syntax error' }
-  )
-  .refine(
-    (val) => {
-      try {
-        const scope = getSampleScope()
-        const result = math.compile(val).evaluate(scope)
-        return typeof result === 'number' && isFinite(result)
-      } catch {
-        return false
-      }
-    },
-    { message: 'Formula must evaluate to a finite number' }
-  )
-
-// ---------------------------------------------------------------------------
-// Suggestion matching
-// ---------------------------------------------------------------------------
+/**
+ * Extracts all identifiers from the formula and returns those that are not in the list of valid variables or math built-ins.
+ * @param {string} val The formula string to analyse
+ * @param {string[]} mathBuiltins List of built-in function names from mathjs to exclude from unknown identifiers
+ * @returns {string[]} An array of unknown identifier names found in the formula
+ */
 function getActiveSuggestions(
   value: string,
   cursor: number
@@ -127,9 +31,12 @@ function getActiveSuggestions(
   return { suggestions, wordStart, word }
 }
 
-// ---------------------------------------------------------------------------
-// Preview evaluation
-// ---------------------------------------------------------------------------
+/**
+ * Evaluates the formula with sample variable values to provide a live preview.
+ * Returns either the computed result or an error message if evaluation fails.
+ * @param {string} formula The formula string to evaluate
+ * @returns {{ result: number | null; error: string | null }} An object containing either the numeric result or an error message
+ */
 function evaluatePreview(formula: string): { result: number | null; error: string | null } {
   if (!formula.trim()) return { result: null, error: null }
   try {
@@ -144,12 +51,13 @@ function evaluatePreview(formula: string): { result: number | null; error: strin
   }
 }
 
-// ---------------------------------------------------------------------------
-// Highlighted formula display
-// ---------------------------------------------------------------------------
+/**
+ * Simple syntax highlighter for the formula input. Wraps known variables, numbers, and operators
+ * @param {string} formula The raw formula string to highlight
+ * @returns {string} HTML string with syntax highlighting applied
+ */
 function highlightFormula(formula: string): string {
-  // Tokenise the plain-text formula first, then wrap each token in a coloured
-  // span — avoids regex running over already-injected HTML tag characters.
+  // Tokenise the plain-text formula first, then wrap each token in a coloured span - avoids regex running over already-injected HTML tag characters.
   const escape = (s: string) => s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
 
   const varKeys = FORMULA_VARIABLES.map((v) => v.key)
@@ -158,7 +66,7 @@ function highlightFormula(formula: string): string {
   )
 
   // Build tokeniser: known vars | numbers | operators | identifiers | whitespace | single-char fallback
-  // IMPORTANT: fallback must NOT be \S+ — it greedily eats "sqrt(discord_messages)" as one token.
+  // IMPORTANT: fallback must NOT be \S+ as it greedily eats "sqrt(discord_messages)" as one token.
   // Instead use an identifier pattern so "sqrt" tokenises separately from the "(" that follows it.
   const tokenRe = new RegExp(
     [
@@ -186,23 +94,19 @@ function highlightFormula(formula: string): string {
         return `<span style="color:#6b7280">${tok}</span>`
       }
       if (/^\s+$/.test(tok)) return tok
-      // Unknown identifier — show dimly so it's visible but clearly wrong
+      // Unknown identifier - show dimly so it's visible but clearly wrong
       return `<span style="color:#6b7280">${escape(tok)}</span>`
     })
     .join('')
 }
 
-// ---------------------------------------------------------------------------
-// Props
-// ---------------------------------------------------------------------------
+// # endregion
+
 export interface FormulaInputProps {
   initialFormula?: string | null
   onSaveSuccess?: (formula: string) => void
 }
 
-// ---------------------------------------------------------------------------
-// Component
-// ---------------------------------------------------------------------------
 export default function FormulaInput({ initialFormula = '', onSaveSuccess }: FormulaInputProps) {
   const [formula, setFormula] = useState(initialFormula ?? '')
   const [error, setError] = useState<string | null>(null)
@@ -313,15 +217,7 @@ export default function FormulaInput({ initialFormula = '', onSaveSuccess }: For
 
     setSaving(true)
     try {
-      // Upserts Config row: scope = "GLOBAL", key = "healthFormula", value = formula string.
-      // Uses Prisma upsert server-side so concurrent writes always converge on latest value.
-      // The API route should do:
-      //   await prisma.config.upsert({
-      //     where:  { scope_key: { scope: 'GLOBAL', key: 'healthFormula' } },
-      //     update: { value: formula },
-      //     create: { scope: 'GLOBAL', projectId: null, key: 'healthFormula', value: formula },
-      //   })
-      const res = await fetch('/api/config/health-formula', {
+      const res = await fetch('/api/admin/formula', {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ formula }),
@@ -345,7 +241,7 @@ export default function FormulaInput({ initialFormula = '', onSaveSuccess }: For
 
   return (
     <div className="font-mono flex flex-col gap-6 w-full mx-auto px-5 sm:px-10 lg:px-20 py-10">
-      {/* ── Header ── */}
+      {/* Header */}
       <div>
         <h2 className="text-[#077CF1] font-extrabold text-sm uppercase tracking-widest m-0">
           Health Formula
@@ -354,10 +250,14 @@ export default function FormulaInput({ initialFormula = '', onSaveSuccess }: For
           Define the global health formula applied to all projects. Use the variables below with
           standard math operators (+, -, *, /, ^, sqrt, log, …). Click on any variable below for a
           quick insert into the formula. Auto-completion for variables is also provided.
+          <br />
+          <br />
+          <strong>NOTE:</strong> Two or more variables in succession without an operator between
+          them will be treated as multiplied (e.g. prs discord_messages = prs * discord_messages).
         </p>
       </div>
 
-      {/* ── Variable reference chips ── */}
+      {/* Variable reference chips */}
       <div className="flex flex-wrap gap-2">
         {FORMULA_VARIABLES.map((v) => (
           <button
@@ -385,9 +285,9 @@ export default function FormulaInput({ initialFormula = '', onSaveSuccess }: For
         ))}
       </div>
 
-      {/* ── Input area ── */}
+      {/* Input area */}
       <div className="relative">
-        {/* Gradient border wrapper — inline style required for dynamic gradient */}
+        {/* Gradient border wrapper */}
         <div
           className="rounded-2xl p-0.5 transition-all duration-300"
           style={{
@@ -429,7 +329,7 @@ export default function FormulaInput({ initialFormula = '', onSaveSuccess }: For
           </div>
         </div>
 
-        {/* ── Autocomplete dropdown ── */}
+        {/* Autocomplete dropdown */}
         {suggestions.length > 0 && (
           <div
             ref={suggBoxRef}
@@ -459,7 +359,7 @@ export default function FormulaInput({ initialFormula = '', onSaveSuccess }: For
         )}
       </div>
 
-      {/* ── Validation error ── */}
+      {/* Validation error */}
       {error && (
         <div
           className="flex items-center gap-2 px-3.5 py-2.5 rounded-xl
@@ -473,7 +373,7 @@ export default function FormulaInput({ initialFormula = '', onSaveSuccess }: For
         </div>
       )}
 
-      {/* ── Live preview ── */}
+      {/* Live preview */}
       {formula.trim() && (
         <div
           className="flex items-center justify-between px-4 py-3 rounded-xl border transition-all duration-200"
@@ -500,7 +400,7 @@ export default function FormulaInput({ initialFormula = '', onSaveSuccess }: For
         </div>
       )}
 
-      {/* ── Save button ── */}
+      {/* Save button */}
       <div className="flex items-center gap-3">
         <button
           onClick={handleSave}

--- a/apps/web/src/components/dashboard/FormulaInput.tsx
+++ b/apps/web/src/components/dashboard/FormulaInput.tsx
@@ -1,0 +1,564 @@
+'use client'
+
+import { useState, useRef, useEffect, useCallback } from 'react'
+import { create, all } from 'mathjs'
+import { z } from 'zod'
+
+// ---------------------------------------------------------------------------
+// mathjs instance
+// ---------------------------------------------------------------------------
+const math = create(all)
+
+// ---------------------------------------------------------------------------
+// Variables
+// ---------------------------------------------------------------------------
+export const FORMULA_VARIABLES = [
+  {
+    key: 'prs',
+    label: 'Pull Requests',
+    description: 'Total open/merged PRs this week',
+    color: '#077CF1',
+    bg: 'rgba(7,124,241,0.10)',
+  },
+  {
+    key: 'lines_changed',
+    label: 'Lines Changed',
+    description: 'Lines added + removed across all commits',
+    color: '#E333A3',
+    bg: 'rgba(227,51,163,0.10)',
+  },
+  {
+    key: 'discord_messages',
+    label: 'Discord Messages',
+    description: 'Messages sent in linked channels',
+    color: '#5B8AF0',
+    bg: 'rgba(91,138,240,0.10)',
+  },
+  {
+    key: 'commits',
+    label: 'Commits',
+    description: 'Commits pushed this week',
+    color: '#0FAAA0',
+    bg: 'rgba(15,170,160,0.10)',
+  },
+] as const
+
+export type FormulaVariable = (typeof FORMULA_VARIABLES)[number]['key']
+
+// ---------------------------------------------------------------------------
+// Placeholder sample values (replace with real data fetching)
+// ---------------------------------------------------------------------------
+const getSampleScope = (): Record<FormulaVariable, number> => ({
+  prs: 4, // TODO: fetch from GitHub API for this project
+  lines_changed: 320, // TODO: fetch from GitHub commit stats
+  discord_messages: 47, // TODO: fetch from Discord channel stats
+  commits: 12, // TODO: fetch from GitHub commit count
+})
+
+// ---------------------------------------------------------------------------
+// Zod schema
+// ---------------------------------------------------------------------------
+const VALID_VARIABLE_KEYS = FORMULA_VARIABLES.map((v) => v.key)
+
+const getUnknownIdentifiers = (val: string): string[] => {
+  const identifiers = val.match(/[a-zA-Z_][a-zA-Z0-9_]*/g) ?? []
+  const mathBuiltins = Object.keys(math)
+  return identifiers.filter(
+    (id) => !VALID_VARIABLE_KEYS.includes(id as FormulaVariable) && !mathBuiltins.includes(id)
+  )
+}
+
+const formulaSchema = z
+  .string()
+  .min(1, 'Formula cannot be empty')
+  .superRefine((val, ctx) => {
+    const unknown = getUnknownIdentifiers(val)
+    if (unknown.length > 0) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `Unknown variable${unknown.length > 1 ? 's' : ''}: ${unknown.join(', ')}`,
+      })
+    }
+  })
+  .refine(
+    (val) => {
+      try {
+        const scope = getSampleScope()
+        math.compile(val).evaluate(scope)
+        return true
+      } catch {
+        return false
+      }
+    },
+    { message: 'Formula has a syntax error' }
+  )
+  .refine(
+    (val) => {
+      try {
+        const scope = getSampleScope()
+        const result = math.compile(val).evaluate(scope)
+        return typeof result === 'number' && isFinite(result)
+      } catch {
+        return false
+      }
+    },
+    { message: 'Formula must evaluate to a finite number' }
+  )
+
+// ---------------------------------------------------------------------------
+// Suggestion matching
+// ---------------------------------------------------------------------------
+function getActiveSuggestions(
+  value: string,
+  cursor: number
+): {
+  suggestions: (typeof FORMULA_VARIABLES)[number][]
+  wordStart: number
+  word: string
+} {
+  const before = value.slice(0, cursor)
+  const match = before.match(/[a-zA-Z_][a-zA-Z0-9_]*$/)
+  if (!match) return { suggestions: [], wordStart: cursor, word: '' }
+
+  const word = match[0].toLowerCase()
+  const wordStart = cursor - word.length
+  const suggestions = FORMULA_VARIABLES.filter((v) => v.key.startsWith(word) && v.key !== word)
+
+  return { suggestions, wordStart, word }
+}
+
+// ---------------------------------------------------------------------------
+// Preview evaluation
+// ---------------------------------------------------------------------------
+function evaluatePreview(formula: string): { result: number | null; error: string | null } {
+  if (!formula.trim()) return { result: null, error: null }
+  try {
+    const scope = getSampleScope()
+    const result = math.compile(formula).evaluate(scope)
+    if (typeof result !== 'number' || !isFinite(result)) {
+      return { result: null, error: 'Result is not a finite number' }
+    }
+    return { result, error: null }
+  } catch (e) {
+    return { result: null, error: String(e) }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Highlighted formula display
+// ---------------------------------------------------------------------------
+function highlightFormula(formula: string): string {
+  // Tokenise the plain-text formula first, then wrap each token in a coloured
+  // span — avoids regex running over already-injected HTML tag characters.
+  const escape = (s: string) => s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+
+  const varKeys = FORMULA_VARIABLES.map((v) => v.key)
+  const varColorMap: Record<string, string> = Object.fromEntries(
+    FORMULA_VARIABLES.map((v) => [v.key, v.color])
+  )
+
+  // Build tokeniser: known vars | numbers | operators | identifiers | whitespace | single-char fallback
+  // IMPORTANT: fallback must NOT be \S+ — it greedily eats "sqrt(discord_messages)" as one token.
+  // Instead use an identifier pattern so "sqrt" tokenises separately from the "(" that follows it.
+  const tokenRe = new RegExp(
+    [
+      ...varKeys,
+      String.raw`\d+(?:\.\d+)?`,
+      String.raw`[+\-*/%^(),]`,
+      String.raw`[a-zA-Z_][a-zA-Z0-9_]*`,
+      String.raw`\s+`,
+      String.raw`[\s\S]`,
+    ].join('|'),
+    'g'
+  )
+
+  const tokens = formula.match(tokenRe) ?? (formula ? [formula] : [])
+
+  return tokens
+    .map((tok) => {
+      if (varColorMap[tok]) {
+        return `<span style="color:${varColorMap[tok]};font-weight:600">${escape(tok)}</span>`
+      }
+      if (/^\d+(?:\.\d+)?$/.test(tok)) {
+        return `<span style="color:#0FAAA0">${tok}</span>`
+      }
+      if (/^[+\-*/%^()]+$/.test(tok)) {
+        return `<span style="color:#6b7280">${tok}</span>`
+      }
+      if (/^\s+$/.test(tok)) return tok
+      // Unknown identifier — show dimly so it's visible but clearly wrong
+      return `<span style="color:#6b7280">${escape(tok)}</span>`
+    })
+    .join('')
+}
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+export interface FormulaInputProps {
+  initialFormula?: string | null
+  onSaveSuccess?: (formula: string) => void
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+export default function FormulaInput({ initialFormula = '', onSaveSuccess }: FormulaInputProps) {
+  const [formula, setFormula] = useState(initialFormula ?? '')
+  const [error, setError] = useState<string | null>(null)
+  const [saving, setSaving] = useState(false)
+  const [saved, setSaved] = useState(false)
+  const [suggestions, setSuggestions] = useState<(typeof FORMULA_VARIABLES)[number][]>([])
+  const [activeSuggIdx, setActiveSuggIdx] = useState(0)
+  const [suggWordStart, setSuggWordStart] = useState(0)
+
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+  const overlayRef = useRef<HTMLDivElement>(null)
+  const suggBoxRef = useRef<HTMLDivElement>(null)
+
+  const preview = evaluatePreview(formula)
+
+  // Sync overlay scroll with textarea scroll
+  const syncScroll = useCallback(() => {
+    if (overlayRef.current && textareaRef.current) {
+      overlayRef.current.scrollTop = textareaRef.current.scrollTop
+      overlayRef.current.scrollLeft = textareaRef.current.scrollLeft
+    }
+  }, [])
+
+  // Validate on change
+  useEffect(() => {
+    if (!formula.trim()) {
+      setError(null)
+      return
+    }
+    const result = formulaSchema.safeParse(formula)
+    setError(result.success ? null : result.error.issues[0].message)
+  }, [formula])
+
+  // Handle input change
+  const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const val = e.target.value
+    setFormula(val)
+    setSaved(false)
+
+    const cursor = e.target.selectionStart ?? val.length
+    const { suggestions: sugg, wordStart } = getActiveSuggestions(val, cursor)
+    setSuggestions(sugg)
+    setSuggWordStart(wordStart)
+    setActiveSuggIdx(0)
+  }
+
+  // Apply a suggestion
+  const applySuggestion = (varKey: string) => {
+    const cursor = textareaRef.current?.selectionStart ?? formula.length
+    const word = formula.slice(suggWordStart, cursor)
+    const before = formula.slice(0, suggWordStart)
+    const after = formula.slice(suggWordStart + word.length)
+    const newFormula = before + varKey + after
+    setFormula(newFormula)
+    setSuggestions([])
+
+    // Place cursor after inserted variable
+    setTimeout(() => {
+      const pos = suggWordStart + varKey.length
+      textareaRef.current?.setSelectionRange(pos, pos)
+      textareaRef.current?.focus()
+    }, 0)
+  }
+
+  // Keyboard handling
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (suggestions.length === 0) return
+
+    if (e.key === 'ArrowDown') {
+      e.preventDefault()
+      setActiveSuggIdx((i) => (i + 1) % suggestions.length)
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault()
+      setActiveSuggIdx((i) => (i - 1 + suggestions.length) % suggestions.length)
+    } else if (e.key === 'Enter' || e.key === 'Tab') {
+      e.preventDefault()
+      applySuggestion(suggestions[activeSuggIdx].key)
+    } else if (e.key === 'Escape') {
+      setSuggestions([])
+    }
+  }
+
+  // Insert variable chip from the reference panel
+  const insertVariable = (varKey: string) => {
+    const ta = textareaRef.current
+    const cursor = ta?.selectionStart ?? formula.length
+    const before = formula.slice(0, cursor)
+    const after = formula.slice(cursor)
+    const separator = before.length > 0 && !/[\s(]$/.test(before) ? ' ' : ''
+    const newFormula = before + separator + varKey + after
+    setFormula(newFormula)
+    setSaved(false)
+
+    setTimeout(() => {
+      const pos = cursor + separator.length + varKey.length
+      ta?.setSelectionRange(pos, pos)
+      ta?.focus()
+    }, 0)
+  }
+
+  // Save handler
+  const handleSave = async () => {
+    const result = formulaSchema.safeParse(formula)
+    if (!result.success) {
+      setError(result.error.issues[0].message)
+      return
+    }
+
+    setSaving(true)
+    try {
+      // Upserts Config row: scope = "GLOBAL", key = "healthFormula", value = formula string.
+      // Uses Prisma upsert server-side so concurrent writes always converge on latest value.
+      // The API route should do:
+      //   await prisma.config.upsert({
+      //     where:  { scope_key: { scope: 'GLOBAL', key: 'healthFormula' } },
+      //     update: { value: formula },
+      //     create: { scope: 'GLOBAL', projectId: null, key: 'healthFormula', value: formula },
+      //   })
+      const res = await fetch('/api/config/health-formula', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ formula }),
+      })
+
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}))
+        throw new Error(body?.message ?? 'Failed to save formula')
+      }
+
+      setSaved(true)
+      onSaveSuccess?.(formula)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to save')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const isValid = !error && formula.trim().length > 0
+
+  return (
+    <div className="font-mono flex flex-col gap-6 w-full mx-auto px-5 sm:px-10 lg:px-20 py-10">
+      {/* ── Header ── */}
+      <div>
+        <h2 className="text-[#077CF1] font-extrabold text-sm uppercase tracking-widest m-0">
+          Health Formula
+        </h2>
+        <p className="text-gray-500 text-xs mt-1.5 leading-relaxed">
+          Define the global health formula applied to all projects. Use the variables below with
+          standard math operators (+, -, *, /, ^, sqrt, log, …). Click on any variable below for a
+          quick insert into the formula. Auto-completion for variables is also provided.
+        </p>
+      </div>
+
+      {/* ── Variable reference chips ── */}
+      <div className="flex flex-wrap gap-2">
+        {FORMULA_VARIABLES.map((v) => (
+          <button
+            key={v.key}
+            onClick={() => insertVariable(v.key)}
+            title={v.description}
+            className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-lg border cursor-pointer
+                       outline-none transition-all duration-150 hover:-translate-y-px"
+            style={{
+              borderColor: `${v.color}33`,
+              background: v.bg,
+            }}
+            onMouseEnter={(e) => {
+              ;(e.currentTarget as HTMLButtonElement).style.borderColor = v.color
+            }}
+            onMouseLeave={(e) => {
+              ;(e.currentTarget as HTMLButtonElement).style.borderColor = `${v.color}33`
+            }}
+          >
+            <span className="w-1.5 h-1.5 rounded-full shrink-0" style={{ background: v.color }} />
+            <span className="text-[0.72rem] font-semibold tracking-wide" style={{ color: v.color }}>
+              {v.key}
+            </span>
+          </button>
+        ))}
+      </div>
+
+      {/* ── Input area ── */}
+      <div className="relative">
+        {/* Gradient border wrapper — inline style required for dynamic gradient */}
+        <div
+          className="rounded-2xl p-0.5 transition-all duration-300"
+          style={{
+            background: error
+              ? 'linear-gradient(135deg, #E333A3 0%, #ff6b6b 100%)'
+              : isValid
+                ? 'linear-gradient(135deg, #077CF1 0%, #0FAAA0 100%)'
+                : 'linear-gradient(135deg, #2a2a3e 0%, #3a3a5e 100%)',
+          }}
+        >
+          <div className="rounded-[14px] bg-[#0d0f1a] relative overflow-hidden">
+            {/* Syntax highlight overlay */}
+            <div
+              ref={overlayRef}
+              aria-hidden="true"
+              className="absolute inset-0 px-4 py-3.5 font-mono text-[0.88rem] leading-[1.7]
+                         whitespace-pre-wrap break-words pointer-events-none overflow-hidden
+                         select-none"
+              dangerouslySetInnerHTML={{ __html: highlightFormula(formula) }}
+            />
+
+            {/* Actual textarea */}
+            <textarea
+              ref={textareaRef}
+              value={formula}
+              onChange={handleChange}
+              onKeyDown={handleKeyDown}
+              onScroll={syncScroll}
+              placeholder="e.g.  prs * 2 + commits + discord_messages / 10"
+              rows={3}
+              spellCheck={false}
+              autoCorrect="off"
+              autoCapitalize="off"
+              className="block w-full px-4 py-3.5 font-mono text-[0.88rem] leading-[1.7]
+                         bg-transparent border-none outline-none resize-y
+                         relative z-10 text-transparent placeholder:text-[#3a3f5c]"
+              style={{ caretColor: '#077CF1' }}
+            />
+          </div>
+        </div>
+
+        {/* ── Autocomplete dropdown ── */}
+        {suggestions.length > 0 && (
+          <div
+            ref={suggBoxRef}
+            className="absolute top-[calc(100%+6px)] left-0 z-50 bg-[#12141f]
+                       border border-[#077CF133] rounded-xl overflow-hidden min-w-[220px]
+                       shadow-[0_8px_24px_rgba(0,0,0,0.4)]"
+          >
+            {suggestions.map((v, i) => (
+              <div
+                key={v.key}
+                onClick={() => applySuggestion(v.key)}
+                onMouseEnter={() => setActiveSuggIdx(i)}
+                className="flex items-center gap-2.5 px-3.5 py-2 cursor-pointer transition-colors duration-100"
+                style={{
+                  background: i === activeSuggIdx ? '#077CF115' : 'transparent',
+                  borderLeft:
+                    i === activeSuggIdx ? `3px solid ${v.color}` : '3px solid transparent',
+                }}
+              >
+                <span className="font-bold text-[0.8rem]" style={{ color: v.color }}>
+                  {v.key}
+                </span>
+                <span className="text-[0.7rem] text-gray-500">{v.description}</span>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* ── Validation error ── */}
+      {error && (
+        <div
+          className="flex items-center gap-2 px-3.5 py-2.5 rounded-xl
+                        bg-[#E333A3]/[0.08] border border-[#E333A3]/25"
+        >
+          <svg width="14" height="14" viewBox="0 0 16 16" fill="none" className="shrink-0">
+            <circle cx="8" cy="8" r="7" stroke="#E333A3" strokeWidth="1.5" />
+            <path d="M8 5v4M8 11v.5" stroke="#E333A3" strokeWidth="1.5" strokeLinecap="round" />
+          </svg>
+          <span className="text-[#E333A3] text-xs">{error}</span>
+        </div>
+      )}
+
+      {/* ── Live preview ── */}
+      {formula.trim() && (
+        <div
+          className="flex items-center justify-between px-4 py-3 rounded-xl border transition-all duration-200"
+          style={{
+            background: preview.error ? 'rgba(227,51,163,0.06)' : 'rgba(7,124,241,0.08)',
+            borderColor: preview.error ? 'rgba(227,51,163,0.2)' : 'rgba(7,124,241,0.2)',
+          }}
+        >
+          <div className="flex items-center gap-2 flex-wrap">
+            <span className="text-[0.7rem] text-gray-500 uppercase tracking-widest">
+              Preview score
+            </span>
+            <span className="text-[0.65rem] text-gray-600">
+              (prs=4, lines_changed=320, discord_messages=47, commits=12)
+            </span>
+          </div>
+          {preview.error ? (
+            <span className="text-[0.8rem] text-[#E333A3]">—</span>
+          ) : (
+            <span className="text-[1.4rem] font-extrabold text-[#077CF1] tracking-tight">
+              {preview.result !== null ? Math.round(preview.result * 100) / 100 : '—'}
+            </span>
+          )}
+        </div>
+      )}
+
+      {/* ── Save button ── */}
+      <div className="flex items-center gap-3">
+        <button
+          onClick={handleSave}
+          disabled={!isValid || saving}
+          className="inline-flex items-center gap-1.5 px-5 py-2.5 rounded-xl border-none
+                     font-mono text-[0.8rem] font-bold uppercase tracking-widest
+                     transition-all duration-200 disabled:cursor-not-allowed"
+          style={{
+            background:
+              isValid && !saving ? 'linear-gradient(135deg, #077CF1 0%, #0FAAA0 100%)' : '#1f2231',
+            color: isValid && !saving ? '#fff' : '#4b5563',
+          }}
+        >
+          {saving ? (
+            <>
+              <svg width="13" height="13" viewBox="0 0 16 16" fill="none" className="animate-spin">
+                <circle
+                  cx="8"
+                  cy="8"
+                  r="6"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeDasharray="20 15"
+                />
+              </svg>
+              Saving…
+            </>
+          ) : (
+            <>
+              <svg width="13" height="13" viewBox="0 0 16 16" fill="none">
+                <path
+                  d="M3 8l4 4 6-6"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+              Save Formula
+            </>
+          )}
+        </button>
+
+        {saved && (
+          <span className="flex items-center gap-1 text-[#0FAAA0] text-xs">
+            <svg width="12" height="12" viewBox="0 0 16 16" fill="none">
+              <path
+                d="M3 8l4 4 6-6"
+                stroke="#0FAAA0"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+            Saved
+          </span>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/components/dashboard/FormulaInput.tsx
+++ b/apps/web/src/components/dashboard/FormulaInput.tsx
@@ -14,8 +14,10 @@ export interface FormulaInputProps {
   onSaveSuccess?: (formula: string) => void
 }
 
-export default function FormulaInput({ initialFormula = '', onSaveSuccess }: FormulaInputProps) {
+export default function FormulaInput({ initialFormula = null, onSaveSuccess }: FormulaInputProps) {
   const [formula, setFormula] = useState(initialFormula ?? '')
+  const [savedFormula, setSavedFormula] = useState<string | null>(initialFormula ?? null)
+  const [loadingInitial, setLoadingInitial] = useState(initialFormula == null)
   const [error, setError] = useState<string | null>(null)
   const [saving, setSaving] = useState(false)
   const [saved, setSaved] = useState(false)
@@ -29,7 +31,6 @@ export default function FormulaInput({ initialFormula = '', onSaveSuccess }: For
 
   const preview = evaluatePreview(formula)
 
-  // Sync overlay scroll with textarea scroll
   const syncScroll = useCallback(() => {
     if (overlayRef.current && textareaRef.current) {
       overlayRef.current.scrollTop = textareaRef.current.scrollTop
@@ -37,7 +38,24 @@ export default function FormulaInput({ initialFormula = '', onSaveSuccess }: For
     }
   }, [])
 
-  // Validate on change
+  useEffect(() => {
+    if (initialFormula != null) return
+    const load = async () => {
+      try {
+        const res = await fetch('/api/formula')
+        if (!res.ok) return
+        const data = (await res.json()) as { formula: string | null }
+        if (data.formula) {
+          setFormula(data.formula)
+          setSavedFormula(data.formula)
+        }
+      } finally {
+        setLoadingInitial(false)
+      }
+    }
+    load()
+  }, [initialFormula])
+
   useEffect(() => {
     if (!formula.trim()) {
       setError(null)
@@ -47,7 +65,6 @@ export default function FormulaInput({ initialFormula = '', onSaveSuccess }: For
     setError(result.success ? null : result.error.issues[0].message)
   }, [formula])
 
-  // Handle input change
   const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     const val = e.target.value
     setFormula(val)
@@ -60,17 +77,14 @@ export default function FormulaInput({ initialFormula = '', onSaveSuccess }: For
     setActiveSuggIdx(0)
   }
 
-  // Apply a suggestion
   const applySuggestion = (varKey: string) => {
     const cursor = textareaRef.current?.selectionStart ?? formula.length
     const word = formula.slice(suggWordStart, cursor)
     const before = formula.slice(0, suggWordStart)
     const after = formula.slice(suggWordStart + word.length)
-    const newFormula = before + varKey + after
-    setFormula(newFormula)
+    setFormula(before + varKey + after)
     setSuggestions([])
 
-    // Place cursor after inserted variable
     setTimeout(() => {
       const pos = suggWordStart + varKey.length
       textareaRef.current?.setSelectionRange(pos, pos)
@@ -78,7 +92,6 @@ export default function FormulaInput({ initialFormula = '', onSaveSuccess }: For
     }, 0)
   }
 
-  // Keyboard handling
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if (suggestions.length === 0) return
 
@@ -96,15 +109,13 @@ export default function FormulaInput({ initialFormula = '', onSaveSuccess }: For
     }
   }
 
-  // Insert variable chip from the reference panel
   const insertVariable = (varKey: string) => {
     const ta = textareaRef.current
     const cursor = ta?.selectionStart ?? formula.length
     const before = formula.slice(0, cursor)
     const after = formula.slice(cursor)
     const separator = before.length > 0 && !/[\s(]$/.test(before) ? ' ' : ''
-    const newFormula = before + separator + varKey + after
-    setFormula(newFormula)
+    setFormula(before + separator + varKey + after)
     setSaved(false)
 
     setTimeout(() => {
@@ -114,7 +125,6 @@ export default function FormulaInput({ initialFormula = '', onSaveSuccess }: For
     }, 0)
   }
 
-  // Save handler
   const handleSave = async () => {
     const result = formulaSchema.safeParse(formula)
     if (!result.success) {
@@ -136,6 +146,7 @@ export default function FormulaInput({ initialFormula = '', onSaveSuccess }: For
       }
 
       setSaved(true)
+      setSavedFormula(formula)
       onSaveSuccess?.(formula)
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Failed to save')
@@ -145,6 +156,23 @@ export default function FormulaInput({ initialFormula = '', onSaveSuccess }: For
   }
 
   const isValid = !error && formula.trim().length > 0
+  const isDirty = savedFormula !== null && formula !== savedFormula
+  const unchanged = savedFormula !== null && formula === savedFormula
+
+  if (loadingInitial) {
+    return (
+      <div className="font-mono flex flex-col gap-6 w-full mx-auto px-5 sm:px-10 lg:px-20 py-10 animate-pulse">
+        <div className="h-4 w-36 rounded bg-white/10" />
+        <div className="h-3 w-full rounded bg-white/5" />
+        <div className="flex gap-2">
+          {[80, 112, 140, 72].map((w, i) => (
+            <div key={i} className="h-6 rounded-lg bg-white/10" style={{ width: w }} />
+          ))}
+        </div>
+        <div className="h-24 rounded-2xl bg-white/5" />
+      </div>
+    )
+  }
 
   return (
     <div className="font-mono flex flex-col gap-6 w-full mx-auto px-5 sm:px-10 lg:px-20 py-10">
@@ -163,6 +191,50 @@ export default function FormulaInput({ initialFormula = '', onSaveSuccess }: For
           them will be treated as multiplied (e.g. prs discord_messages = prs * discord_messages).
         </p>
       </div>
+
+      {/* Currently saved formula */}
+      {savedFormula && (
+        <div
+          className="rounded-2xl px-4 py-3.5 border"
+          style={{
+            background: 'rgba(15,170,160,0.08)',
+            borderColor: 'rgba(15,170,160,0.25)',
+          }}
+        >
+          <div className="flex items-center justify-between gap-3">
+            <div className="flex items-center gap-2">
+              <span
+                className="flex items-center justify-center w-5 h-5 rounded-full shrink-0"
+                style={{ background: 'rgba(15,170,160,0.15)' }}
+              >
+                <svg width="11" height="11" viewBox="0 0 16 16" fill="none">
+                  <path
+                    d="M3 8l4 4 6-6"
+                    stroke="#0FAAA0"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                </svg>
+              </span>
+              <span className="text-[0.65rem] text-[#0FAAA0]/80 uppercase tracking-widest font-bold">
+                Currently saved
+              </span>
+            </div>
+            {isDirty && (
+              <span
+                className="px-2 py-0.5 rounded-full text-[0.6rem] text-[#E333A3] uppercase tracking-widest font-bold"
+                style={{ background: 'rgba(227,51,163,0.12)' }}
+              >
+                Unsaved changes
+              </span>
+            )}
+          </div>
+          <code className="block mt-2 text-[0.82rem] text-[#0FAAA0] break-all leading-snug">
+            {savedFormula}
+          </code>
+        </div>
+      )}
 
       {/* Variable reference chips */}
       <div className="flex flex-wrap gap-2">
@@ -194,7 +266,6 @@ export default function FormulaInput({ initialFormula = '', onSaveSuccess }: For
 
       {/* Input area */}
       <div className="relative">
-        {/* Gradient border wrapper */}
         <div
           className="rounded-2xl p-0.5 transition-all duration-300"
           style={{
@@ -206,7 +277,6 @@ export default function FormulaInput({ initialFormula = '', onSaveSuccess }: For
           }}
         >
           <div className="rounded-[14px] bg-[#0d0f1a] relative overflow-hidden">
-            {/* Syntax highlight overlay */}
             <div
               ref={overlayRef}
               aria-hidden="true"
@@ -215,8 +285,6 @@ export default function FormulaInput({ initialFormula = '', onSaveSuccess }: For
                          select-none"
               dangerouslySetInnerHTML={{ __html: highlightFormula(formula) }}
             />
-
-            {/* Actual textarea */}
             <textarea
               ref={textareaRef}
               value={formula}
@@ -236,7 +304,6 @@ export default function FormulaInput({ initialFormula = '', onSaveSuccess }: For
           </div>
         </div>
 
-        {/* Autocomplete dropdown */}
         {suggestions.length > 0 && (
           <div
             ref={suggBoxRef}
@@ -268,10 +335,7 @@ export default function FormulaInput({ initialFormula = '', onSaveSuccess }: For
 
       {/* Validation error */}
       {error && (
-        <div
-          className="flex items-center gap-2 px-3.5 py-2.5 rounded-xl
-                        bg-[#E333A3]/[0.08] border border-[#E333A3]/25"
-        >
+        <div className="flex items-center gap-2 px-3.5 py-2.5 rounded-xl bg-[#E333A3]/[0.08] border border-[#E333A3]/25">
           <svg width="14" height="14" viewBox="0 0 16 16" fill="none" className="shrink-0">
             <circle cx="8" cy="8" r="7" stroke="#E333A3" strokeWidth="1.5" />
             <path d="M8 5v4M8 11v.5" stroke="#E333A3" strokeWidth="1.5" strokeLinecap="round" />
@@ -311,14 +375,16 @@ export default function FormulaInput({ initialFormula = '', onSaveSuccess }: For
       <div className="flex items-center gap-3">
         <button
           onClick={handleSave}
-          disabled={!isValid || saving}
+          disabled={!isValid || saving || unchanged}
           className="inline-flex items-center gap-1.5 px-5 py-2.5 rounded-xl border-none
-                     font-mono text-[0.8rem] font-bold uppercase tracking-widest
-                     transition-all duration-200 disabled:cursor-not-allowed"
+             font-mono text-[0.8rem] font-bold uppercase tracking-widest
+             transition-all duration-200 disabled:cursor-not-allowed"
           style={{
             background:
-              isValid && !saving ? 'linear-gradient(135deg, #077CF1 0%, #0FAAA0 100%)' : '#1f2231',
-            color: isValid && !saving ? '#fff' : '#4b5563',
+              isValid && !saving && !unchanged
+                ? 'linear-gradient(135deg, #077CF1 0%, #0FAAA0 100%)'
+                : '#1f2231',
+            color: isValid && !saving && !unchanged ? '#fff' : '#4b5563',
           }}
         >
           {saving ? (

--- a/apps/web/src/components/dashboard/FormulaInput.tsx
+++ b/apps/web/src/components/dashboard/FormulaInput.tsx
@@ -1,106 +1,13 @@
 'use client'
 
 import { useState, useRef, useEffect, useCallback } from 'react'
-import { FORMULA_VARIABLES, getSampleScope, math } from '@/lib/admin/formula'
+import {
+  evaluatePreview,
+  FORMULA_VARIABLES,
+  getActiveSuggestions,
+  highlightFormula,
+} from '@/lib/admin/formula'
 import { formulaSchema } from '@/lib/schemas/admin'
-
-// #region Helper functions
-
-/**
- * Extracts all identifiers from the formula and returns those that are not in the list of valid variables or math built-ins.
- * @param {string} val The formula string to analyse
- * @param {string[]} mathBuiltins List of built-in function names from mathjs to exclude from unknown identifiers
- * @returns {string[]} An array of unknown identifier names found in the formula
- */
-function getActiveSuggestions(
-  value: string,
-  cursor: number
-): {
-  suggestions: (typeof FORMULA_VARIABLES)[number][]
-  wordStart: number
-  word: string
-} {
-  const before = value.slice(0, cursor)
-  const match = before.match(/[a-zA-Z_][a-zA-Z0-9_]*$/)
-  if (!match) return { suggestions: [], wordStart: cursor, word: '' }
-
-  const word = match[0].toLowerCase()
-  const wordStart = cursor - word.length
-  const suggestions = FORMULA_VARIABLES.filter((v) => v.key.startsWith(word) && v.key !== word)
-
-  return { suggestions, wordStart, word }
-}
-
-/**
- * Evaluates the formula with sample variable values to provide a live preview.
- * Returns either the computed result or an error message if evaluation fails.
- * @param {string} formula The formula string to evaluate
- * @returns {{ result: number | null; error: string | null }} An object containing either the numeric result or an error message
- */
-function evaluatePreview(formula: string): { result: number | null; error: string | null } {
-  if (!formula.trim()) return { result: null, error: null }
-  try {
-    const scope = getSampleScope()
-    const result = math.compile(formula).evaluate(scope)
-    if (typeof result !== 'number' || !isFinite(result)) {
-      return { result: null, error: 'Result is not a finite number' }
-    }
-    return { result, error: null }
-  } catch (e) {
-    return { result: null, error: String(e) }
-  }
-}
-
-/**
- * Simple syntax highlighter for the formula input. Wraps known variables, numbers, and operators
- * @param {string} formula The raw formula string to highlight
- * @returns {string} HTML string with syntax highlighting applied
- */
-function highlightFormula(formula: string): string {
-  // Tokenise the plain-text formula first, then wrap each token in a coloured span - avoids regex running over already-injected HTML tag characters.
-  const escape = (s: string) => s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
-
-  const varKeys = FORMULA_VARIABLES.map((v) => v.key)
-  const varColorMap: Record<string, string> = Object.fromEntries(
-    FORMULA_VARIABLES.map((v) => [v.key, v.color])
-  )
-
-  // Build tokeniser: known vars | numbers | operators | identifiers | whitespace | single-char fallback
-  // IMPORTANT: fallback must NOT be \S+ as it greedily eats "sqrt(discord_messages)" as one token.
-  // Instead use an identifier pattern so "sqrt" tokenises separately from the "(" that follows it.
-  const tokenRe = new RegExp(
-    [
-      ...varKeys,
-      String.raw`\d+(?:\.\d+)?`,
-      String.raw`[+\-*/%^(),]`,
-      String.raw`[a-zA-Z_][a-zA-Z0-9_]*`,
-      String.raw`\s+`,
-      String.raw`[\s\S]`,
-    ].join('|'),
-    'g'
-  )
-
-  const tokens = formula.match(tokenRe) ?? (formula ? [formula] : [])
-
-  return tokens
-    .map((tok) => {
-      if (varColorMap[tok]) {
-        return `<span style="color:${varColorMap[tok]};font-weight:600">${escape(tok)}</span>`
-      }
-      if (/^\d+(?:\.\d+)?$/.test(tok)) {
-        return `<span style="color:#0FAAA0">${tok}</span>`
-      }
-      if (/^[+\-*/%^()]+$/.test(tok)) {
-        return `<span style="color:#6b7280">${tok}</span>`
-      }
-      if (/^\s+$/.test(tok)) return tok
-      // Unknown identifier - show dimly so it's visible but clearly wrong
-      return `<span style="color:#6b7280">${escape(tok)}</span>`
-    })
-    .join('')
-}
-
-// # endregion
 
 export interface FormulaInputProps {
   initialFormula?: string | null
@@ -217,7 +124,7 @@ export default function FormulaInput({ initialFormula = '', onSaveSuccess }: For
 
     setSaving(true)
     try {
-      const res = await fetch('/api/admin/formula', {
+      const res = await fetch('/api/formula', {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ formula }),

--- a/apps/web/src/components/ui/WebsterFolder.tsx
+++ b/apps/web/src/components/ui/WebsterFolder.tsx
@@ -30,7 +30,10 @@ const FOLDER_VIEWBOX = '186 116 567 386'
 
 export default function WebsterFolder() {
   return (
-    <div className="group relative inline-block drop-shadow-2xl" style={{ paddingTop: 130 }}>
+    <div
+      className="group relative inline-block drop-shadow-2xl"
+      style={{ paddingTop: 130, perspective: 800 }}
+    >
       {/* Folder Back */}
       <div className="absolute inset-x-0 z-10" style={{ top: 130 }}>
         <svg
@@ -46,7 +49,7 @@ export default function WebsterFolder() {
               className="webster-folder-cls-1"
               d="M405.85,235.11h-167.82c-24.35,0-44.1-19.74-44.1-44.1v-66.33c0-24.35,19.74-44.1,44.1-44.1h108.3c3.65.3,8.9,1.16,14.75,3.63,6.53,2.76,11.15,6.41,13.98,9.03,15.74,11.78,31.48,23.55,47.23,35.33,92.15.31,184.31.63,276.46.94,2.81-.21,21.49-1.27,35.2,12.93,8.58,8.89,10.77,19.17,11.43,23.37-.07,12.7-.14,25.4-.2,38.1-85.66-17.62-195.76-23.77-308.15,18.29-10.76,4.03-21.15,8.35-31.18,12.92h0Z"
             />
-            <rect
+            {/* <rect
               className="webster-folder-cls-3"
               x="193.94"
               y="164.01"
@@ -54,7 +57,7 @@ export default function WebsterFolder() {
               height="329.72"
               rx="28.2"
               ry="28.2"
-            />
+            /> */}
           </g>
         </svg>
       </div>
@@ -70,7 +73,14 @@ export default function WebsterFolder() {
       </div>
 
       {/* Folder Front */}
-      <div className="absolute inset-x-0 z-30" style={{ top: 130 }}>
+      <div
+        className="absolute inset-x-0 z-30 transition-transform duration-300 ease-[cubic-bezier(0.34,1.56,0.64,1)] group-hover:[transform:rotateX(-15deg)]"
+        style={{
+          top: 130,
+          transformOrigin: '50% 98%',
+          transformStyle: 'preserve-3d',
+        }}
+      >
         <svg
           xmlns="http://www.w3.org/2000/svg"
           viewBox={FOLDER_VIEWBOX}

--- a/apps/web/src/lib/admin/formula.ts
+++ b/apps/web/src/lib/admin/formula.ts
@@ -1,0 +1,71 @@
+import { create, all } from 'mathjs'
+
+export const math = create(all)
+
+// #region Constants
+
+export const FORMULA_VARIABLES = [
+  {
+    key: 'prs',
+    label: 'Pull Requests',
+    description: 'Total open/merged PRs this week',
+    color: '#077CF1',
+    bg: 'rgba(7,124,241,0.10)',
+  },
+  {
+    key: 'lines_changed',
+    label: 'Lines Changed',
+    description: 'Lines added + removed across all commits',
+    color: '#E333A3',
+    bg: 'rgba(227,51,163,0.10)',
+  },
+  {
+    key: 'discord_messages',
+    label: 'Discord Messages',
+    description: 'Messages sent in linked channels',
+    color: '#5B8AF0',
+    bg: 'rgba(91,138,240,0.10)',
+  },
+  {
+    key: 'commits',
+    label: 'Commits',
+    description: 'Commits pushed this week',
+    color: '#0FAAA0',
+    bg: 'rgba(15,170,160,0.10)',
+  },
+] as const
+
+const VALID_VARIABLE_KEYS = FORMULA_VARIABLES.map((v) => v.key)
+
+// #endregion
+
+type FormulaVariable = (typeof FORMULA_VARIABLES)[number]['key']
+
+// #region Util functions for Zod schema
+
+/**
+ * Returns a sample scope with dummy values for all variables, used for validation and live preview.
+ * In the future, we could fetch real data for the current project to make the preview more accurate.
+ * @returns {Record<FormulaVariable, number>} An object mapping variable keys to sample numeric values
+ */
+export const getSampleScope = (): Record<FormulaVariable, number> => ({
+  prs: 4,
+  lines_changed: 320,
+  discord_messages: 47,
+  commits: 12,
+})
+
+/**
+ * Extracts all identifiers from the formula and returns those that are not in the list of valid variables or math built-ins.
+ * @param {string} val The formula string to analyse
+ * @returns {string[]} An array of unknown identifier names found in the formula
+ */
+export const getUnknownIdentifiers = (val: string): string[] => {
+  const identifiers = val.match(/[a-zA-Z_][a-zA-Z0-9_]*/g) ?? []
+  const mathBuiltins = Object.keys(math)
+  return identifiers.filter(
+    (id) => !VALID_VARIABLE_KEYS.includes(id as FormulaVariable) && !mathBuiltins.includes(id)
+  )
+}
+
+// #endregion

--- a/apps/web/src/lib/admin/formula.ts
+++ b/apps/web/src/lib/admin/formula.ts
@@ -69,3 +69,101 @@ export const getUnknownIdentifiers = (val: string): string[] => {
 }
 
 // #endregion
+
+// #region Util functions for FormulaInput component
+
+/**
+ * Extracts all identifiers from the formula and returns those that are not in the list of valid variables or math built-ins.
+ * @param {string} val The formula string to analyse
+ * @param {string[]} mathBuiltins List of built-in function names from mathjs to exclude from unknown identifiers
+ * @returns {string[]} An array of unknown identifier names found in the formula
+ */
+export function getActiveSuggestions(
+  value: string,
+  cursor: number
+): {
+  suggestions: (typeof FORMULA_VARIABLES)[number][]
+  wordStart: number
+  word: string
+} {
+  const before = value.slice(0, cursor)
+  const match = before.match(/[a-zA-Z_][a-zA-Z0-9_]*$/)
+  if (!match) return { suggestions: [], wordStart: cursor, word: '' }
+
+  const word = match[0].toLowerCase()
+  const wordStart = cursor - word.length
+  const suggestions = FORMULA_VARIABLES.filter((v) => v.key.startsWith(word) && v.key !== word)
+
+  return { suggestions, wordStart, word }
+}
+
+/**
+ * Evaluates the formula with sample variable values to provide a live preview.
+ * Returns either the computed result or an error message if evaluation fails.
+ * @param {string} formula The formula string to evaluate
+ * @returns {{ result: number | null; error: string | null }} An object containing either the numeric result or an error message
+ */
+export function evaluatePreview(formula: string): { result: number | null; error: string | null } {
+  if (!formula.trim()) return { result: null, error: null }
+  try {
+    const scope = getSampleScope()
+    const result = math.compile(formula).evaluate(scope)
+    if (typeof result !== 'number' || !isFinite(result)) {
+      return { result: null, error: 'Result is not a finite number' }
+    }
+    return { result, error: null }
+  } catch (e) {
+    return { result: null, error: String(e) }
+  }
+}
+
+/**
+ * Simple syntax highlighter for the formula input. Wraps known variables, numbers, and operators
+ * @param {string} formula The raw formula string to highlight
+ * @returns {string} HTML string with syntax highlighting applied
+ */
+export function highlightFormula(formula: string): string {
+  // Tokenise the plain-text formula first, then wrap each token in a coloured span - avoids regex running over already-injected HTML tag characters.
+  const escape = (s: string) => s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+
+  const varKeys = FORMULA_VARIABLES.map((v) => v.key)
+  const varColorMap: Record<string, string> = Object.fromEntries(
+    FORMULA_VARIABLES.map((v) => [v.key, v.color])
+  )
+
+  // Build tokeniser: known vars | numbers | operators | identifiers | whitespace | single-char fallback
+  // IMPORTANT: fallback must NOT be \S+ as it greedily eats "sqrt(discord_messages)" as one token.
+  // Instead use an identifier pattern so "sqrt" tokenises separately from the "(" that follows it.
+  const tokenRe = new RegExp(
+    [
+      ...varKeys,
+      String.raw`\d+(?:\.\d+)?`,
+      String.raw`[+\-*/%^(),]`,
+      String.raw`[a-zA-Z_][a-zA-Z0-9_]*`,
+      String.raw`\s+`,
+      String.raw`[\s\S]`,
+    ].join('|'),
+    'g'
+  )
+
+  const tokens = formula.match(tokenRe) ?? (formula ? [formula] : [])
+
+  return tokens
+    .map((tok) => {
+      if (varColorMap[tok]) {
+        return `<span style="color:${varColorMap[tok]};font-weight:600">${escape(tok)}</span>`
+      }
+      if (/^\d+(?:\.\d+)?$/.test(tok)) {
+        return `<span style="color:#0FAAA0">${tok}</span>`
+      }
+      if (/^[+\-*/%^()]+$/.test(tok)) {
+        return `<span style="color:#6b7280">${tok}</span>`
+      }
+      if (/^\s+$/.test(tok)) return tok
+      // Unknown identifier - show dimly so it's visible but clearly wrong
+      return `<span style="color:#6b7280">${escape(tok)}</span>`
+    })
+    .join('')
+}
+
+// #endregion

--- a/apps/web/src/lib/schemas/admin.ts
+++ b/apps/web/src/lib/schemas/admin.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod'
+import { getSampleScope, getUnknownIdentifiers, math } from '@/lib/admin/formula'
 
 // --- Shared primitives ---
 
@@ -90,3 +91,42 @@ export const rolesSchema = z
       })
     }
   })
+
+// -- Formula Input --
+
+export const formulaSchema = z
+  .string()
+  .min(1, 'Formula cannot be empty')
+  .superRefine((val, ctx) => {
+    const unknown = getUnknownIdentifiers(val)
+    if (unknown.length > 0) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `Unknown variable${unknown.length > 1 ? 's' : ''}: ${unknown.join(', ')}`,
+      })
+    }
+  })
+  .refine(
+    (val) => {
+      try {
+        const scope = getSampleScope()
+        math.compile(val).evaluate(scope)
+        return true
+      } catch {
+        return false
+      }
+    },
+    { message: 'Formula has a syntax error' }
+  )
+  .refine(
+    (val) => {
+      try {
+        const scope = getSampleScope()
+        const result = math.compile(val).evaluate(scope)
+        return typeof result === 'number' && isFinite(result)
+      } catch {
+        return false
+      }
+    },
+    { message: 'Formula must evaluate to a finite number' }
+  )

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -174,8 +174,8 @@ model Config {
   id        String   @id @default(cuid())
   scope     String   // "GLOBAL" or the Project.id string
   projectId String?  // Nullable FK; null for global configs
-  key       String
-  value     Json     // Float, Int, Boolean, or structured object
+  key       String   // "healthFormula"
+  value     Json     // Float, Int, Boolean, or structured object - stores the formula string
   updatedAt DateTime @updatedAt
   project   Project? @relation(fields: [projectId], references: [id], onDelete: Cascade)
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,6 +52,9 @@ importers:
       lucide-react:
         specifier: ^1.7.0
         version: 1.7.0(react@19.2.4)
+      mathjs:
+        specifier: ^15.2.0
+        version: 15.2.0
       next:
         specifier: ^15.1.0
         version: 15.5.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -3244,6 +3247,12 @@ packages:
         integrity: sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==,
       }
 
+  complex.js@2.4.3:
+    resolution:
+      {
+        integrity: sha512-UrQVSUur14tNX6tiP4y8T4w4FeJAX3bi2cIv0pu/DTLFNxoq7z2Yh83Vfzztj6Px3X/lubqQ9IrPp7Bpn6p4MQ==,
+      }
+
   compress-commons@6.0.2:
     resolution:
       {
@@ -3811,6 +3820,12 @@ packages:
         integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==,
       }
     engines: { node: '>=6' }
+
+  escape-latex@1.2.0:
+    resolution:
+      {
+        integrity: sha512-nV5aVWW1K0wEiUIEdZ4erkGGH8mDxGyxSeqPzRNtWP7ataw+/olFObw7hujFWlVjNsaDFw5VZ5NzVSIqRgfTiw==,
+      }
 
   escape-string-regexp@4.0.0:
     resolution:
@@ -4804,6 +4819,12 @@ packages:
         integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==,
       }
 
+  javascript-natural-sort@0.7.1:
+    resolution:
+      {
+        integrity: sha512-nO6jcEfZWQXDhOiBtG2KvKyEptz7RVbpGP4vTD2hLBdmNQSsCiicO2Ioinv6UI4y9ukqnBpy+XZ9H6uLNgJTlw==,
+      }
+
   jiti@1.21.7:
     resolution:
       {
@@ -5212,6 +5233,14 @@ packages:
         integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==,
       }
     engines: { node: '>= 0.4' }
+
+  mathjs@15.2.0:
+    resolution:
+      {
+        integrity: sha512-UAQzSVob9rNLdGpqcFMYmSu9dkuLYy7Lr2hBEQS5SHQdknA9VppJz3cy2KkpMzTODunad6V6cNv+5kOLsePLow==,
+      }
+    engines: { node: '>= 18' }
+    hasBin: true
 
   mdn-data@2.27.1:
     resolution:
@@ -6202,6 +6231,12 @@ packages:
         integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==,
       }
 
+  seedrandom@3.0.5:
+    resolution:
+      {
+        integrity: sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg==,
+      }
+
   semver@6.3.1:
     resolution:
       {
@@ -6635,6 +6670,12 @@ packages:
         integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==,
       }
 
+  tiny-emitter@2.1.0:
+    resolution:
+      {
+        integrity: sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==,
+      }
+
   tiny-invariant@1.3.3:
     resolution:
       {
@@ -6840,6 +6881,13 @@ packages:
         integrity: sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==,
       }
     engines: { node: '>= 0.4' }
+
+  typed-function@4.2.2:
+    resolution:
+      {
+        integrity: sha512-VwaXim9Gp1bngi/q3do8hgttYn2uC3MoT/gfuMWylnj1IeZBUAyPddHZlo1K05BDoj8DYPpMdiHqH1dDYdJf2A==,
+      }
+    engines: { node: '>= 18' }
 
   typescript-eslint@8.57.2:
     resolution:
@@ -8960,6 +9008,8 @@ snapshots:
       array-ify: 1.0.0
       dot-prop: 5.3.0
 
+  complex.js@2.4.3: {}
+
   compress-commons@6.0.2:
     dependencies:
       crc-32: 1.2.2
@@ -9382,6 +9432,8 @@ snapshots:
       '@esbuild/win32-x64': 0.27.4
 
   escalade@3.2.0: {}
+
+  escape-latex@1.2.0: {}
 
   escape-string-regexp@4.0.0: {}
 
@@ -10070,6 +10122,8 @@ snapshots:
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
 
+  javascript-natural-sort@0.7.1: {}
+
   jiti@1.21.7: {}
 
   jiti@2.6.1: {}
@@ -10291,6 +10345,18 @@ snapshots:
       semver: 7.7.4
 
   math-intrinsics@1.1.0: {}
+
+  mathjs@15.2.0:
+    dependencies:
+      '@babel/runtime': 7.28.6
+      complex.js: 2.4.3
+      decimal.js: 10.6.0
+      escape-latex: 1.2.0
+      fraction.js: 5.3.4
+      javascript-natural-sort: 0.7.1
+      seedrandom: 3.0.5
+      tiny-emitter: 2.1.0
+      typed-function: 4.2.2
 
   mdn-data@2.27.1: {}
 
@@ -10919,6 +10985,8 @@ snapshots:
 
   scheduler@0.27.0: {}
 
+  seedrandom@3.0.5: {}
+
   semver@6.3.1: {}
 
   semver@7.7.4: {}
@@ -11305,6 +11373,8 @@ snapshots:
     dependencies:
       any-promise: 1.3.0
 
+  tiny-emitter@2.1.0: {}
+
   tiny-invariant@1.3.3: {}
 
   tinybench@2.9.0: {}
@@ -11436,6 +11506,8 @@ snapshots:
       is-typed-array: 1.1.15
       possible-typed-array-names: 1.1.0
       reflect.getprototypeof: 1.0.10
+
+  typed-function@4.2.2: {}
 
   typescript-eslint@8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3):
     dependencies:


### PR DESCRIPTION
## Description

Adds an admin UI component and API route that allows admins to define a global mathematical
formula for computing a weekly health score across all projects.

## Solution

### `FormulaInput` component (`components/dashboard/FormulaInput.tsx`)

- Textarea with a **syntax-highlighting overlay** — tokenises the formula on each keystroke and
  wraps known variables, numbers, and operators in coloured spans without mutating the underlying
  value
- **Intellisense-style autocomplete** for the four variables (`prs`, `lines_changed`,
  `discord_messages`, `commits`) — triggered as you type, navigable with arrow keys, accepted with
  `Enter`/`Tab`, dismissed with `Escape`
- **Variable chips** that insert at the current cursor position on click
- **Live preview score** evaluated against sample values on every keystroke so admins can
  sanity-check the formula before saving
- **Zod + mathjs validation** (client-side, reactive): unknown variable detection, syntax error
  catch, and finite-number result guard — errors shown inline with a clear message
- Save button disabled until the formula is valid; shows a spinner during the request and a
  confirmation on success

### `PUT /api/admin/formula` + `GET /api/admin/formula`

- Server-side re-validation with the same schema (never trust the client)
- Prisma `upsert` on `Config` with `scope = "GLOBAL"`, `key = "healthFormula"` — maps to
  `INSERT ... ON CONFLICT (scope, key) DO UPDATE` in Postgres, which is atomic and handles
  concurrent writes without optimistic locking (last write wins, which is the correct semantic for
  a single shared formula)
- No schema migration required — the existing `Config` model with `@@unique([scope, key])` covers
  this exactly

## Notes

- The formula evaluator (`mathjs`) supports the full range of operations: `+`, `-`, `*`, `/`, `^`,
  `sqrt`, `log`, `abs`, parentheses, etc.
- Empty-state handling (hiding the health graph when no formula is set) is not part of this PR —
  that belongs in the graph/stats consumer once the score computation job reads this config key
- Sample values used in the preview (`prs=4, lines_changed=320, discord_messages=47, commits=12`)
  are placeholders; real values will be fetched per-project by the weekly stats job