### PR TITLE
[#204] branch commit walk looks back 2 weeks to catch late commits

### DIFF
--- a/apps/worker/src/jobs/github.ts
+++ b/apps/worker/src/jobs/github.ts
@@ -39,7 +39,7 @@ export async function runGitHubIngestion(weekStart: Date, weekEnd: Date): Promis
         }
 
         try {
-          const commitCount = await ingestRepoCommits(repo)
+          const commitCount = await ingestRepoCommits(repo, weekEnd)
           totalProcessed += commitCount
         } catch (err) {
           logger.error(`Failed to ingest commits for ${repo.owner}/${repo.name}: ${err}`)

--- a/apps/worker/src/lib/github-commit-tracker.integration.test.ts
+++ b/apps/worker/src/lib/github-commit-tracker.integration.test.ts
@@ -68,6 +68,10 @@ function setupOctokit(
   return { mockPaginate, mockRequest, mockOctokit }
 }
 
+// Current week = Mon 2026-05-04 .. Sun 2026-05-10; the branch walk's 2-week lookback
+// therefore starts on Mon 2026-04-27.
+const weekEnd = new Date('2026-05-10T23:59:59Z')
+
 describe('github-commit-tracker (integration)', () => {
   beforeEach(async () => {
     vi.clearAllMocks()
@@ -198,7 +202,7 @@ describe('github-commit-tracker (integration)', () => {
         ]
       )
 
-      await ingestRepoCommits(repo)
+      await ingestRepoCommits(repo, weekEnd)
 
       expect(mockPaginate).toHaveBeenCalledTimes(2)
       const paginateCalls = mockPaginate.mock.calls
@@ -212,7 +216,7 @@ describe('github-commit-tracker (integration)', () => {
       expect(savedCommit!.message).toBe('Feature work')
     })
 
-    it('ingests all commits from compare endpoint regardless of author date', async () => {
+    it('ingests commits within the 2-week lookback and skips older ones', async () => {
       const repo = await seedRepo()
       const identity = await seedIdentity(333, 'newdev')
       vi.mocked(resolveIdentity).mockResolvedValue(identity.id)
@@ -231,17 +235,12 @@ describe('github-commit-tracker (integration)', () => {
             author: { id: 333, login: 'newdev' },
             commit: { message: 'New commit', author: { date: '2026-05-07T10:00:00Z' } },
           }),
-          makeCommitData({
-            sha: 'old-commit',
-            author: { id: 333, login: 'newdev' },
-            commit: { message: 'Old commit', author: { date: '2026-01-01T10:00:00Z' } },
-          }),
         ]
       )
 
-      const totalCommits = await ingestRepoCommits(repo)
+      const totalCommits = await ingestRepoCommits(repo, weekEnd)
 
-      expect(totalCommits).toBe(2)
+      expect(totalCommits).toBe(1)
 
       const savedNew = await db.commitFact.findUnique({
         where: { repoId_sha: { repoId: repo.id, sha: 'new-commit' } },
@@ -249,10 +248,41 @@ describe('github-commit-tracker (integration)', () => {
       expect(savedNew).not.toBeNull()
       expect(savedNew!.authorIdentityId).toBe(identity.id)
 
+      // Authored before the lookback window (Mon 2026-04-27) — must not be ingested.
       const savedOld = await db.commitFact.findUnique({
         where: { repoId_sha: { repoId: repo.id, sha: 'old-commit' } },
       })
-      expect(savedOld).not.toBeNull()
+      expect(savedOld).toBeNull()
+    })
+
+    it('captures a prior-week commit pushed late to a branch with no PR', async () => {
+      const repo = await seedRepo()
+      const identity = await seedIdentity(444, 'latedev')
+      vi.mocked(resolveIdentity).mockResolvedValue(identity.id)
+
+      setupOctokit(
+        [
+          [{ name: 'feature' }],
+          [{ sha: 'late-commit', commit: { author: { date: '2026-04-29T10:00:00Z' } } }],
+        ],
+        [
+          makeCommitData({
+            sha: 'late-commit',
+            author: { id: 444, login: 'latedev' },
+            commit: { message: 'Prior-week work', author: { date: '2026-04-29T10:00:00Z' } },
+          }),
+        ]
+      )
+
+      const totalCommits = await ingestRepoCommits(repo, weekEnd)
+
+      expect(totalCommits).toBe(1)
+
+      const saved = await db.commitFact.findUnique({
+        where: { repoId_sha: { repoId: repo.id, sha: 'late-commit' } },
+      })
+      expect(saved).not.toBeNull()
+      expect(saved!.branch).toBe('feature')
     })
 
     it('handles repos with no commits in the window', async () => {
@@ -263,7 +293,7 @@ describe('github-commit-tracker (integration)', () => {
         []
       )
 
-      const totalCommits = await ingestRepoCommits(repo)
+      const totalCommits = await ingestRepoCommits(repo, weekEnd)
 
       expect(totalCommits).toBe(0)
       expect(mockPaginate).toHaveBeenCalledTimes(3)

--- a/apps/worker/src/lib/github-commit-tracker.integration.test.ts
+++ b/apps/worker/src/lib/github-commit-tracker.integration.test.ts
@@ -285,6 +285,44 @@ describe('github-commit-tracker (integration)', () => {
       expect(saved!.branch).toBe('feature')
     })
 
+    it('skips commits authored after weekEnd when the job runs late', async () => {
+      const repo = await seedRepo()
+      const identity = await seedIdentity(555, 'futuredev')
+      vi.mocked(resolveIdentity).mockResolvedValue(identity.id)
+
+      setupOctokit(
+        [
+          [{ name: 'feature' }],
+          [
+            { sha: 'in-window-commit', commit: { author: { date: '2026-05-07T10:00:00Z' } } },
+            { sha: 'future-commit', commit: { author: { date: '2026-05-20T10:00:00Z' } } },
+          ],
+        ],
+        [
+          makeCommitData({
+            sha: 'in-window-commit',
+            author: { id: 555, login: 'futuredev' },
+            commit: { message: 'In-window work', author: { date: '2026-05-07T10:00:00Z' } },
+          }),
+        ]
+      )
+
+      const totalCommits = await ingestRepoCommits(repo, weekEnd)
+
+      expect(totalCommits).toBe(1)
+
+      const savedInWindow = await db.commitFact.findUnique({
+        where: { repoId_sha: { repoId: repo.id, sha: 'in-window-commit' } },
+      })
+      expect(savedInWindow).not.toBeNull()
+
+      // Authored after weekEnd (Sun 2026-05-10) — belongs to a later week, must not be ingested.
+      const savedFuture = await db.commitFact.findUnique({
+        where: { repoId_sha: { repoId: repo.id, sha: 'future-commit' } },
+      })
+      expect(savedFuture).toBeNull()
+    })
+
     it('handles repos with no commits in the window', async () => {
       const repo = await seedRepo()
 

--- a/apps/worker/src/lib/github-commit-tracker.test.ts
+++ b/apps/worker/src/lib/github-commit-tracker.test.ts
@@ -183,6 +183,27 @@ describe('ingestRepoCommits (unit, no DB)', () => {
     ])
   })
 
+  it('skips commits authored after weekEnd (e.g. when the job runs late)', async () => {
+    mockOctokit({
+      defaultBranch: 'main',
+      branches: [{ name: 'main' }, { name: 'feature' }],
+      compareByBasehead: {
+        'main...feature': [
+          // Authored within the window — captured.
+          { sha: 'in-window-commit', commit: { author: { date: '2026-05-07T10:00:00Z' } } },
+          // Authored after weekEnd (Sun 2026-05-10); belongs to a later week, so it must be
+          // skipped even though the compare endpoint returns it when the job runs late.
+          { sha: 'future-commit', commit: { author: { date: '2026-05-20T10:00:00Z' } } },
+        ],
+      },
+    })
+
+    const total = await ingestRepoCommits(repo, weekEnd)
+
+    expect(total).toBe(1)
+    expect(upsertCalls()).toEqual([{ sha: 'in-window-commit', branch: 'feature' }])
+  })
+
   it('keeps commits that have no author date rather than dropping them', async () => {
     mockOctokit({
       defaultBranch: 'main',

--- a/apps/worker/src/lib/github-commit-tracker.test.ts
+++ b/apps/worker/src/lib/github-commit-tracker.test.ts
@@ -34,6 +34,10 @@ const repo = {
   installationId: '123',
 }
 
+// Current week = Mon 2026-05-04 .. Sun 2026-05-10; the branch walk's 2-week lookback
+// therefore starts on Mon 2026-04-27. Commits authored on/after that date are ingested.
+const weekEnd = new Date('2026-05-10T23:59:59Z')
+
 function makeCommitDetail(sha: string, date = '2026-05-05T10:00:00Z') {
   return {
     sha,
@@ -98,7 +102,7 @@ describe('ingestRepoCommits (unit, no DB)', () => {
       },
     })
 
-    await ingestRepoCommits(repo)
+    await ingestRepoCommits(repo, weekEnd)
 
     const routesCalled = paginate.mock.calls.map((c) => c[0])
     expect(routesCalled).toContain('GET /repos/{owner}/{repo}/compare/{basehead}')
@@ -122,7 +126,7 @@ describe('ingestRepoCommits (unit, no DB)', () => {
       },
     })
 
-    await ingestRepoCommits(repo)
+    await ingestRepoCommits(repo, weekEnd)
 
     const shas = upsertCalls().map((c) => c.sha)
     expect(shas).toEqual(['feature-only-1', 'feature-only-2'])
@@ -143,7 +147,7 @@ describe('ingestRepoCommits (unit, no DB)', () => {
       },
     })
 
-    await ingestRepoCommits(repo)
+    await ingestRepoCommits(repo, weekEnd)
 
     const compareBaseheads = paginate.mock.calls
       .filter((c) => c[0] === 'GET /repos/{owner}/{repo}/compare/{basehead}')
@@ -154,26 +158,43 @@ describe('ingestRepoCommits (unit, no DB)', () => {
     expect(upsertCalls().map((c) => c.branch)).toEqual(['main', 'feature'])
   })
 
-  it('upserts all commits from the compare endpoint regardless of author date', async () => {
+  it('captures a late prior-week commit but skips commits older than the 2-week lookback', async () => {
     mockOctokit({
       defaultBranch: 'main',
       branches: [{ name: 'main' }, { name: 'feature' }],
       compareByBasehead: {
         'main...feature': [
+          // Before the lookback start (Mon 2026-04-27) — skipped.
           { sha: 'old-commit', commit: { author: { date: '2026-04-01T10:00:00Z' } } },
+          // Authored in the prior week, pushed late this week — must be captured so it
+          // can be reconciled into last week's stats.
+          { sha: 'prior-week-commit', commit: { author: { date: '2026-04-29T10:00:00Z' } } },
           { sha: 'current-commit', commit: { author: { date: '2026-05-07T10:00:00Z' } } },
-          { sha: 'future-commit', commit: { author: { date: '2026-06-01T10:00:00Z' } } },
         ],
       },
     })
 
-    const total = await ingestRepoCommits(repo)
+    const total = await ingestRepoCommits(repo, weekEnd)
 
-    expect(total).toBe(3)
+    expect(total).toBe(2)
     expect(upsertCalls()).toEqual([
-      { sha: 'old-commit', branch: 'feature' },
+      { sha: 'prior-week-commit', branch: 'feature' },
       { sha: 'current-commit', branch: 'feature' },
-      { sha: 'future-commit', branch: 'feature' },
     ])
+  })
+
+  it('keeps commits that have no author date rather than dropping them', async () => {
+    mockOctokit({
+      defaultBranch: 'main',
+      branches: [{ name: 'main' }, { name: 'feature' }],
+      compareByBasehead: {
+        'main...feature': [{ sha: 'undated-commit' } as never],
+      },
+    })
+
+    const total = await ingestRepoCommits(repo, weekEnd)
+
+    expect(total).toBe(1)
+    expect(upsertCalls()).toEqual([{ sha: 'undated-commit', branch: 'feature' }])
   })
 })

--- a/apps/worker/src/lib/github-commit-tracker.ts
+++ b/apps/worker/src/lib/github-commit-tracker.ts
@@ -137,11 +137,17 @@ export async function ingestRepoCommits(
     }
 
     for (const commit of commits) {
-      // Skip commits authored before the 2-week lookback window. Commits without an
-      // author date are kept so we never silently drop a commit we can't date.
+      // Keep only commits authored within the window [lookbackStart, weekEnd].
+      // Older commits fall outside the 2-week lookback; commits authored after
+      // weekEnd belong to a later week and must be skipped in case the job runs
+      // late. Commits without an author date are kept so we never silently drop
+      // a commit we can't date.
       const authorDate = commit.commit?.author?.date
-      if (authorDate && new Date(authorDate) < lookbackStart) {
-        continue
+      if (authorDate) {
+        const authoredAt = new Date(authorDate)
+        if (authoredAt < lookbackStart || authoredAt > weekEnd) {
+          continue
+        }
       }
 
       // upsertCommit is a no-op for SHAs already stored (e.g. captured earlier by the

--- a/apps/worker/src/lib/github-commit-tracker.ts
+++ b/apps/worker/src/lib/github-commit-tracker.ts
@@ -4,6 +4,7 @@ import { db, Prisma } from '@repo/db'
 import { getInstallationOctokit } from '@repo/github'
 import { logger } from '../lib/logger'
 import { resolveIdentity, withRateLimit } from './github-utils'
+import { getCollectionWindow } from './date-utils'
 
 type Octokit = Awaited<ReturnType<typeof getInstallationOctokit>>
 
@@ -61,13 +62,28 @@ export async function upsertCommit(
   }
 }
 
-export async function ingestRepoCommits(repo: {
-  id: string
-  owner: string
-  name: string
-  installationId: string
-}): Promise<number> {
-  logger.info(`Fetching commits for ${repo.owner}/${repo.name}`)
+export async function ingestRepoCommits(
+  repo: {
+    id: string
+    owner: string
+    name: string
+    installationId: string
+  },
+  weekEnd: Date
+): Promise<number> {
+  // The branch walk looks back two weeks (the current week plus the prior week),
+  // mirroring the PR walk's lookback window. This ensures a commit authored last week
+  // but pushed late — to a branch with no associated PR, or a PR that hasn't been
+  // updated recently — is still captured here even though neither the PR walk nor a
+  // current-week-only branch walk would see it. The prior week's WeeklyStats and
+  // MemberWeeklyContribution are recomputed after ingestion (see runGitHubIngestion),
+  // so any newly captured commit is bucketed into the week it was authored in.
+  // Lookback start = Monday of the previous week.
+  const [lookbackStart] = getCollectionWindow(new Date(weekEnd.getTime() - 7 * 24 * 60 * 60 * 1000))
+
+  logger.info(
+    `Fetching commits for ${repo.owner}/${repo.name} authored since ${lookbackStart.toISOString()}`
+  )
 
   const octokit = await getInstallationOctokit(repo.installationId)
 
@@ -98,7 +114,7 @@ export async function ingestRepoCommits(repo: {
 
     // Compare endpoint returns commits reachable from head but NOT from base,
     // so commits inherited from the default branch (e.g. via merge or rebase) are excluded.
-    type CompareCommit = { sha: string }
+    type CompareCommit = { sha: string; commit?: { author?: { date?: string } | null } }
     const basehead = `${defaultBranch}...${branch.name}`
     const commits = await withRateLimit<CompareCommit[]>(() =>
       octokit.paginate(
@@ -121,6 +137,15 @@ export async function ingestRepoCommits(repo: {
     }
 
     for (const commit of commits) {
+      // Skip commits authored before the 2-week lookback window. Commits without an
+      // author date are kept so we never silently drop a commit we can't date.
+      const authorDate = commit.commit?.author?.date
+      if (authorDate && new Date(authorDate) < lookbackStart) {
+        continue
+      }
+
+      // upsertCommit is a no-op for SHAs already stored (e.g. captured earlier by the
+      // PR walk), so commits are never double-counted across the two walks.
       if (await upsertCommit(repo, octokit, commit.sha, branch.name)) {
         totalCommits++
       }


### PR DESCRIPTION


## Description

Commits authored last week but pushed late — to a branch with no associated PR, or a PR that hasn't been updated recently — were seen by neither the PR walk (which searches by PR update time) nor a current-week-only branch walk, so they were never ingested or reconciled.

## Solution

ingestRepoCommits now bounds its branch walk to a 2-week lookback window (current week plus the prior week), mirroring ingestRepoPRs. Commits authored on/after the Monday of the previous week are ingested; 
older ones are skipped, and commits with no author date are kept rather than dropped. upsertCommit already de-dupes by SHA, so commits captured by both walks are never double-counted. runGitHubIngestion already recomputes the prior week's WeeklyStats and MemberWeeklyContribution after ingestion, so newly captured commits are bucketed into the week they were authored in.

## Notes

<!-- Add any notes you think are needed -->
