### PR TITLE
[#233] Add date to graph tooltip

### DIFF
--- a/apps/web/src/components/charts/LineGraph.tsx
+++ b/apps/web/src/components/charts/LineGraph.tsx
@@ -23,21 +23,25 @@ function formatDate(iso: string): string {
   return `${dd}/${mm}`
 }
 
-const TOOLTIP_BOX_HEIGHT = 26
+const TOOLTIP_BOX_HEIGHT = 50
 const TOOLTIP_FOREIGN_OBJECT_WIDTH = 80
 
 function ActivePointTooltip({
   cx,
   cy,
   value,
+  payload,
   viewBox,
 }: {
   cx?: number
   cy?: number
   value?: number
+  payload?: { date?: string }
   viewBox?: { x: number; y: number; width: number; height: number }
 }) {
   if (cx === undefined || cy === undefined) return null
+
+  const date = payload?.date ?? ''
 
   const clampedX = viewBox
     ? Math.max(
@@ -59,8 +63,12 @@ function ActivePointTooltip({
         height={TOOLTIP_BOX_HEIGHT + 8}
       >
         <div className="flex flex-col items-center">
-          <div className="rounded-md bg-[#077CF1] px-2 py-1 font-mono text-sm font-bold text-white">
-            {value}
+          <div className="flex flex-col items-center rounded-md bg-[#077CF1] px-2.5 py-1 text-white shadow-sm">
+            {date && <span className="text-[12px] font-mono text-blue-100">{date}</span>}
+
+            <span className="rounded-md bg-[#077CF1] font-mono text-sm font-bold text-white">
+              {value}
+            </span>
           </div>
           <div className="-mt-1 h-2 w-2 rotate-45 bg-[#077CF1]" />
         </div>

--- a/apps/web/src/components/charts/LineGraph.tsx
+++ b/apps/web/src/components/charts/LineGraph.tsx
@@ -43,6 +43,17 @@ function ActivePointTooltip({
 
   const date = payload?.date ?? ''
 
+  const tooltipHeight = TOOLTIP_BOX_HEIGHT + 16
+  const minY = viewBox?.y ?? 0
+
+  // Check if positioning above would overflow the top boundary of the SVG
+  const isNearTop = cy - tooltipHeight < minY
+
+  // Compute dynamic Y position & arrow orientation
+  const foreignObjectY = isNearTop
+    ? cy + 16 // Position below the point
+    : cy - tooltipHeight // Position above the point
+
   const clampedX = viewBox
     ? Math.max(
         viewBox.x,
@@ -56,21 +67,26 @@ function ActivePointTooltip({
   return (
     <g>
       <circle cx={cx} cy={cy} r={4} fill="#077CF1" />
+
       <foreignObject
         x={clampedX}
-        y={cy - TOOLTIP_BOX_HEIGHT - 16}
+        y={foreignObjectY}
         width={TOOLTIP_FOREIGN_OBJECT_WIDTH}
-        height={TOOLTIP_BOX_HEIGHT + 8}
+        height={TOOLTIP_BOX_HEIGHT + 16}
+        className="overflow-visible"
       >
         <div className="flex flex-col items-center">
+          {/* Arrow tail points up when tooltip is placed below */}
+          {isNearTop && <div className="-mb-1 h-2 w-2 rotate-45 bg-[#077CF1]" />}
+
           <div className="flex flex-col items-center rounded-md bg-[#077CF1] px-2.5 py-1 text-white shadow-sm">
             {date && <span className="text-[12px] font-mono text-blue-100">{date}</span>}
 
-            <span className="rounded-md bg-[#077CF1] font-mono text-sm font-bold text-white">
-              {value}
-            </span>
+            <span className="font-mono text-sm font-bold text-white">{value}</span>
           </div>
-          <div className="-mt-1 h-2 w-2 rotate-45 bg-[#077CF1]" />
+
+          {/* Arrow tail points down when tooltip is placed above */}
+          {!isNearTop && <div className="-mt-1 h-2 w-2 rotate-45 bg-[#077CF1]" />}
         </div>
       </foreignObject>
     </g>
@@ -93,7 +109,7 @@ export default function LineGraph({ title, dates, dataPoints }: LineGraphProps) 
       {/* Chart area — fixed height, data points spread evenly across full width */}
       <div className="bg-white px-2 pt-4 pb-2" style={{ height: '280px' }}>
         <ResponsiveContainer width="100%" height="100%">
-          <LineChart data={data} margin={{ top: 44, right: 24, bottom: 8, left: 8 }}>
+          <LineChart data={data} margin={{ top: 44, right: 34, bottom: 8, left: 8 }}>
             <CartesianGrid vertical={false} stroke="#E0E0E0" />
             <XAxis
               dataKey="date"


### PR DESCRIPTION
## Description

Date of datapoint now sits above the value in the graph tooltip. Tooltip usually rendered above datapoint but if clipped by edge of chart container is rendered below.

## Solution
* ngl not much to say
* Calculates the top y position of the tooltip to see if it should be rendered above or below the point
* Date text a bit smaller/subdued than value

## Notes

Rendering above:
<img width="893" height="365" alt="{E9B69AB6-F38A-4D4C-8652-C0AF090DF07F}" src="https://github.com/user-attachments/assets/6f43cfd0-baeb-4821-a5ec-92654cf302d0" />

Rendering below:
<img width="879" height="342" alt="{E36AF46F-B819-4B41-9A9F-BC8592DA7AA8}" src="https://github.com/user-attachments/assets/f821ac01-07e6-4e24-b6fa-11dffb0e23a6" />

