### PR TITLE
[#232] member contribution breakdown page

### DIFF
--- a/apps/web/src/app/(public)/project/[slug]/members/[memberId]/page.tsx
+++ b/apps/web/src/app/(public)/project/[slug]/members/[memberId]/page.tsx
@@ -1,0 +1,111 @@
+import Link from 'next/link'
+import { notFound, redirect } from 'next/navigation'
+import MemberAvatar from '@/components/ui/MemberAvatar'
+import MemberContributionChart from '@/components/charts/MemberContributionChart'
+import { getUserRoles } from '@/lib/auth'
+import { getProjectHeaderData } from '@/lib/project/projects'
+import { getMemberContributionBreakdown } from '@/lib/project/member-contribution'
+import { Role } from '@repo/db'
+
+function formatWeek(weekStart: Date): string {
+  return weekStart.toLocaleDateString('en-NZ', {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+    timeZone: 'UTC',
+  })
+}
+
+export default async function MemberContributionPage({
+  params,
+}: {
+  params: Promise<{ slug: string; memberId: string }>
+}) {
+  const { slug, memberId } = await params
+
+  // Exec-only page — everyone else goes back to the team members page.
+  // ADMIN is treated as a superset of EXEC, matching the (exec) route group.
+  const roles = await getUserRoles()
+  if (!roles.includes(Role.EXEC) && !roles.includes(Role.ADMIN)) {
+    redirect(`/project/${slug}/members`)
+  }
+
+  const [project, breakdown] = await Promise.all([
+    getProjectHeaderData(slug),
+    getMemberContributionBreakdown(slug, memberId),
+  ])
+
+  if (!project || !breakdown) {
+    notFound()
+  }
+
+  const { member, latestWeekStart, ranges } = breakdown
+
+  return (
+    <>
+      {/* PAGE HEADER */}
+      <div className="bg-wdcc-blue-light w-full px-5 sm:px-10 lg:px-20 pt-8 sm:pt-12 lg:pt-16 pb-8 lg:pb-14">
+        <nav
+          aria-label="Breadcrumb"
+          className="font-mono text-xs lg:text-sm uppercase tracking-[0.2em] text-wdcc-grey"
+        >
+          <Link href="/" className="hover:text-wdcc-oshan transition-colors">
+            Projects
+          </Link>
+          <span className="mx-2">›</span>
+          <Link href={`/project/${slug}`} className="hover:text-wdcc-oshan transition-colors">
+            {project.name}
+          </Link>
+          <span className="mx-2">›</span>
+          <Link
+            href={`/project/${slug}/members`}
+            className="hover:text-wdcc-oshan transition-colors"
+          >
+            Team Members
+          </Link>
+          <span className="mx-2">›</span>
+          <span className="text-wdcc-oshan font-medium">{member.name}</span>
+        </nav>
+
+        <div className="mt-5 flex items-center gap-4">
+          <MemberAvatar
+            name={member.name}
+            imageUrl={member.imageUrl}
+            color="#077CF1"
+            className="w-14 h-14 lg:w-20 lg:h-20 shrink-0"
+          />
+          <div className="min-w-0">
+            <h1 className="font-extrabold tracking-tight !leading-none text-[clamp(1.75rem,4vw,3rem)]">
+              {member.name}
+            </h1>
+            <p className="mt-2 font-mono text-sm lg:text-base text-wdcc-grey truncate">
+              {member.username ? `@${member.username} · ` : ''}
+              {project.name}
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {/* CONTRIBUTION BREAKDOWN */}
+      <div className="px-5 sm:px-10 lg:px-20 py-8 lg:py-14">
+        <h2 className="text-2xl lg:text-3xl font-extrabold">Contribution breakdown</h2>
+        <p className="mt-2 font-mono text-sm text-wdcc-grey">
+          {latestWeekStart
+            ? `Current week is the week starting ${formatWeek(latestWeekStart)} — the most recent week collected for ${project.name}.`
+            : `No contribution data has been collected for ${project.name} yet.`}
+        </p>
+
+        <div className="mt-6">
+          <MemberContributionChart ranges={ranges} />
+        </div>
+
+        <Link
+          href={`/project/${slug}/members`}
+          className="mt-8 inline-block font-mono text-sm text-wdcc-blue hover:underline"
+        >
+          ← Back to team members
+        </Link>
+      </div>
+    </>
+  )
+}

--- a/apps/web/src/app/(public)/project/[slug]/members/page.tsx
+++ b/apps/web/src/app/(public)/project/[slug]/members/page.tsx
@@ -2,9 +2,10 @@ import Link from 'next/link'
 import { notFound } from 'next/navigation'
 import MemberCard from '@/components/ui/MemberCard'
 import LastUpdatedTime from '@/components/headers/LastUpdatedTime'
+import { getUserRoles } from '@/lib/auth'
 import { getProjectHeaderData } from '@/lib/project/projects'
 import { getProjectTeamMembers } from '@/lib/project/weekly-stats'
-import { db, SyncJobStatus, SyncJobType } from '@repo/db'
+import { db, Role, SyncJobStatus, SyncJobType } from '@repo/db'
 
 async function getLastUpdated(slug: string): Promise<Date> {
   try {
@@ -25,15 +26,19 @@ async function getLastUpdated(slug: string): Promise<Date> {
 
 export default async function TeamMembersPage({ params }: { params: Promise<{ slug: string }> }) {
   const slug = (await params).slug
-  const [project, members, lastUpdated] = await Promise.all([
+  const [project, members, lastUpdated, roles] = await Promise.all([
     getProjectHeaderData(slug),
     getProjectTeamMembers(slug).catch(() => []),
     getLastUpdated(slug),
+    getUserRoles(),
   ])
 
   if (!project) {
     notFound()
   }
+
+  // Only execs can drill into a member's contribution breakdown.
+  const isExec = roles.includes(Role.EXEC) || roles.includes(Role.ADMIN)
 
   return (
     <>
@@ -81,7 +86,12 @@ export default async function TeamMembersPage({ params }: { params: Promise<{ sl
         {members.length > 0 ? (
           <div className="grid grid-cols-2 gap-4 lg:grid-cols-3 xl:grid-cols-4 lg:gap-8">
             {members.map((member, index) => (
-              <MemberCard key={member.id} member={member} index={index} />
+              <MemberCard
+                key={member.id}
+                member={member}
+                index={index}
+                href={isExec ? `/project/${slug}/members/${member.id}` : undefined}
+              />
             ))}
           </div>
         ) : (

--- a/apps/web/src/app/(public)/project/[slug]/page.tsx
+++ b/apps/web/src/app/(public)/project/[slug]/page.tsx
@@ -2,23 +2,29 @@ import TeamHeader from '@/components/headers/TeamHeader'
 import WeeklyMvp from '@/components/ui/WeeklyMvp'
 import TeamSection from '@/components/ui/TeamSection'
 import ViewAllMembersButton from '@/components/ui/ViewAllMembersButton'
+import { getUserRoles } from '@/lib/auth'
 import { getProjectHeaderData } from '@/lib/project/projects'
 import { getProjectMembers } from '@/lib/project/members'
 import { getProjectWeeklyMvp } from '@/lib/project/weekly-stats'
 import { notFound } from 'next/navigation'
 import GraphViewToggle from '@/components/charts/GraphViewToggle'
+import { Role } from '@repo/db'
 
 export default async function ProjectPage({ params }: { params: Promise<{ slug: string }> }) {
   const slug = (await params).slug
-  const [project, mvp, members] = await Promise.all([
+  const [project, mvp, members, roles] = await Promise.all([
     getProjectHeaderData(slug),
     getProjectWeeklyMvp(slug).catch(() => null),
     getProjectMembers(slug).catch(() => []),
+    getUserRoles(),
   ])
 
   if (!project) {
     notFound()
   }
+
+  // Only execs can drill into a member's contribution breakdown.
+  const isExec = roles.includes(Role.EXEC) || roles.includes(Role.ADMIN)
 
   const mvpName = mvp?.projectMember.displayName ?? mvp?.projectMember.person.displayName
 
@@ -39,7 +45,7 @@ export default async function ProjectPage({ params }: { params: Promise<{ slug: 
           </div>
         )}
 
-        <TeamSection slug={slug} members={members} />
+        <TeamSection slug={slug} members={members} isExec={isExec} />
         <ViewAllMembersButton slug={slug} members={members} />
 
         <GraphViewToggle slug={slug} />

--- a/apps/web/src/components/charts/MemberContributionChart.tsx
+++ b/apps/web/src/components/charts/MemberContributionChart.tsx
@@ -1,0 +1,152 @@
+'use client'
+
+import { useState } from 'react'
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Cell,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts'
+import { formatStat } from '@/lib/project/leaderboard'
+import {
+  METRICS,
+  TIME_RANGES,
+  type MemberContributionBreakdown,
+  type MetricComparison,
+  type TimeRangeKey,
+} from '@/lib/project/member-contribution'
+
+const AVERAGE_COLOR = '#C7CCE0'
+
+const tick = { fontFamily: 'var(--font-mono)', fontSize: 11, fill: '#5A5E7A' }
+
+function formatValue(value: number): string {
+  return value.toLocaleString(undefined, { maximumFractionDigits: 1 })
+}
+
+function formatPct(pct: number | null): string {
+  if (pct === null) return 'n/a'
+  const rounded = Math.round(pct * 10) / 10
+  return `${rounded > 0 ? '+' : ''}${rounded.toLocaleString(undefined, { maximumFractionDigits: 1 })}%`
+}
+
+function pctColor(pct: number | null): string {
+  if (pct === null) return 'text-wdcc-grey-light'
+  if (pct > 0) return 'text-green-700'
+  if (pct < 0) return 'text-red-600'
+  return 'text-wdcc-grey'
+}
+
+function MetricPanel({
+  label,
+  color,
+  comparison,
+}: {
+  label: string
+  color: string
+  comparison: MetricComparison
+}) {
+  const bars = [
+    { label: 'Member', value: comparison.member, fill: color },
+    { label: 'Project avg', value: comparison.projectAverage, fill: AVERAGE_COLOR },
+    { label: 'All projects', value: comparison.globalAverage, fill: AVERAGE_COLOR },
+  ]
+
+  return (
+    <div className="rounded-xl border border-[#ECEEF6] bg-white p-4">
+      <div className="flex items-baseline justify-between gap-2">
+        <h3 className="font-mono text-sm text-wdcc-grey">{label}</h3>
+        <span className="font-mono text-xl text-wdcc-oshan">{formatValue(comparison.member)}</span>
+      </div>
+
+      <div className="mt-3 h-[170px]">
+        <ResponsiveContainer width="100%" height="100%">
+          <BarChart data={bars} margin={{ top: 8, right: 4, bottom: 0, left: 0 }}>
+            <CartesianGrid vertical={false} stroke="#ECEEF6" />
+            <XAxis dataKey="label" tick={tick} axisLine={false} tickLine={false} interval={0} />
+            <YAxis
+              tick={tick}
+              axisLine={false}
+              tickLine={false}
+              width={44}
+              tickFormatter={formatStat}
+            />
+            <Tooltip
+              cursor={{ fill: '#F5F7FB' }}
+              formatter={(value: number) => [formatValue(value), label]}
+              contentStyle={{ fontFamily: 'var(--font-mono)', fontSize: 12, borderRadius: 8 }}
+            />
+            <Bar dataKey="value" radius={[4, 4, 0, 0]} isAnimationActive={false}>
+              {bars.map((bar) => (
+                <Cell key={bar.label} fill={bar.fill} />
+              ))}
+            </Bar>
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
+
+      <dl className="mt-3 space-y-1.5 border-t border-[#ECEEF6] pt-3 font-mono text-xs">
+        <div className="flex items-center justify-between gap-2">
+          <dt className="text-wdcc-grey-light">vs this project</dt>
+          <dd className={pctColor(comparison.projectDiffPct)}>
+            {formatPct(comparison.projectDiffPct)}
+            <span className="ml-1 text-wdcc-grey-light">
+              (avg {formatValue(comparison.projectAverage)})
+            </span>
+          </dd>
+        </div>
+        <div className="flex items-center justify-between gap-2">
+          <dt className="text-wdcc-grey-light">vs all projects</dt>
+          <dd className={pctColor(comparison.globalDiffPct)}>
+            {formatPct(comparison.globalDiffPct)}
+            <span className="ml-1 text-wdcc-grey-light">
+              (avg {formatValue(comparison.globalAverage)})
+            </span>
+          </dd>
+        </div>
+      </dl>
+    </div>
+  )
+}
+
+export default function MemberContributionChart({
+  ranges,
+}: {
+  ranges: MemberContributionBreakdown['ranges']
+}) {
+  // Every range is computed on the server at page load, so switching is instant.
+  const [range, setRange] = useState<TimeRangeKey>('week')
+  const breakdown = ranges[range]
+
+  return (
+    <div>
+      <div role="group" aria-label="Time range" className="flex flex-wrap gap-2">
+        {TIME_RANGES.map(({ key, label }) => (
+          <button
+            key={key}
+            type="button"
+            onClick={() => setRange(key)}
+            aria-pressed={range === key}
+            className={`rounded-full border px-4 py-1.5 font-mono text-sm transition-colors ${
+              range === key
+                ? 'border-wdcc-blue bg-wdcc-blue text-white'
+                : 'border-[#ECEEF6] bg-white text-wdcc-grey hover:bg-gray-50'
+            }`}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+
+      <div className="mt-5 grid gap-4 md:grid-cols-3">
+        {METRICS.map(({ key, label, color }) => (
+          <MetricPanel key={key} label={label} color={color} comparison={breakdown[key]} />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/components/ui/MemberCard.tsx
+++ b/apps/web/src/components/ui/MemberCard.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link'
 import MemberAvatar from './MemberAvatar'
 import type { TeamMemberStats } from '@/lib/project/weekly-stats'
 import { AVATAR_COLORS } from '@/lib/project/members'
@@ -26,8 +27,20 @@ const STATS = [
   },
 ] as const
 
-export default function MemberCard({ member, index }: { member: TeamMemberStats; index: number }) {
-  return (
+/**
+ * `href` makes the card a link to the member's contribution breakdown. Only execs
+ * get one — for everyone else the card stays a plain, non-interactive tile.
+ */
+export default function MemberCard({
+  member,
+  index,
+  href,
+}: {
+  member: TeamMemberStats
+  index: number
+  href?: string
+}) {
+  const card = (
     <div className="h-full rounded-2xl lg:rounded-3xl p-px bg-[linear-gradient(160deg,#E333A366_0%,#077CF14D_50%,#FFB05F80_100%)]">
       <div className="h-full rounded-[15px] lg:rounded-[23px] bg-white overflow-hidden flex flex-col">
         {/* Avatar — banner background on desktop only, per Figma */}
@@ -67,5 +80,17 @@ export default function MemberCard({ member, index }: { member: TeamMemberStats;
         </div>
       </div>
     </div>
+  )
+
+  if (!href) return card
+
+  return (
+    <Link
+      href={href}
+      aria-label={`View contribution breakdown for ${member.name}`}
+      className="block h-full rounded-2xl lg:rounded-3xl transition-transform duration-200 hover:scale-[1.03]"
+    >
+      {card}
+    </Link>
   )
 }

--- a/apps/web/src/components/ui/TeamSection.tsx
+++ b/apps/web/src/components/ui/TeamSection.tsx
@@ -9,13 +9,18 @@ const MAX_VISIBLE_MEMBERS = 6
 /**
  * Desktop-only team member cards with an overflow "+N" card when there are more members than max.
  * The header action and the overflow card both link to the project's team members page.
+ *
+ * When `isExec` is set, each member card also links straight to that member's
+ * contribution breakdown, so execs can skip the team members page.
  */
 export default function TeamSection({
   slug,
   members,
+  isExec = false,
 }: {
   slug: string
   members: ProjectMemberSummary[]
+  isExec?: boolean
 }) {
   if (members.length === 0) {
     return null
@@ -45,22 +50,39 @@ export default function TeamSection({
       </div>
 
       <div className="mt-8 flex gap-4">
-        {visibleMembers.map((member, index) => (
-          <div
-            key={member.id}
-            className="flex-1 min-w-0 overflow-hidden rounded-2xl border border-[#E9EBF4] bg-white shadow-[0_4px_16px_rgba(0,0,0,0.1)]"
-          >
-            <div className="flex h-[140px] items-end justify-center bg-[#E9EBF4] xl:h-[170px]">
-              <MemberAvatar
-                name={member.name}
-                imageUrl={member.imageUrl}
-                color={AVATAR_COLORS[index % AVATAR_COLORS.length]}
-                className="w-36 h-36"
-              />
+        {visibleMembers.map((member, index) => {
+          const content = (
+            <>
+              <div className="flex h-[140px] items-end justify-center bg-[#E9EBF4] xl:h-[170px]">
+                <MemberAvatar
+                  name={member.name}
+                  imageUrl={member.imageUrl}
+                  color={AVATAR_COLORS[index % AVATAR_COLORS.length]}
+                  className="w-36 h-36"
+                />
+              </div>
+              <p className="truncate px-2 py-3 text-center font-mono">{member.name}</p>
+            </>
+          )
+
+          return isExec ? (
+            <Link
+              key={member.id}
+              href={`/project/${slug}/members/${member.id}`}
+              aria-label={`View contribution breakdown for ${member.name}`}
+              className="flex-1 min-w-0 block overflow-hidden rounded-2xl border border-[#E9EBF4] bg-white shadow-[0_4px_16px_rgba(0,0,0,0.1)] transition-transform duration-200 hover:scale-[1.03]"
+            >
+              {content}
+            </Link>
+          ) : (
+            <div
+              key={member.id}
+              className="flex-1 min-w-0 overflow-hidden rounded-2xl border border-[#E9EBF4] bg-white shadow-[0_4px_16px_rgba(0,0,0,0.1)]"
+            >
+              {content}
             </div>
-            <p className="truncate px-2 py-3 text-center font-mono">{member.name}</p>
-          </div>
-        ))}
+          )
+        })}
 
         {overflowCount > 0 && (
           <Link

--- a/apps/web/src/lib/project/member-contribution.ts
+++ b/apps/web/src/lib/project/member-contribution.ts
@@ -1,0 +1,201 @@
+import { db, Prisma } from '@repo/db'
+
+export const TIME_RANGES = [
+  { key: 'week', label: 'Current week' },
+  { key: 'last4', label: 'Last 4 weeks' },
+  { key: 'all', label: 'All time' },
+] as const
+
+export type TimeRangeKey = (typeof TIME_RANGES)[number]['key']
+
+export const METRICS = [
+  { key: 'linesAdded', label: 'Lines committed', color: '#E333A3' },
+  { key: 'commits', label: 'Commits', color: '#077CF1' },
+  { key: 'prsMerged', label: 'PRs merged', color: '#F4900C' },
+] as const
+
+export type MetricKey = (typeof METRICS)[number]['key']
+
+export interface MetricComparison {
+  member: number
+  projectAverage: number
+  globalAverage: number
+  // Percent difference against each average, or null when the average is 0
+  // (there is nothing meaningful to compare against).
+  projectDiffPct: number | null
+  globalDiffPct: number | null
+}
+
+export type RangeBreakdown = Record<MetricKey, MetricComparison>
+
+export interface MemberContributionBreakdown {
+  member: {
+    id: string
+    name: string
+    username: string | null
+    imageUrl: string | null
+  }
+  // Monday 00:00 UTC of the most recent week collected for this project, or null
+  // when the project has no contribution rows at all.
+  latestWeekStart: Date | null
+  ranges: Record<TimeRangeKey, RangeBreakdown>
+}
+
+const SUM_FIELDS = { linesAdded: true, commits: true, prsMerged: true } as const
+
+const THREE_WEEKS_MS = 3 * 7 * 24 * 60 * 60 * 1000
+
+const ZERO_COMPARISON: MetricComparison = {
+  member: 0,
+  projectAverage: 0,
+  globalAverage: 0,
+  projectDiffPct: null,
+  globalDiffPct: null,
+}
+
+const EMPTY_BREAKDOWN: RangeBreakdown = {
+  linesAdded: ZERO_COMPARISON,
+  commits: ZERO_COMPARISON,
+  prsMerged: ZERO_COMPARISON,
+}
+
+type Sums = Partial<Record<MetricKey, number | null>>
+
+function percentDiff(value: number, average: number): number | null {
+  if (average === 0) return null
+  return ((value - average) / average) * 100
+}
+
+/**
+ * Week filter for a range, anchored on the project's most recent collected week.
+ * `all` spans every week ever collected, so it has no filter.
+ */
+function weekFilter(range: TimeRangeKey, anchor: Date): Prisma.DateTimeFilter | undefined {
+  if (range === 'all') return undefined
+  if (range === 'week') return { equals: anchor }
+  // Four weeks inclusive of the anchor week.
+  return { gte: new Date(anchor.getTime() - THREE_WEEKS_MS), lte: anchor }
+}
+
+/**
+ * One member's contribution totals for each time range, alongside the average
+ * member totals for this project and across every project, so the page can show
+ * how the member compares. Every range is computed up front — the client only
+ * switches between them.
+ *
+ * Averages divide by the number of *active* members (of the project, or of all
+ * projects), so a member with no contribution row still counts as a zero and
+ * drags the average down, matching how the team members page shows them.
+ *
+ * Returns null when the member does not belong to this project.
+ */
+export async function getMemberContributionBreakdown(
+  slug: string,
+  memberId: string
+): Promise<MemberContributionBreakdown | null> {
+  const member = await db.projectMember.findFirst({
+    where: { id: memberId, project: { slug }, isActive: true },
+    select: {
+      id: true,
+      displayName: true,
+      person: {
+        select: {
+          displayName: true,
+          imageUrl: true,
+          identities: {
+            where: { provider: 'GITHUB' },
+            select: { username: true },
+          },
+        },
+      },
+    },
+  })
+  if (!member) return null
+
+  const memberInfo = {
+    id: member.id,
+    name: member.displayName ?? member.person.displayName,
+    username: member.person.identities[0]?.username ?? null,
+    imageUrl: member.person.imageUrl,
+  }
+
+  // Anchored on this project's latest week rather than a global max: if this
+  // project's sync fails for a week another project collected, a global max
+  // would resolve to a week this project has no rows for and report zeros.
+  const latest = await db.memberWeeklyContribution.findFirst({
+    where: { projectMember: { project: { slug } } },
+    orderBy: { weekStart: 'desc' },
+    select: { weekStart: true },
+  })
+
+  if (!latest) {
+    return {
+      member: memberInfo,
+      latestWeekStart: null,
+      ranges: { week: EMPTY_BREAKDOWN, last4: EMPTY_BREAKDOWN, all: EMPTY_BREAKDOWN },
+    }
+  }
+
+  const [projectMemberCount, globalMemberCount, rangeTotals] = await Promise.all([
+    db.projectMember.count({ where: { project: { slug }, isActive: true } }),
+    db.projectMember.count({ where: { isActive: true } }),
+    Promise.all(
+      TIME_RANGES.map(async ({ key }) => {
+        const weekStart = weekFilter(key, latest.weekStart)
+        const window = weekStart ? { weekStart } : {}
+
+        const [memberSums, projectSums, globalSums] = await Promise.all([
+          db.memberWeeklyContribution.aggregate({
+            where: { ...window, projectMemberId: memberId },
+            _sum: SUM_FIELDS,
+          }),
+          db.memberWeeklyContribution.aggregate({
+            where: { ...window, projectMember: { project: { slug }, isActive: true } },
+            _sum: SUM_FIELDS,
+          }),
+          db.memberWeeklyContribution.aggregate({
+            where: { ...window, projectMember: { isActive: true } },
+            _sum: SUM_FIELDS,
+          }),
+        ])
+
+        return {
+          key,
+          memberSums: memberSums._sum,
+          projectSums: projectSums._sum,
+          globalSums: globalSums._sum,
+        }
+      })
+    ),
+  ])
+
+  const build = (memberSums: Sums, projectSums: Sums, globalSums: Sums): RangeBreakdown =>
+    Object.fromEntries(
+      METRICS.map(({ key }) => {
+        const value = memberSums[key] ?? 0
+        const projectAverage =
+          projectMemberCount > 0 ? (projectSums[key] ?? 0) / projectMemberCount : 0
+        const globalAverage = globalMemberCount > 0 ? (globalSums[key] ?? 0) / globalMemberCount : 0
+
+        return [
+          key,
+          {
+            member: value,
+            projectAverage,
+            globalAverage,
+            projectDiffPct: percentDiff(value, projectAverage),
+            globalDiffPct: percentDiff(value, globalAverage),
+          } satisfies MetricComparison,
+        ]
+      })
+    ) as RangeBreakdown
+
+  const ranges = Object.fromEntries(
+    rangeTotals.map(({ key, memberSums, projectSums, globalSums }) => [
+      key,
+      build(memberSums, projectSums, globalSums),
+    ])
+  ) as Record<TimeRangeKey, RangeBreakdown>
+
+  return { member: memberInfo, latestWeekStart: latest.weekStart, ranges }
+}


### PR DESCRIPTION
## Description

Adds the member contribution breakdown page.

## Solution

- Adds exec only member contribution breakdown page at `/project/[slug]/members/[memberId]`

- **Data layer** - new `lib/project/member-contribution.ts` exposes
`getMemberContributionBreakdown(slug, memberId)`. It computes all three time
ranges (current week / last 4 weeks / all time) server-side in one pass, each
with the member's totals plus the average across this project's members and
across all projects' members, and the % difference against both. Week ranges are
anchored on the project's own latest collected week.

- **UI** - `MemberContributionChart` renders one small bar chart per metric
(lines committed, commits, PRs merged), each comparing member vs project average
vs all-projects average, with the two percentage differences below. 

<img width="2490" height="520" alt="image" src="https://github.com/user-attachments/assets/42051652-9a49-4b60-8c8a-2f2757566998" />

## Notes

Averages divide by all active members and non contributors count as 0.
