### PR TITLE
[#221] View Member Button

### DIFF
--- a/apps/web/src/app/(public)/project/[slug]/page.tsx
+++ b/apps/web/src/app/(public)/project/[slug]/page.tsx
@@ -1,16 +1,19 @@
 import TeamHeader from '@/components/headers/TeamHeader'
 import WeeklyMvp from '@/components/ui/WeeklyMvp'
+import TeamSection from '@/components/ui/TeamSection'
 import ViewAllMembersButton from '@/components/ui/ViewAllMembersButton'
 import { getProjectHeaderData } from '@/lib/project/projects'
+import { getProjectMembers } from '@/lib/project/members'
 import { getProjectWeeklyMvp } from '@/lib/project/weekly-stats'
 import { notFound } from 'next/navigation'
 import GraphViewToggle from '@/components/charts/GraphViewToggle'
 
 export default async function ProjectPage({ params }: { params: Promise<{ slug: string }> }) {
   const slug = (await params).slug
-  const [project, mvp] = await Promise.all([
+  const [project, mvp, members] = await Promise.all([
     getProjectHeaderData(slug),
     getProjectWeeklyMvp(slug).catch(() => null),
+    getProjectMembers(slug).catch(() => []),
   ])
 
   if (!project) {
@@ -36,7 +39,8 @@ export default async function ProjectPage({ params }: { params: Promise<{ slug: 
           </div>
         )}
 
-        <ViewAllMembersButton />
+        <TeamSection members={members} />
+        <ViewAllMembersButton members={members} />
 
         <GraphViewToggle slug={slug} />
       </div>

--- a/apps/web/src/components/ui/MemberAvatar.tsx
+++ b/apps/web/src/components/ui/MemberAvatar.tsx
@@ -1,0 +1,55 @@
+'use client'
+
+import { useState } from 'react'
+import Image from 'next/image'
+import { cn } from '@/lib/utils'
+
+interface MemberAvatarProps {
+  name: string
+  imageUrl: string | null
+  color: string
+  // What to render when there is no photo: a person silhouette for desktop view or a solid dot for mobile view
+  fallback?: 'silhouette' | 'dot'
+  className?: string
+}
+
+export default function MemberAvatar({
+  name,
+  imageUrl,
+  color,
+  fallback = 'silhouette',
+  className,
+}: MemberAvatarProps) {
+  const [imgError, setImgError] = useState(false)
+
+  if (imageUrl && !imgError) {
+    return (
+      <Image
+        src={imageUrl}
+        alt={name}
+        width={96}
+        height={96}
+        className={cn('rounded-full object-cover', className)}
+        onError={() => setImgError(true)}
+      />
+    )
+  }
+
+  if (fallback === 'dot') {
+    return (
+      <span
+        aria-label={name}
+        role="img"
+        className={cn('block rounded-full', className)}
+        style={{ backgroundColor: color }}
+      />
+    )
+  }
+
+  return (
+    <svg viewBox="0 0 96 96" role="img" aria-label={name} className={className}>
+      <circle cx="48" cy="30" r="22" fill={color} />
+      <path d="M48 58c-23 0-36 15-38 38h76c-2-23-15-38-38-38z" fill={color} />
+    </svg>
+  )
+}

--- a/apps/web/src/components/ui/TeamSection.tsx
+++ b/apps/web/src/components/ui/TeamSection.tsx
@@ -1,0 +1,72 @@
+import { ArrowRight } from 'lucide-react'
+import MemberAvatar from './MemberAvatar'
+import { AVATAR_COLORS } from '@/lib/project/members'
+import type { ProjectMemberSummary } from '@/lib/project/members'
+
+const MAX_VISIBLE_MEMBERS = 6
+
+/**
+ * Desktop-only team member cards with an overflow "+N" card when there are more members than max.
+ */
+export default function TeamSection({ members }: { members: ProjectMemberSummary[] }) {
+  if (members.length === 0) {
+    return null
+  }
+
+  const visibleMembers = members.slice(0, MAX_VISIBLE_MEMBERS)
+  const overflowCount = members.length - visibleMembers.length
+
+  return (
+    <section className="hidden lg:block w-full">
+      <div className="flex items-center justify-between">
+        <div className="flex items-baseline gap-4">
+          <h2 className="text-3xl font-extrabold">The team</h2>
+          <p className="font-mono text-lg text-wdcc-grey-light">
+            {members.length} contributor{members.length !== 1 && 's'}
+          </p>
+        </div>
+
+        <button
+          type="button"
+          aria-label="View all members (coming soon)"
+          className="flex items-center gap-3 rounded-full bg-wdcc-oshan px-7 py-4 font-sans text-xl font-medium text-white cursor-default"
+        >
+          View all members
+          <ArrowRight className="w-5 h-5" />
+        </button>
+      </div>
+
+      <div className="mt-8 flex gap-4">
+        {visibleMembers.map((member, index) => (
+          <div
+            key={member.id}
+            className="flex-1 min-w-0 overflow-hidden rounded-2xl border border-[#E9EBF4] bg-white shadow-[0_4px_16px_rgba(0,0,0,0.1)]"
+          >
+            <div className="flex h-[140px] items-end justify-center bg-[#E9EBF4] xl:h-[170px]">
+              <MemberAvatar
+                name={member.name}
+                imageUrl={member.imageUrl}
+                color={AVATAR_COLORS[index % AVATAR_COLORS.length]}
+                className="w-36 h-36"
+              />
+            </div>
+            <p className="truncate px-2 py-3 text-center font-mono">{member.name}</p>
+          </div>
+        ))}
+
+        {overflowCount > 0 && (
+          <button
+            type="button"
+            aria-label={`View all ${members.length} members`}
+            className="flex flex-1 min-w-0 flex-col overflow-hidden rounded-2xl border border-[#E9EBF4] bg-white shadow-[0_4px_16px_rgba(0,0,0,0.1)] cursor-default"
+          >
+            <span className="flex w-full flex-1 items-center justify-center bg-wdcc-oshan text-3xl font-extrabold text-white xl:text-4xl">
+              +{overflowCount}
+            </span>
+            <span className="w-full py-3 text-center font-mono text-wdcc-blue">View all ›</span>
+          </button>
+        )}
+      </div>
+    </section>
+  )
+}

--- a/apps/web/src/components/ui/ViewAllMembersButton.tsx
+++ b/apps/web/src/components/ui/ViewAllMembersButton.tsx
@@ -1,21 +1,37 @@
 import { ArrowRight } from 'lucide-react'
+import MemberAvatar from './MemberAvatar'
+import { AVATAR_COLORS } from '@/lib/project/members'
+import type { ProjectMemberSummary } from '@/lib/project/members'
+
+const MAX_PREVIEW_AVATARS = 3
 
 /**
- * Mobile-only "View all members" button.
+ * Mobile-only "View all members" button showing a preview of the first few members' avatars.
  */
-export default function ViewAllMembersButton() {
+export default function ViewAllMembersButton({ members }: { members: ProjectMemberSummary[] }) {
+  const previewMembers = members.slice(0, MAX_PREVIEW_AVATARS)
+
   return (
     <button
       type="button"
-      aria-label="View all members (coming soon)"
+      aria-label="View all members"
       className="lg:hidden w-full flex items-center gap-4 rounded-2xl bg-wdcc-oshan px-6 py-5 text-white cursor-default"
     >
-      <div className="flex items-center -space-x-2 shrink-0">
-        <span className="w-6 h-6 rounded-full border-2 border-wdcc-oshan bg-[#077CF1]" />
-        <span className="w-6 h-6 rounded-full border-2 border-wdcc-oshan bg-[#E333A3]" />
-        <span className="w-6 h-6 rounded-full border-2 border-wdcc-oshan bg-[#FFB05F]" />
-      </div>
-      <span className="font-sans text-base font-semibold">View all members</span>
+      {previewMembers.length > 0 && (
+        <div className="flex items-center -space-x-2 shrink-0">
+          {previewMembers.map((member, index) => (
+            <MemberAvatar
+              key={member.id}
+              name={member.name}
+              imageUrl={member.imageUrl}
+              color={AVATAR_COLORS[index % AVATAR_COLORS.length]}
+              fallback="dot"
+              className="w-6 h-6 rounded-full border-2 border-wdcc-oshan"
+            />
+          ))}
+        </div>
+      )}
+      <span className="font-sans text-sm font-semibold">View all members</span>
       <ArrowRight className="ml-auto w-5 h-5 shrink-0" />
     </button>
   )

--- a/apps/web/src/lib/project/members.ts
+++ b/apps/web/src/lib/project/members.ts
@@ -1,0 +1,36 @@
+import { db } from '@repo/db'
+import { unstable_cacheLife, unstable_cacheTag } from 'next/cache'
+
+export const AVATAR_COLORS = ['#077CF1', '#4CAF64', '#E333A3', '#F2A33C', '#9A63F0', '#48A6A6']
+
+export interface ProjectMemberSummary {
+  id: string
+  name: string
+  imageUrl: string | null
+}
+
+export async function getProjectMembers(slug: string): Promise<ProjectMemberSummary[]> {
+  'use cache'
+  unstable_cacheLife('days')
+  unstable_cacheTag('projects')
+
+  const members = await db.projectMember.findMany({
+    where: { project: { slug }, isActive: true },
+    select: {
+      id: true,
+      displayName: true,
+      person: {
+        select: {
+          displayName: true,
+          imageUrl: true,
+        },
+      },
+    },
+  })
+
+  return members.map((member) => ({
+    id: member.id,
+    name: member.displayName ?? member.person.displayName,
+    imageUrl: member.person.imageUrl,
+  }))
+}


### PR DESCRIPTION
## Description

- Built the view all members preview button

## Solution

- On desktop, it shows the first 6 members and a +N with N being the extra amount of members
- On mobile, it shows three avatar circles in the box in the view members button
- Colours and design used match the figma design

## Notes

- Configured to have 6 member cards at max on desktop and 3 avatars at max on mobile
- Colours used are hardcoded in member.ts

<img width="1831" height="342" alt="image" src="https://github.com/user-attachments/assets/5da12564-e00b-4129-9998-4146713c4665" />

<img width="288" height="75" alt="image" src="https://github.com/user-attachments/assets/376ed4e8-4aac-4a00-9b46-4a38650716f4" />
