### PR TITLE
[#220] Team member page

### DIFF
--- a/apps/web/src/app/(public)/project/[slug]/members/page.tsx
+++ b/apps/web/src/app/(public)/project/[slug]/members/page.tsx
@@ -76,8 +76,8 @@ export default async function TeamMembersPage({ params }: { params: Promise<{ sl
       <div className="px-5 sm:px-10 lg:px-20 py-8 lg:py-14">
         {members.length > 0 ? (
           <div className="grid grid-cols-2 gap-4 lg:grid-cols-3 xl:grid-cols-4 lg:gap-8">
-            {members.map((member) => (
-              <MemberCard key={member.id} member={member} />
+            {members.map((member, index) => (
+              <MemberCard key={member.id} member={member} index={index} />
             ))}
           </div>
         ) : (

--- a/apps/web/src/app/(public)/project/[slug]/members/page.tsx
+++ b/apps/web/src/app/(public)/project/[slug]/members/page.tsx
@@ -1,0 +1,91 @@
+import Link from 'next/link'
+import { notFound } from 'next/navigation'
+import MemberCard from '@/components/ui/MemberCard'
+import LastUpdatedTime from '@/components/headers/LastUpdatedTime'
+import { getProjectHeaderData } from '@/lib/project/projects'
+import { getProjectTeamMembers } from '@/lib/project/weekly-stats'
+import { db, SyncJobStatus, SyncJobType } from '@repo/db'
+
+async function getLastUpdated(): Promise<Date> {
+  try {
+    const syncJob = await db.syncJob.findFirst({
+      where: { type: SyncJobType.GITHUB, status: SyncJobStatus.SUCCESS },
+      orderBy: { finishedAt: 'desc' },
+      select: { finishedAt: true },
+    })
+    return syncJob?.finishedAt ?? new Date()
+  } catch {
+    return new Date()
+  }
+}
+
+export default async function TeamMembersPage({ params }: { params: Promise<{ slug: string }> }) {
+  const slug = (await params).slug
+  const [project, members, lastUpdated] = await Promise.all([
+    getProjectHeaderData(slug),
+    getProjectTeamMembers(slug).catch(() => []),
+    getLastUpdated(),
+  ])
+
+  if (!project) {
+    notFound()
+  }
+
+  return (
+    <>
+      {/* PAGE HEADER */}
+      <div className="bg-wdcc-blue-light w-full px-5 sm:px-10 lg:px-20 pt-8 sm:pt-12 lg:pt-16 pb-8 lg:pb-14">
+        <div className="flex flex-col lg:flex-row lg:items-end lg:justify-between gap-6">
+          <div className="min-w-0">
+            <nav
+              aria-label="Breadcrumb"
+              className="font-mono text-xs lg:text-sm uppercase tracking-[0.2em] text-wdcc-grey"
+            >
+              <Link href="/" className="hover:text-wdcc-oshan transition-colors">
+                Projects
+              </Link>
+              <span className="mx-2">›</span>
+              <Link href={`/project/${slug}`} className="hover:text-wdcc-oshan transition-colors">
+                {project.name}
+              </Link>
+              <span className="mx-2">›</span>
+              <span className="text-wdcc-oshan font-medium">Team Members</span>
+            </nav>
+
+            <h1 className="mt-3 lg:mt-5 font-extrabold tracking-tight !leading-none text-[clamp(2rem,5vw,4rem)]">
+              Team Members
+            </h1>
+
+            <p className="mt-3 lg:mt-5 font-mono text-sm lg:text-lg text-wdcc-grey">
+              {project.name} · {members.length} contributor{members.length !== 1 ? 's' : ''} ·
+              ranked by lines committed
+            </p>
+          </div>
+
+          {/* Updated pill — desktop only, per Figma */}
+          <div className="hidden lg:flex items-center gap-3 rounded-full bg-white px-5 py-2.5 shrink-0 w-fit">
+            <span className="w-3 h-3 rounded-full bg-green-600 shrink-0" />
+            <span className="font-mono text-base text-wdcc-grey whitespace-nowrap">
+              Updated <LastUpdatedTime isoDate={lastUpdated.toISOString()} />
+            </span>
+          </div>
+        </div>
+      </div>
+
+      {/* MEMBER GRID */}
+      <div className="px-5 sm:px-10 lg:px-20 py-8 lg:py-14">
+        {members.length > 0 ? (
+          <div className="grid grid-cols-2 gap-4 lg:grid-cols-3 xl:grid-cols-4 lg:gap-8">
+            {members.map((member) => (
+              <MemberCard key={member.id} member={member} />
+            ))}
+          </div>
+        ) : (
+          <p className="py-16 text-center font-mono text-wdcc-grey">
+            No team members yet. Members appear here once they are added to the project.
+          </p>
+        )}
+      </div>
+    </>
+  )
+}

--- a/apps/web/src/app/(public)/project/[slug]/members/page.tsx
+++ b/apps/web/src/app/(public)/project/[slug]/members/page.tsx
@@ -6,10 +6,14 @@ import { getProjectHeaderData } from '@/lib/project/projects'
 import { getProjectTeamMembers } from '@/lib/project/weekly-stats'
 import { db, SyncJobStatus, SyncJobType } from '@repo/db'
 
-async function getLastUpdated(): Promise<Date> {
+async function getLastUpdated(slug: string): Promise<Date> {
   try {
     const syncJob = await db.syncJob.findFirst({
-      where: { type: SyncJobType.GITHUB, status: SyncJobStatus.SUCCESS },
+      where: {
+        type: SyncJobType.GITHUB,
+        status: SyncJobStatus.SUCCESS,
+        project: { slug },
+      },
       orderBy: { finishedAt: 'desc' },
       select: { finishedAt: true },
     })
@@ -24,7 +28,7 @@ export default async function TeamMembersPage({ params }: { params: Promise<{ sl
   const [project, members, lastUpdated] = await Promise.all([
     getProjectHeaderData(slug),
     getProjectTeamMembers(slug).catch(() => []),
-    getLastUpdated(),
+    getLastUpdated(slug),
   ])
 
   if (!project) {

--- a/apps/web/src/app/(public)/project/[slug]/page.tsx
+++ b/apps/web/src/app/(public)/project/[slug]/page.tsx
@@ -1,10 +1,8 @@
 import TeamHeader from '@/components/headers/TeamHeader'
 import WeeklyMvp from '@/components/ui/WeeklyMvp'
 import TeamSection from '@/components/ui/TeamSection'
-import ViewAllMembersButton from '@/components/ui/ViewAllMembersButton'
 import { getProjectHeaderData } from '@/lib/project/projects'
-import { getProjectMembers } from '@/lib/project/members'
-import { getProjectWeeklyMvp } from '@/lib/project/weekly-stats'
+import { getProjectTeamMembers, getProjectWeeklyMvp } from '@/lib/project/weekly-stats'
 import { notFound } from 'next/navigation'
 import GraphViewToggle from '@/components/charts/GraphViewToggle'
 
@@ -13,7 +11,7 @@ export default async function ProjectPage({ params }: { params: Promise<{ slug: 
   const [project, mvp, members] = await Promise.all([
     getProjectHeaderData(slug),
     getProjectWeeklyMvp(slug).catch(() => null),
-    getProjectMembers(slug).catch(() => []),
+    getProjectTeamMembers(slug).catch(() => []),
   ])
 
   if (!project) {
@@ -39,8 +37,7 @@ export default async function ProjectPage({ params }: { params: Promise<{ slug: 
           </div>
         )}
 
-        <TeamSection members={members} />
-        <ViewAllMembersButton members={members} />
+        <TeamSection slug={slug} members={members} />
 
         <GraphViewToggle slug={slug} />
       </div>

--- a/apps/web/src/app/(public)/project/[slug]/page.tsx
+++ b/apps/web/src/app/(public)/project/[slug]/page.tsx
@@ -1,8 +1,10 @@
 import TeamHeader from '@/components/headers/TeamHeader'
 import WeeklyMvp from '@/components/ui/WeeklyMvp'
 import TeamSection from '@/components/ui/TeamSection'
+import ViewAllMembersButton from '@/components/ui/ViewAllMembersButton'
 import { getProjectHeaderData } from '@/lib/project/projects'
-import { getProjectTeamMembers, getProjectWeeklyMvp } from '@/lib/project/weekly-stats'
+import { getProjectMembers } from '@/lib/project/members'
+import { getProjectWeeklyMvp } from '@/lib/project/weekly-stats'
 import { notFound } from 'next/navigation'
 import GraphViewToggle from '@/components/charts/GraphViewToggle'
 
@@ -11,7 +13,7 @@ export default async function ProjectPage({ params }: { params: Promise<{ slug: 
   const [project, mvp, members] = await Promise.all([
     getProjectHeaderData(slug),
     getProjectWeeklyMvp(slug).catch(() => null),
-    getProjectTeamMembers(slug).catch(() => []),
+    getProjectMembers(slug).catch(() => []),
   ])
 
   if (!project) {
@@ -38,6 +40,7 @@ export default async function ProjectPage({ params }: { params: Promise<{ slug: 
         )}
 
         <TeamSection slug={slug} members={members} />
+        <ViewAllMembersButton slug={slug} members={members} />
 
         <GraphViewToggle slug={slug} />
       </div>

--- a/apps/web/src/components/ui/MemberAvatar.tsx
+++ b/apps/web/src/components/ui/MemberAvatar.tsx
@@ -2,54 +2,31 @@
 
 import { useState } from 'react'
 import Image from 'next/image'
-import { cn } from '@/lib/utils'
 
 interface MemberAvatarProps {
   name: string
-  imageUrl: string | null
-  color: string
-  // What to render when there is no photo: a person silhouette for desktop view or a solid dot for mobile view
-  fallback?: 'silhouette' | 'dot'
+  imageUrl?: string | null
+  size?: number
   className?: string
 }
 
-export default function MemberAvatar({
-  name,
-  imageUrl,
-  color,
-  fallback = 'silhouette',
-  className,
-}: MemberAvatarProps) {
+/**
+ * Circular member avatar. Falls back to the same local placeholder as the
+ * Weekly MVP component when there is no image or it fails to load.
+ */
+export default function MemberAvatar({ name, imageUrl, size = 96, className }: MemberAvatarProps) {
   const [imgError, setImgError] = useState(false)
 
-  if (imageUrl && !imgError) {
-    return (
-      <Image
-        src={imageUrl}
-        alt={name}
-        width={96}
-        height={96}
-        className={cn('rounded-full object-cover', className)}
-        onError={() => setImgError(true)}
-      />
-    )
-  }
-
-  if (fallback === 'dot') {
-    return (
-      <span
-        aria-label={name}
-        role="img"
-        className={cn('block rounded-full', className)}
-        style={{ backgroundColor: color }}
-      />
-    )
-  }
+  const imgSrc = imageUrl && !imgError ? imageUrl : '/default-avatar.svg'
 
   return (
-    <svg viewBox="0 0 96 96" role="img" aria-label={name} className={className}>
-      <circle cx="48" cy="30" r="22" fill={color} />
-      <path d="M48 58c-23 0-36 15-38 38h76c-2-23-15-38-38-38z" fill={color} />
-    </svg>
+    <Image
+      src={imgSrc}
+      alt={name}
+      width={size}
+      height={size}
+      className={`rounded-full object-cover ${className ?? ''}`}
+      onError={() => setImgError(true)}
+    />
   )
 }

--- a/apps/web/src/components/ui/MemberAvatar.tsx
+++ b/apps/web/src/components/ui/MemberAvatar.tsx
@@ -2,31 +2,54 @@
 
 import { useState } from 'react'
 import Image from 'next/image'
+import { cn } from '@/lib/utils'
 
 interface MemberAvatarProps {
   name: string
-  imageUrl?: string | null
-  size?: number
+  imageUrl: string | null
+  color: string
+  // What to render when there is no photo: a person silhouette for desktop view or a solid dot for mobile view
+  fallback?: 'silhouette' | 'dot'
   className?: string
 }
 
-/**
- * Circular member avatar. Falls back to the same local placeholder as the
- * Weekly MVP component when there is no image or it fails to load.
- */
-export default function MemberAvatar({ name, imageUrl, size = 96, className }: MemberAvatarProps) {
+export default function MemberAvatar({
+  name,
+  imageUrl,
+  color,
+  fallback = 'silhouette',
+  className,
+}: MemberAvatarProps) {
   const [imgError, setImgError] = useState(false)
 
-  const imgSrc = imageUrl && !imgError ? imageUrl : '/default-avatar.svg'
+  if (imageUrl && !imgError) {
+    return (
+      <Image
+        src={imageUrl}
+        alt={name}
+        width={96}
+        height={96}
+        className={cn('rounded-full object-cover', className)}
+        onError={() => setImgError(true)}
+      />
+    )
+  }
+
+  if (fallback === 'dot') {
+    return (
+      <span
+        aria-label={name}
+        role="img"
+        className={cn('block rounded-full', className)}
+        style={{ backgroundColor: color }}
+      />
+    )
+  }
 
   return (
-    <Image
-      src={imgSrc}
-      alt={name}
-      width={size}
-      height={size}
-      className={`rounded-full object-cover ${className ?? ''}`}
-      onError={() => setImgError(true)}
-    />
+    <svg viewBox="0 0 96 96" role="img" aria-label={name} className={className}>
+      <circle cx="48" cy="30" r="22" fill={color} />
+      <path d="M48 58c-23 0-36 15-38 38h76c-2-23-15-38-38-38z" fill={color} />
+    </svg>
   )
 }

--- a/apps/web/src/components/ui/MemberCard.tsx
+++ b/apps/web/src/components/ui/MemberCard.tsx
@@ -1,5 +1,6 @@
 import MemberAvatar from './MemberAvatar'
 import type { TeamMemberStats } from '@/lib/project/weekly-stats'
+import { AVATAR_COLORS } from '@/lib/project/members'
 
 const STATS = [
   {
@@ -25,7 +26,7 @@ const STATS = [
   },
 ] as const
 
-export default function MemberCard({ member }: { member: TeamMemberStats }) {
+export default function MemberCard({ member, index }: { member: TeamMemberStats; index: number }) {
   return (
     <div className="h-full rounded-2xl lg:rounded-3xl p-px bg-[linear-gradient(160deg,#E333A366_0%,#077CF14D_50%,#FFB05F80_100%)]">
       <div className="h-full rounded-[15px] lg:rounded-[23px] bg-white overflow-hidden flex flex-col">
@@ -34,7 +35,7 @@ export default function MemberCard({ member }: { member: TeamMemberStats }) {
           <MemberAvatar
             name={member.name}
             imageUrl={member.imageUrl}
-            size={112}
+            color={AVATAR_COLORS[index % AVATAR_COLORS.length]}
             className="w-14 h-14 lg:w-24 lg:h-24 xl:w-28 xl:h-28"
           />
         </div>

--- a/apps/web/src/components/ui/MemberCard.tsx
+++ b/apps/web/src/components/ui/MemberCard.tsx
@@ -1,0 +1,70 @@
+import MemberAvatar from './MemberAvatar'
+import type { TeamMemberStats } from '@/lib/project/weekly-stats'
+
+const STATS = [
+  {
+    key: 'linesCommitted',
+    label: 'Lines committed',
+    shortLabel: 'Lines',
+    tick: 'bg-leaderboard-loc-fill',
+    mobileValue: 'text-leaderboard-loc-fill',
+  },
+  {
+    key: 'commits',
+    label: 'Commits',
+    shortLabel: 'Commits',
+    tick: 'bg-leaderboard-commits-fill',
+    mobileValue: 'text-leaderboard-commits-fill',
+  },
+  {
+    key: 'pullRequests',
+    label: 'Pull requests',
+    shortLabel: 'PRs',
+    tick: 'bg-leaderboard-prs-fill',
+    mobileValue: 'text-leaderboard-prs-fill',
+  },
+] as const
+
+export default function MemberCard({ member }: { member: TeamMemberStats }) {
+  return (
+    <div className="h-full rounded-2xl lg:rounded-3xl p-px bg-[linear-gradient(160deg,#E333A366_0%,#077CF14D_50%,#FFB05F80_100%)]">
+      <div className="h-full rounded-[15px] lg:rounded-[23px] bg-white overflow-hidden flex flex-col">
+        {/* Avatar — banner background on desktop only, per Figma */}
+        <div className="flex justify-center items-center pt-5 lg:pt-0 lg:h-[180px] xl:h-[210px] lg:bg-[linear-gradient(180deg,#F2F5FC_0%,#DCE3F2_100%)]">
+          <MemberAvatar
+            name={member.name}
+            imageUrl={member.imageUrl}
+            size={112}
+            className="w-14 h-14 lg:w-24 lg:h-24 xl:w-28 xl:h-28"
+          />
+        </div>
+
+        <div className="flex flex-col px-4 pb-4 pt-3 lg:px-6 lg:pb-6 lg:pt-5">
+          <p className="font-mono text-base lg:text-xl text-wdcc-oshan text-center lg:text-left truncate">
+            {member.name}
+          </p>
+          <p className="mt-0.5 font-mono text-xs lg:text-sm text-wdcc-grey-light text-center lg:text-left truncate">
+            {member.username ? `@${member.username}` : ' '}
+          </p>
+
+          <div className="mt-3 lg:mt-4 divide-y divide-[#ECEEF6]">
+            {STATS.map((stat) => (
+              <div key={stat.key} className="flex items-center gap-2 py-2 lg:py-2.5">
+                <span className={`hidden lg:block w-1 h-3.5 rounded-full shrink-0 ${stat.tick}`} />
+                <span className="font-mono text-xs lg:text-sm text-wdcc-grey-light whitespace-nowrap">
+                  <span className="lg:hidden">{stat.shortLabel}</span>
+                  <span className="hidden lg:inline">{stat.label}</span>
+                </span>
+                <span
+                  className={`ml-auto font-mono text-sm lg:text-lg ${stat.mobileValue} lg:text-wdcc-oshan`}
+                >
+                  {member[stat.key].toLocaleString()}
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/components/ui/TeamSection.tsx
+++ b/apps/web/src/components/ui/TeamSection.tsx
@@ -1,88 +1,80 @@
 import Link from 'next/link'
 import { ArrowRight } from 'lucide-react'
 import MemberAvatar from './MemberAvatar'
-import ViewAllMembersButton from './ViewAllMembersButton'
-import type { TeamMemberStats } from '@/lib/project/weekly-stats'
+import { AVATAR_COLORS } from '@/lib/project/members'
+import type { ProjectMemberSummary } from '@/lib/project/members'
 
 const MAX_VISIBLE_MEMBERS = 6
 
 /**
- * "The team" section on the project page. Desktop shows a strip of member
- * avatar cards with a link to the full team members page; mobile shows the
- * "View all members" button instead.
+ * Desktop-only team member cards with an overflow "+N" card when there are more members than max.
+ * The header action and the overflow card both link to the project's team members page.
  */
 export default function TeamSection({
   slug,
   members,
 }: {
   slug: string
-  members: TeamMemberStats[]
+  members: ProjectMemberSummary[]
 }) {
+  if (members.length === 0) {
+    return null
+  }
+
   const membersHref = `/project/${slug}/members`
   const visibleMembers = members.slice(0, MAX_VISIBLE_MEMBERS)
   const overflowCount = members.length - visibleMembers.length
 
   return (
-    <>
-      {/* MOBILE */}
-      <ViewAllMembersButton slug={slug} />
-
-      {/* DESKTOP */}
-      <section className="hidden lg:flex w-full flex-col gap-8">
-        <div className="flex items-center justify-between gap-6">
-          <div className="flex items-baseline gap-4 min-w-0">
-            <h2 className="text-2xl lg:text-4xl font-extrabold whitespace-nowrap">The team</h2>
-            <span className="font-mono text-base text-wdcc-grey-light truncate">
-              {members.length} contributor{members.length !== 1 ? 's' : ''}
-            </span>
-          </div>
-
-          <Link
-            href={membersHref}
-            className="flex items-center gap-3 rounded-full bg-wdcc-oshan px-6 py-3 text-white font-sans text-base font-semibold whitespace-nowrap shrink-0 transition-transform duration-200 hover:scale-[1.03]"
-          >
-            View all members
-            <ArrowRight className="w-5 h-5" />
-          </Link>
+    <section className="hidden lg:block w-full">
+      <div className="flex items-center justify-between">
+        <div className="flex items-baseline gap-4">
+          <h2 className="text-3xl font-extrabold">The team</h2>
+          <p className="font-mono text-lg text-wdcc-grey-light">
+            {members.length} contributor{members.length !== 1 && 's'}
+          </p>
         </div>
 
-        {members.length > 0 && (
-          <div className="flex gap-4">
-            {visibleMembers.map((member) => (
-              <div
-                key={member.id}
-                className="flex-1 min-w-0 flex flex-col rounded-xl border border-[#E4E7F0] bg-white overflow-hidden"
-              >
-                <div className="flex justify-center items-center py-6 bg-[#F1F3F9]">
-                  <MemberAvatar
-                    name={member.name}
-                    imageUrl={member.imageUrl}
-                    size={64}
-                    className="w-16 h-16"
-                  />
-                </div>
-                <p className="font-mono text-xs text-wdcc-oshan text-center px-2 py-3 truncate">
-                  {member.name}
-                </p>
-              </div>
-            ))}
+        <Link
+          href={membersHref}
+          className="flex items-center gap-3 rounded-full bg-wdcc-oshan px-7 py-4 font-sans text-xl font-medium text-white transition-transform duration-200 hover:scale-[1.03]"
+        >
+          View all members
+          <ArrowRight className="w-5 h-5" />
+        </Link>
+      </div>
 
-            {overflowCount > 0 && (
-              <Link
-                href={membersHref}
-                className="flex-1 min-w-0 flex flex-col rounded-xl border border-[#E4E7F0] bg-white overflow-hidden transition-transform duration-200 hover:scale-[1.03]"
-              >
-                <div className="flex-1 flex justify-center items-center py-6 bg-wdcc-oshan">
-                  <span className="font-sans text-2xl font-bold text-white">+{overflowCount}</span>
-                </div>
-                <p className="font-mono text-xs text-wdcc-blue text-center px-2 py-3 whitespace-nowrap">
-                  View all ›
-                </p>
-              </Link>
-            )}
+      <div className="mt-8 flex gap-4">
+        {visibleMembers.map((member, index) => (
+          <div
+            key={member.id}
+            className="flex-1 min-w-0 overflow-hidden rounded-2xl border border-[#E9EBF4] bg-white shadow-[0_4px_16px_rgba(0,0,0,0.1)]"
+          >
+            <div className="flex h-[140px] items-end justify-center bg-[#E9EBF4] xl:h-[170px]">
+              <MemberAvatar
+                name={member.name}
+                imageUrl={member.imageUrl}
+                color={AVATAR_COLORS[index % AVATAR_COLORS.length]}
+                className="w-36 h-36"
+              />
+            </div>
+            <p className="truncate px-2 py-3 text-center font-mono">{member.name}</p>
           </div>
+        ))}
+
+        {overflowCount > 0 && (
+          <Link
+            href={membersHref}
+            aria-label={`View all ${members.length} members`}
+            className="flex flex-1 min-w-0 flex-col overflow-hidden rounded-2xl border border-[#E9EBF4] bg-white shadow-[0_4px_16px_rgba(0,0,0,0.1)] transition-transform duration-200 hover:scale-[1.03]"
+          >
+            <span className="flex w-full flex-1 items-center justify-center bg-wdcc-oshan text-3xl font-extrabold text-white xl:text-4xl">
+              +{overflowCount}
+            </span>
+            <span className="w-full py-3 text-center font-mono text-wdcc-blue">View all ›</span>
+          </Link>
         )}
-      </section>
-    </>
+      </div>
+    </section>
   )
 }

--- a/apps/web/src/components/ui/TeamSection.tsx
+++ b/apps/web/src/components/ui/TeamSection.tsx
@@ -1,72 +1,88 @@
+import Link from 'next/link'
 import { ArrowRight } from 'lucide-react'
 import MemberAvatar from './MemberAvatar'
-import { AVATAR_COLORS } from '@/lib/project/members'
-import type { ProjectMemberSummary } from '@/lib/project/members'
+import ViewAllMembersButton from './ViewAllMembersButton'
+import type { TeamMemberStats } from '@/lib/project/weekly-stats'
 
 const MAX_VISIBLE_MEMBERS = 6
 
 /**
- * Desktop-only team member cards with an overflow "+N" card when there are more members than max.
+ * "The team" section on the project page. Desktop shows a strip of member
+ * avatar cards with a link to the full team members page; mobile shows the
+ * "View all members" button instead.
  */
-export default function TeamSection({ members }: { members: ProjectMemberSummary[] }) {
-  if (members.length === 0) {
-    return null
-  }
-
+export default function TeamSection({
+  slug,
+  members,
+}: {
+  slug: string
+  members: TeamMemberStats[]
+}) {
+  const membersHref = `/project/${slug}/members`
   const visibleMembers = members.slice(0, MAX_VISIBLE_MEMBERS)
   const overflowCount = members.length - visibleMembers.length
 
   return (
-    <section className="hidden lg:block w-full">
-      <div className="flex items-center justify-between">
-        <div className="flex items-baseline gap-4">
-          <h2 className="text-3xl font-extrabold">The team</h2>
-          <p className="font-mono text-lg text-wdcc-grey-light">
-            {members.length} contributor{members.length !== 1 && 's'}
-          </p>
+    <>
+      {/* MOBILE */}
+      <ViewAllMembersButton slug={slug} />
+
+      {/* DESKTOP */}
+      <section className="hidden lg:flex w-full flex-col gap-8">
+        <div className="flex items-center justify-between gap-6">
+          <div className="flex items-baseline gap-4 min-w-0">
+            <h2 className="text-2xl lg:text-4xl font-extrabold whitespace-nowrap">The team</h2>
+            <span className="font-mono text-base text-wdcc-grey-light truncate">
+              {members.length} contributor{members.length !== 1 ? 's' : ''}
+            </span>
+          </div>
+
+          <Link
+            href={membersHref}
+            className="flex items-center gap-3 rounded-full bg-wdcc-oshan px-6 py-3 text-white font-sans text-base font-semibold whitespace-nowrap shrink-0 transition-transform duration-200 hover:scale-[1.03]"
+          >
+            View all members
+            <ArrowRight className="w-5 h-5" />
+          </Link>
         </div>
 
-        <button
-          type="button"
-          aria-label="View all members (coming soon)"
-          className="flex items-center gap-3 rounded-full bg-wdcc-oshan px-7 py-4 font-sans text-xl font-medium text-white cursor-default"
-        >
-          View all members
-          <ArrowRight className="w-5 h-5" />
-        </button>
-      </div>
+        {members.length > 0 && (
+          <div className="flex gap-4">
+            {visibleMembers.map((member) => (
+              <div
+                key={member.id}
+                className="flex-1 min-w-0 flex flex-col rounded-xl border border-[#E4E7F0] bg-white overflow-hidden"
+              >
+                <div className="flex justify-center items-center py-6 bg-[#F1F3F9]">
+                  <MemberAvatar
+                    name={member.name}
+                    imageUrl={member.imageUrl}
+                    size={64}
+                    className="w-16 h-16"
+                  />
+                </div>
+                <p className="font-mono text-xs text-wdcc-oshan text-center px-2 py-3 truncate">
+                  {member.name}
+                </p>
+              </div>
+            ))}
 
-      <div className="mt-8 flex gap-4">
-        {visibleMembers.map((member, index) => (
-          <div
-            key={member.id}
-            className="flex-1 min-w-0 overflow-hidden rounded-2xl border border-[#E9EBF4] bg-white shadow-[0_4px_16px_rgba(0,0,0,0.1)]"
-          >
-            <div className="flex h-[140px] items-end justify-center bg-[#E9EBF4] xl:h-[170px]">
-              <MemberAvatar
-                name={member.name}
-                imageUrl={member.imageUrl}
-                color={AVATAR_COLORS[index % AVATAR_COLORS.length]}
-                className="w-36 h-36"
-              />
-            </div>
-            <p className="truncate px-2 py-3 text-center font-mono">{member.name}</p>
+            {overflowCount > 0 && (
+              <Link
+                href={membersHref}
+                className="flex-1 min-w-0 flex flex-col rounded-xl border border-[#E4E7F0] bg-white overflow-hidden transition-transform duration-200 hover:scale-[1.03]"
+              >
+                <div className="flex-1 flex justify-center items-center py-6 bg-wdcc-oshan">
+                  <span className="font-sans text-2xl font-bold text-white">+{overflowCount}</span>
+                </div>
+                <p className="font-mono text-xs text-wdcc-blue text-center px-2 py-3 whitespace-nowrap">
+                  View all ›
+                </p>
+              </Link>
+            )}
           </div>
-        ))}
-
-        {overflowCount > 0 && (
-          <button
-            type="button"
-            aria-label={`View all ${members.length} members`}
-            className="flex flex-1 min-w-0 flex-col overflow-hidden rounded-2xl border border-[#E9EBF4] bg-white shadow-[0_4px_16px_rgba(0,0,0,0.1)] cursor-default"
-          >
-            <span className="flex w-full flex-1 items-center justify-center bg-wdcc-oshan text-3xl font-extrabold text-white xl:text-4xl">
-              +{overflowCount}
-            </span>
-            <span className="w-full py-3 text-center font-mono text-wdcc-blue">View all ›</span>
-          </button>
         )}
-      </div>
-    </section>
+      </section>
+    </>
   )
 }

--- a/apps/web/src/components/ui/ViewAllMembersButton.tsx
+++ b/apps/web/src/components/ui/ViewAllMembersButton.tsx
@@ -1,21 +1,45 @@
 import Link from 'next/link'
 import { ArrowRight } from 'lucide-react'
+import MemberAvatar from './MemberAvatar'
+import { AVATAR_COLORS } from '@/lib/project/members'
+import type { ProjectMemberSummary } from '@/lib/project/members'
+
+const MAX_PREVIEW_AVATARS = 3
 
 /**
- * Mobile-only "View all members" link to the project's team members page.
+ * Mobile-only link to the project's team members page, showing a preview of the
+ * first few members' avatars.
  */
-export default function ViewAllMembersButton({ slug }: { slug: string }) {
+export default function ViewAllMembersButton({
+  slug,
+  members,
+}: {
+  slug: string
+  members: ProjectMemberSummary[]
+}) {
+  const previewMembers = members.slice(0, MAX_PREVIEW_AVATARS)
+
   return (
     <Link
       href={`/project/${slug}/members`}
+      aria-label="View all members"
       className="lg:hidden w-full flex items-center gap-4 rounded-2xl bg-wdcc-oshan px-6 py-5 text-white"
     >
-      <div className="flex items-center -space-x-2 shrink-0">
-        <span className="w-6 h-6 rounded-full border-2 border-wdcc-oshan bg-[#077CF1]" />
-        <span className="w-6 h-6 rounded-full border-2 border-wdcc-oshan bg-[#E333A3]" />
-        <span className="w-6 h-6 rounded-full border-2 border-wdcc-oshan bg-[#FFB05F]" />
-      </div>
-      <span className="font-sans text-base font-semibold">View all members</span>
+      {previewMembers.length > 0 && (
+        <div className="flex items-center -space-x-2 shrink-0">
+          {previewMembers.map((member, index) => (
+            <MemberAvatar
+              key={member.id}
+              name={member.name}
+              imageUrl={member.imageUrl}
+              color={AVATAR_COLORS[index % AVATAR_COLORS.length]}
+              fallback="dot"
+              className="w-6 h-6 rounded-full border-2 border-wdcc-oshan"
+            />
+          ))}
+        </div>
+      )}
+      <span className="font-sans text-sm font-semibold">View all members</span>
       <ArrowRight className="ml-auto w-5 h-5 shrink-0" />
     </Link>
   )

--- a/apps/web/src/components/ui/ViewAllMembersButton.tsx
+++ b/apps/web/src/components/ui/ViewAllMembersButton.tsx
@@ -1,38 +1,22 @@
+import Link from 'next/link'
 import { ArrowRight } from 'lucide-react'
-import MemberAvatar from './MemberAvatar'
-import { AVATAR_COLORS } from '@/lib/project/members'
-import type { ProjectMemberSummary } from '@/lib/project/members'
-
-const MAX_PREVIEW_AVATARS = 3
 
 /**
- * Mobile-only "View all members" button showing a preview of the first few members' avatars.
+ * Mobile-only "View all members" link to the project's team members page.
  */
-export default function ViewAllMembersButton({ members }: { members: ProjectMemberSummary[] }) {
-  const previewMembers = members.slice(0, MAX_PREVIEW_AVATARS)
-
+export default function ViewAllMembersButton({ slug }: { slug: string }) {
   return (
-    <button
-      type="button"
-      aria-label="View all members"
-      className="lg:hidden w-full flex items-center gap-4 rounded-2xl bg-wdcc-oshan px-6 py-5 text-white cursor-default"
+    <Link
+      href={`/project/${slug}/members`}
+      className="lg:hidden w-full flex items-center gap-4 rounded-2xl bg-wdcc-oshan px-6 py-5 text-white"
     >
-      {previewMembers.length > 0 && (
-        <div className="flex items-center -space-x-2 shrink-0">
-          {previewMembers.map((member, index) => (
-            <MemberAvatar
-              key={member.id}
-              name={member.name}
-              imageUrl={member.imageUrl}
-              color={AVATAR_COLORS[index % AVATAR_COLORS.length]}
-              fallback="dot"
-              className="w-6 h-6 rounded-full border-2 border-wdcc-oshan"
-            />
-          ))}
-        </div>
-      )}
-      <span className="font-sans text-sm font-semibold">View all members</span>
+      <div className="flex items-center -space-x-2 shrink-0">
+        <span className="w-6 h-6 rounded-full border-2 border-wdcc-oshan bg-[#077CF1]" />
+        <span className="w-6 h-6 rounded-full border-2 border-wdcc-oshan bg-[#E333A3]" />
+        <span className="w-6 h-6 rounded-full border-2 border-wdcc-oshan bg-[#FFB05F]" />
+      </div>
+      <span className="font-sans text-base font-semibold">View all members</span>
       <ArrowRight className="ml-auto w-5 h-5 shrink-0" />
-    </button>
+    </Link>
   )
 }

--- a/apps/web/src/lib/project/weekly-stats.ts
+++ b/apps/web/src/lib/project/weekly-stats.ts
@@ -51,9 +51,10 @@ export interface TeamMemberStats {
 }
 
 /**
- * All active members of a project with their contribution stats for the most
- * recent collected week, ranked by lines committed (ties broken by commits,
- * then name). Members with no contribution row for the week show zeros.
+ * All active members of a project with their contribution stats for that
+ * project's most recent collected week, ranked by lines committed (ties broken
+ * by commits, then name). Members with no contribution row for the week show
+ * zeros.
  */
 export async function getProjectTeamMembers(slug: string): Promise<TeamMemberStats[]> {
   const members = await db.projectMember.findMany({
@@ -75,7 +76,13 @@ export async function getProjectTeamMembers(slug: string): Promise<TeamMemberSta
   })
   if (members.length === 0) return []
 
+  const memberIds = members.map((m) => m.id)
+
+  // Scoped to this project's members rather than the global max weekStart: if this
+  // project's sync fails for a week that another project collected, a global max
+  // would resolve to a week this project has no rows for and zero out every member.
   const latest = await db.memberWeeklyContribution.findFirst({
+    where: { projectMemberId: { in: memberIds } },
     orderBy: { weekStart: 'desc' },
     select: { weekStart: true },
   })
@@ -84,7 +91,7 @@ export async function getProjectTeamMembers(slug: string): Promise<TeamMemberSta
     ? await db.memberWeeklyContribution.findMany({
         where: {
           weekStart: latest.weekStart,
-          projectMemberId: { in: members.map((m) => m.id) },
+          projectMemberId: { in: memberIds },
         },
         select: { projectMemberId: true, linesAdded: true, commits: true, prsMerged: true },
       })

--- a/apps/web/src/lib/project/weekly-stats.ts
+++ b/apps/web/src/lib/project/weekly-stats.ts
@@ -40,6 +40,76 @@ export async function getProjectWeeklyMvp(slug: string) {
   })
 }
 
+export interface TeamMemberStats {
+  id: string
+  name: string
+  username: string | null
+  imageUrl: string | null
+  linesCommitted: number
+  commits: number
+  pullRequests: number
+}
+
+/**
+ * All active members of a project with their contribution stats for the most
+ * recent collected week, ranked by lines committed (ties broken by commits,
+ * then name). Members with no contribution row for the week show zeros.
+ */
+export async function getProjectTeamMembers(slug: string): Promise<TeamMemberStats[]> {
+  const members = await db.projectMember.findMany({
+    where: { project: { slug }, isActive: true },
+    select: {
+      id: true,
+      displayName: true,
+      person: {
+        select: {
+          displayName: true,
+          imageUrl: true,
+          identities: {
+            where: { provider: 'GITHUB' },
+            select: { username: true },
+          },
+        },
+      },
+    },
+  })
+  if (members.length === 0) return []
+
+  const latest = await db.memberWeeklyContribution.findFirst({
+    orderBy: { weekStart: 'desc' },
+    select: { weekStart: true },
+  })
+
+  const contributions = latest
+    ? await db.memberWeeklyContribution.findMany({
+        where: {
+          weekStart: latest.weekStart,
+          projectMemberId: { in: members.map((m) => m.id) },
+        },
+        select: { projectMemberId: true, linesAdded: true, commits: true, prsMerged: true },
+      })
+    : []
+  const contributionsByMember = new Map(contributions.map((c) => [c.projectMemberId, c]))
+
+  return members
+    .map((m) => {
+      const contribution = contributionsByMember.get(m.id)
+      return {
+        id: m.id,
+        name: m.displayName ?? m.person.displayName,
+        username: m.person.identities[0]?.username ?? null,
+        imageUrl: m.person.imageUrl,
+        linesCommitted: contribution?.linesAdded ?? 0,
+        commits: contribution?.commits ?? 0,
+        pullRequests: contribution?.prsMerged ?? 0,
+      }
+    })
+    .sort(
+      (a, b) =>
+        b.linesCommitted - a.linesCommitted || b.commits - a.commits || a.name.localeCompare(b.name)
+    )
+}
+
 export interface ProjectWeeklyStats {
   dates: string[]
   commits: number[]


### PR DESCRIPTION
## Description

Adds the team member page and the member card on the projects page.

## Solution

Implemented the design according to figma.
Desktop member card:
<img width="1409" height="724" alt="image" src="https://github.com/user-attachments/assets/e05057fe-a9a2-4e13-b9d8-7c27ce3efe70" />

Desktop team member page:
<img width="1409" height="1208" alt="image" src="https://github.com/user-attachments/assets/784087e4-16ec-45a1-8ccc-d09eb29f6d44" />

Mobile member card:
<img width="409" height="283" alt="image" src="https://github.com/user-attachments/assets/b43186d8-5675-49d9-b877-10d4a47fd196" />

Mobile team member page:
<img width="412" height="921" alt="image" src="https://github.com/user-attachments/assets/d3949cf0-59b5-4c0f-b649-5a16255b0936" />



## Notes

