### PR TITLE
[#231] Build multi-team metrics comparison component for exec dashboard

### DIFF
--- a/apps/web/src/app/(exec)/exec-dashboard/page.tsx
+++ b/apps/web/src/app/(exec)/exec-dashboard/page.tsx
@@ -1,9 +1,10 @@
+import ExecProjectGraphs from '@/components/charts/ExecProjectGraphs'
+
 export default async function ExecDashboardPage() {
   return (
     <main className="p-8 flex flex-col gap-10">
       <h1 className="text-2xl font-bold">WDCC Projects Health Dashboard — Exec View</h1>
-
-      <div className="flex justify-center gap-[21px]"></div>
+      <ExecProjectGraphs />
     </main>
   )
 }

--- a/apps/web/src/app/api/project/weekly-stats/route.ts
+++ b/apps/web/src/app/api/project/weekly-stats/route.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from 'next/server'
+import { getAllProjectsWeeklyStats } from '@/lib/project/weekly-stats'
+
+export async function GET() {
+  try {
+    const stats = await getAllProjectsWeeklyStats()
+    return NextResponse.json(stats)
+  } catch (err) {
+    console.error('Failed to fetch all-projects weekly stats:', err)
+    return NextResponse.json({ error: 'Failed to fetch weekly stats' }, { status: 500 })
+  }
+}

--- a/apps/web/src/components/charts/ExecProjectGraphs.tsx
+++ b/apps/web/src/components/charts/ExecProjectGraphs.tsx
@@ -1,0 +1,125 @@
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+import MultiLineGraph, { type TeamSeriesMeta } from '@/components/charts/MultiLineGraph'
+import { METRICS, type MetricKey, type TeamWeeklyStats } from '@/lib/project/weekly-stats'
+
+const TEAM_COLORS = [
+  '#077CF1',
+  '#F45B69',
+  '#2EC4B6',
+  '#FF9F1C',
+  '#8338EC',
+  '#06A77D',
+  '#E63946',
+  '#5A5E7A',
+  '#FFBF69',
+  '#3A86FF',
+]
+
+function formatDate(iso: string): string {
+  const d = new Date(iso)
+  const dd = String(d.getDate()).padStart(2, '0')
+  const mm = String(d.getMonth() + 1).padStart(2, '0')
+  return `${dd}/${mm}`
+}
+
+function buildRowsForMetric(teams: TeamWeeklyStats[], metric: MetricKey) {
+  const allDates = Array.from(new Set(teams.flatMap((t) => t.dates))).sort()
+
+  return allDates.map((iso) => {
+    const row: Record<string, string | number | null> = { date: formatDate(iso) }
+    for (const team of teams) {
+      const idx = team.dates.indexOf(iso)
+      const value = idx === -1 ? null : (team[metric]?.[idx] ?? null)
+      row[team.slug] = value
+    }
+    return row
+  })
+}
+
+export default function ExecProjectGraphs() {
+  const [teams, setTeams] = useState<TeamWeeklyStats[] | null>(null)
+  const [activeSlugs, setActiveSlugs] = useState<Set<string>>(new Set())
+
+  useEffect(() => {
+    fetch('/api/project/weekly-stats')
+      .then((res) => res.json())
+      .then((data: TeamWeeklyStats[]) => {
+        setTeams(data)
+        setActiveSlugs(new Set(data.map((t) => t.slug)))
+      })
+      .catch((err) => console.error('Failed to fetch exec weekly stats:', err))
+  }, [])
+
+  const teamMeta: TeamSeriesMeta[] = useMemo(
+    () =>
+      (teams ?? []).map((t, i) => ({
+        slug: t.slug,
+        name: t.name,
+        color: TEAM_COLORS[i % TEAM_COLORS.length],
+      })),
+    [teams]
+  )
+
+  const activeTeams = teams?.filter((t) => activeSlugs.has(t.slug)) ?? []
+  const activeMeta = teamMeta.filter((t) => activeSlugs.has(t.slug))
+
+  function toggleTeam(slug: string) {
+    setActiveSlugs((prev) => {
+      const next = new Set(prev)
+      if (next.has(slug)) {
+        // keep at least one team active
+        if (next.size > 1) next.delete(slug)
+      } else {
+        next.add(slug)
+      }
+      return next
+    })
+  }
+
+  if (teams === null) {
+    return <div className="mx-4 mt-6 font-mono text-[#5A5E7A]">Loading team comparison…</div>
+  }
+
+  return (
+    <div className="mx-4 mt-6 flex w-full flex-col gap-6">
+      {/* Toggle bar */}
+      <div className="flex flex-wrap gap-2">
+        {teamMeta.map((team) => {
+          const isActive = activeSlugs.has(team.slug)
+          return (
+            <button
+              key={team.slug}
+              type="button"
+              onClick={() => toggleTeam(team.slug)}
+              className={`flex items-center gap-1.5 rounded-full border px-3 py-1.5 font-mono text-xs font-bold transition-colors ${
+                isActive
+                  ? 'border-transparent bg-[#E8E8E8] text-[#2B2E48]'
+                  : 'border-[#E0E0E0] bg-white text-[#B9BCCB]'
+              }`}
+            >
+              <span
+                className="h-2 w-2 rounded-full"
+                style={{ backgroundColor: isActive ? team.color : '#D9D9D9' }}
+              />
+              {team.name}
+            </button>
+          )
+        })}
+      </div>
+
+      {/* One graph per metric */}
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+        {METRICS.map(({ key, title }) => (
+          <MultiLineGraph
+            key={key}
+            title={title}
+            rows={buildRowsForMetric(activeTeams, key)}
+            teams={activeMeta}
+          />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/components/charts/MultiLineGraph.tsx
+++ b/apps/web/src/components/charts/MultiLineGraph.tsx
@@ -1,0 +1,125 @@
+'use client'
+
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  Legend,
+} from 'recharts'
+
+export interface TeamSeriesMeta {
+  slug: string
+  name: string
+  color: string
+}
+
+interface MultiLineGraphProps {
+  title: string
+  rows: Record<string, string | number | null>[] // merged rows keyed by team slug, plus `date`
+  teams: TeamSeriesMeta[]
+}
+
+function ComparisonTooltip({
+  active,
+  payload,
+  label,
+}: {
+  active?: boolean
+  payload?: { dataKey: string; name: string; value: number | null; color: string }[]
+  label?: string
+}) {
+  if (!active || !payload?.length) return null
+
+  const entries = payload.filter((p) => p.value !== null && p.value !== undefined)
+  if (entries.length === 0) return null
+
+  return (
+    <div className="min-w-[150px] rounded-md border border-[#E0E0E0] bg-white px-3 py-2 font-mono text-xs shadow-md">
+      <div className="mb-1.5 font-bold text-[#5A5E7A]">{label}</div>
+      <div className="flex flex-col gap-1">
+        {entries.map((p) => (
+          <div key={p.dataKey} className="flex items-center justify-between gap-4">
+            <span className="flex items-center gap-1.5 text-[#2B2E48]">
+              <span
+                className="h-2 w-2 shrink-0 rounded-full"
+                style={{ backgroundColor: p.color }}
+              />
+              {p.name}
+            </span>
+            <span className="font-bold text-[#2B2E48]">{p.value}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function LegendSwatches({ payload }: { payload?: { value: string; color: string }[] }) {
+  if (!payload?.length) return null
+  return (
+    <div className="flex flex-wrap justify-center gap-x-4 gap-y-1 px-4 pb-3 pt-1 font-mono text-xs text-[#5A5E7A]">
+      {payload.map((entry) => (
+        <span key={entry.value} className="flex items-center gap-1.5">
+          <span className="h-2 w-2 rounded-full" style={{ backgroundColor: entry.color }} />
+          {entry.value}
+        </span>
+      ))}
+    </div>
+  )
+}
+
+export default function MultiLineGraph({ title, rows, teams }: MultiLineGraphProps) {
+  return (
+    <div className="w-full overflow-hidden rounded-2xl bg-[#E8E8E8]">
+      {/* Title bar */}
+      <div className="px-5 py-4">
+        <h3 className="font-mono text-xl font-bold text-wdcc-oshan">{title}</h3>
+      </div>
+
+      {/* Chart area */}
+      <div className="bg-white px-2 pb-2 pt-4" style={{ height: '320px' }}>
+        <ResponsiveContainer width="100%" height="100%">
+          <LineChart data={rows} margin={{ top: 12, right: 24, bottom: 8, left: 8 }}>
+            <CartesianGrid vertical={false} stroke="#E0E0E0" />
+            <XAxis
+              dataKey="date"
+              tick={{ fontFamily: 'var(--font-mono)', fontSize: 12, fill: '#5A5E7A' }}
+              axisLine={false}
+              tickLine={false}
+            />
+            <YAxis
+              tick={{ fontFamily: 'var(--font-mono)', fontSize: 12, fill: '#5A5E7A' }}
+              axisLine={false}
+              tickLine={false}
+              width={40}
+            />
+            <Tooltip
+              content={<ComparisonTooltip />}
+              cursor={{ stroke: '#B9BCCB', strokeWidth: 1 }}
+              isAnimationActive={false}
+            />
+            <Legend content={<LegendSwatches />} verticalAlign="bottom" />
+            {teams.map((team) => (
+              <Line
+                key={team.slug}
+                type="linear"
+                dataKey={team.slug}
+                name={team.name}
+                stroke={team.color}
+                strokeWidth={2}
+                dot={false}
+                activeDot={{ r: 4, strokeWidth: 0 }}
+                connectNulls={false}
+                isAnimationActive={false}
+              />
+            ))}
+          </LineChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/lib/project/weekly-stats.ts
+++ b/apps/web/src/lib/project/weekly-stats.ts
@@ -185,6 +185,7 @@ export async function getAllProjectsWeeklyStats(): Promise<TeamWeeklyStats[]> {
   const rows = await db.weeklyStats.findMany({
     where: {
       weekStart: { gte: yearStart },
+      isActive: true,
     },
     orderBy: { weekStart: 'asc' },
     select: {

--- a/apps/web/src/lib/project/weekly-stats.ts
+++ b/apps/web/src/lib/project/weekly-stats.ts
@@ -185,6 +185,7 @@ export async function getAllProjectsWeeklyStats(): Promise<TeamWeeklyStats[]> {
   const rows = await db.weeklyStats.findMany({
     where: {
       weekStart: { gte: yearStart },
+      project: { isActive: true },
     },
     orderBy: { weekStart: 'asc' },
     select: {
@@ -197,7 +198,6 @@ export async function getAllProjectsWeeklyStats(): Promise<TeamWeeklyStats[]> {
       healthScore: true,
       project: {
         select: { slug: true, name: true },
-        where: { isActive: true },
       },
     },
   })

--- a/apps/web/src/lib/project/weekly-stats.ts
+++ b/apps/web/src/lib/project/weekly-stats.ts
@@ -123,7 +123,26 @@ export interface ProjectWeeklyStats {
   prs: number[]
   linesChanged: number[]
   discordMessages: number[]
+  healthScore: number[]
 }
+
+export interface TeamWeeklyStats extends ProjectWeeklyStats {
+  slug: string
+  name: string
+}
+
+export type MetricKey = Extract<
+  keyof ProjectWeeklyStats,
+  'commits' | 'prs' | 'linesChanged' | 'discordMessages' | 'healthScore'
+>
+
+export const METRICS: { key: MetricKey; title: string }[] = [
+  { key: 'commits', title: 'Weekly Commits' },
+  { key: 'prs', title: 'Weekly PRs' },
+  { key: 'linesChanged', title: 'Weekly Lines Changed' },
+  { key: 'discordMessages', title: 'Weekly Discord Messages' },
+  { key: 'healthScore', title: 'Weekly Health Score' },
+]
 
 export async function getProjectWeeklyStats(projectId: string): Promise<ProjectWeeklyStats> {
   const yearStart = new Date(Date.UTC(new Date().getUTCFullYear(), 0, 1))
@@ -141,6 +160,7 @@ export async function getProjectWeeklyStats(projectId: string): Promise<ProjectW
       linesAdded: true,
       linesRemoved: true,
       discordMessages: true,
+      healthScore: true,
     },
   })
 
@@ -150,5 +170,63 @@ export async function getProjectWeeklyStats(projectId: string): Promise<ProjectW
     prs: rows.map((r) => r.prsMerged),
     linesChanged: rows.map((r) => r.linesAdded + r.linesRemoved),
     discordMessages: rows.map((r) => r.discordMessages),
+    healthScore: rows.map((r) => r.healthScore ?? 0),
   }
+}
+
+/**
+ * Weekly stats for every project, for the exec comparison view.
+ * Same shape as getProjectWeeklyStats but scoped across all projects
+ * in a single query instead of N sequential calls.
+ */
+export async function getAllProjectsWeeklyStats(): Promise<TeamWeeklyStats[]> {
+  const yearStart = new Date(Date.UTC(new Date().getUTCFullYear(), 0, 1))
+
+  const rows = await db.weeklyStats.findMany({
+    where: {
+      weekStart: { gte: yearStart },
+    },
+    orderBy: { weekStart: 'asc' },
+    select: {
+      weekStart: true,
+      commits: true,
+      prsMerged: true,
+      linesAdded: true,
+      linesRemoved: true,
+      discordMessages: true,
+      healthScore: true,
+      project: {
+        select: { slug: true, name: true },
+      },
+    },
+  })
+
+  const byProject = new Map<string, TeamWeeklyStats>()
+
+  for (const r of rows) {
+    const slug = r.project.slug
+    let team = byProject.get(slug)
+    if (!team) {
+      team = {
+        slug,
+        name: r.project.name,
+        dates: [],
+        commits: [],
+        prs: [],
+        linesChanged: [],
+        discordMessages: [],
+        healthScore: [],
+      }
+      byProject.set(slug, team)
+    }
+
+    team.dates.push(r.weekStart.toISOString().split('T')[0])
+    team.commits.push(r.commits)
+    team.prs.push(r.prsMerged)
+    team.linesChanged.push(r.linesAdded + r.linesRemoved)
+    team.discordMessages.push(r.discordMessages)
+    team.healthScore.push(r.healthScore ?? 0)
+  }
+
+  return Array.from(byProject.values())
 }

--- a/apps/web/src/lib/project/weekly-stats.ts
+++ b/apps/web/src/lib/project/weekly-stats.ts
@@ -185,7 +185,6 @@ export async function getAllProjectsWeeklyStats(): Promise<TeamWeeklyStats[]> {
   const rows = await db.weeklyStats.findMany({
     where: {
       weekStart: { gte: yearStart },
-      isActive: true,
     },
     orderBy: { weekStart: 'asc' },
     select: {
@@ -198,6 +197,7 @@ export async function getAllProjectsWeeklyStats(): Promise<TeamWeeklyStats[]> {
       healthScore: true,
       project: {
         select: { slug: true, name: true },
+        where: { isActive: true },
       },
     },
   })


### PR DESCRIPTION
## Description
Adds a team-comparison view for the exec dashboard so execs can see how all projects are trending against each other at a glance, instead of having to flip between individual project pages.

## Solution
- **`components/charts/MultiLineGraph.tsx`** — new multi-series line graph built on the existing `LineGraph` styling (grey card header, white chart area, mono labels). Renders one line per team, a custom tooltip showing team name + date + value on hover, and a legend with colour swatches mapping lines to teams.
- **`components/charts/ExecProjectGraphs.tsx`** — fetches all teams' weekly stats, renders one `MultiLineGraph` per metric (commits, PRs, lines changed, Discord messages, health score), and manages toggle state so execs can show/hide individual teams. At least one team stays active at all times so a graph can't go empty.
- **`lib/project/weekly-stats.ts`**
  - Added `healthScore: number[]` to `ProjectWeeklyStats` and wired it through `getProjectWeeklyStats`.
  - Tightened `MetricKey` to `Extract<keyof ProjectWeeklyStats, ...>` so it can't drift out of sync with the interface again (this was the source of a `TeamWeeklyStats` indexing error caught during review).
  - Added `getAllProjectsWeeklyStats()`, which pulls weekly stats for every project in a single query and groups them by project slug, instead of doing N sequential per-project fetches.
- **`app/api/projects/weekly-stats/route.ts`** — new endpoint returning `TeamWeeklyStats[]` for the exec view, alongside the existing `/api/project/[slug]/weekly-stats` per-project route.
- **`app/exec/page.tsx`** — swapped `ProjectGraphs` for `ExecProjectGraphs`.

Team line colours are assigned from a fixed 10-colour palette, cycling if there are more than 10 projects.

## Notes
- Missing weekly data points are rendered as gaps (`connectNulls={false}`) rather than zeros, so a week with no reported activity doesn't visually read as "activity crashed to 0."
- `healthScore` assumes the value is already stored/computed on `weeklyStats` rows — if it's actually derived from the health-formula config at read time instead, that column select in `getAllProjectsWeeklyStats` / `getProjectWeeklyStats` will need to be swapped for a formula evaluation call.