### PR TITLE
[#245] Admin-configurable health score threshold

### DIFF
--- a/apps/web/src/app/(admin)/admin-dashboard/page.tsx
+++ b/apps/web/src/app/(admin)/admin-dashboard/page.tsx
@@ -13,6 +13,7 @@ import Image from 'next/image'
 import ClientSuspense from '@/components/utils/ClientSuspense'
 import { BORDER_DEFAULT, BORDER_HOVER } from '@/lib/admin/layout'
 import FormulaInput from '@/components/dashboard/FormulaInput'
+import ThresholdInput from '@/components/dashboard/ThresholdInput'
 
 const fetchProjects = async (): Promise<Project[]> => {
   try {
@@ -219,6 +220,7 @@ export default function AdminDashboardPage() {
       </ul>
 
       <FormulaInput type="Health" />
+      <ThresholdInput />
       <FormulaInput type="MVP" />
     </>
   )

--- a/apps/web/src/app/api/threshold/route.ts
+++ b/apps/web/src/app/api/threshold/route.ts
@@ -1,0 +1,82 @@
+import { NextResponse } from 'next/server'
+import { db, Role } from '@repo/db'
+import { z } from 'zod'
+import { healthScoreThresholdSchema } from '@/lib/schemas/admin'
+import { hasRole } from '@/lib/auth'
+import {
+  DEFAULT_HEALTH_SCORE_AVG4W_THRESHOLD,
+  DEFAULT_HEALTH_SCORE_WEEK_THRESHOLD,
+  HEALTH_SCORE_AVG4W_THRESHOLD_KEY,
+  HEALTH_SCORE_WEEK_THRESHOLD_KEY,
+} from '@/lib/admin/threshold'
+
+const GLOBAL_SCOPE = 'GLOBAL'
+
+export async function GET() {
+  if (!(await hasRole(Role.ADMIN))) {
+    return Response.json({ error: 'Unauthorized. Admin access required.' }, { status: 403 })
+  }
+
+  const configs = await db.config.findMany({
+    where: {
+      scope: GLOBAL_SCOPE,
+      key: { in: [HEALTH_SCORE_WEEK_THRESHOLD_KEY, HEALTH_SCORE_AVG4W_THRESHOLD_KEY] },
+    },
+  })
+
+  const week = configs.find((c) => c.key === HEALTH_SCORE_WEEK_THRESHOLD_KEY)?.value
+  const avg4w = configs.find((c) => c.key === HEALTH_SCORE_AVG4W_THRESHOLD_KEY)?.value
+
+  return NextResponse.json({
+    week: typeof week === 'number' ? week : DEFAULT_HEALTH_SCORE_WEEK_THRESHOLD,
+    avg4w: typeof avg4w === 'number' ? avg4w : DEFAULT_HEALTH_SCORE_AVG4W_THRESHOLD,
+  })
+}
+
+export async function PUT(request: Request) {
+  if (!(await hasRole(Role.ADMIN))) {
+    return Response.json({ error: 'Unauthorized. Admin access required.' }, { status: 403 })
+  }
+
+  let body: unknown
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ message: 'Invalid JSON body' }, { status: 400 })
+  }
+
+  const parsed = z
+    .object({ week: healthScoreThresholdSchema, avg4w: healthScoreThresholdSchema })
+    .safeParse(body)
+
+  if (!parsed.success) {
+    return NextResponse.json({ message: parsed.error.issues[0].message }, { status: 422 })
+  }
+
+  const { week, avg4w } = parsed.data
+
+  await db.$transaction([
+    db.config.upsert({
+      where: { scope_key: { scope: GLOBAL_SCOPE, key: HEALTH_SCORE_WEEK_THRESHOLD_KEY } },
+      update: { value: week },
+      create: {
+        scope: GLOBAL_SCOPE,
+        projectId: null,
+        key: HEALTH_SCORE_WEEK_THRESHOLD_KEY,
+        value: week,
+      },
+    }),
+    db.config.upsert({
+      where: { scope_key: { scope: GLOBAL_SCOPE, key: HEALTH_SCORE_AVG4W_THRESHOLD_KEY } },
+      update: { value: avg4w },
+      create: {
+        scope: GLOBAL_SCOPE,
+        projectId: null,
+        key: HEALTH_SCORE_AVG4W_THRESHOLD_KEY,
+        value: avg4w,
+      },
+    }),
+  ])
+
+  return NextResponse.json({ week, avg4w })
+}

--- a/apps/web/src/components/dashboard/ThresholdInput.tsx
+++ b/apps/web/src/components/dashboard/ThresholdInput.tsx
@@ -26,6 +26,7 @@ const FIELDS: { key: ThresholdKey; label: string; help: string }[] = [
 export default function ThresholdInput() {
   const [values, setValues] = useState<Record<ThresholdKey, string>>({ week: '', avg4w: '' })
   const [saved, setSaved] = useState<ThresholdValues | null>(null)
+  const [loadingInitial, setLoadingInitial] = useState(true)
   const [errors, setErrors] = useState<Record<ThresholdKey, string | null>>({
     week: null,
     avg4w: null,
@@ -43,6 +44,8 @@ export default function ThresholdInput() {
         setSaved(data)
       } catch (e) {
         console.error('Failed to load thresholds', e)
+      } finally {
+        setLoadingInitial(false)
       }
     }
     load()
@@ -96,6 +99,19 @@ export default function ThresholdInput() {
     } finally {
       setSaving(false)
     }
+  }
+
+  if (loadingInitial) {
+    return (
+      <div className="font-mono flex flex-col gap-6 w-full mx-auto px-5 sm:px-10 lg:px-20 py-10 animate-pulse">
+        <div className="h-4 w-56 rounded bg-white/10" />
+        <div className="h-3 w-full rounded bg-white/5" />
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <div className="h-20 rounded-2xl bg-white/5" />
+          <div className="h-20 rounded-2xl bg-white/5" />
+        </div>
+      </div>
+    )
   }
 
   return (

--- a/apps/web/src/components/dashboard/ThresholdInput.tsx
+++ b/apps/web/src/components/dashboard/ThresholdInput.tsx
@@ -33,6 +33,7 @@ export default function ThresholdInput() {
   })
   const [saving, setSaving] = useState(false)
   const [justSaved, setJustSaved] = useState(false)
+  const [saveError, setSaveError] = useState<string | null>(null)
 
   useEffect(() => {
     const load = async () => {
@@ -54,6 +55,7 @@ export default function ThresholdInput() {
   const handleChange = (key: ThresholdKey, raw: string) => {
     setValues((v) => ({ ...v, [key]: raw }))
     setJustSaved(false)
+    setSaveError(null)
     const result = healthScoreThresholdInputSchema.safeParse(raw)
     setErrors((e) => ({ ...e, [key]: result.success ? null : result.error.issues[0].message }))
   }
@@ -75,6 +77,7 @@ export default function ThresholdInput() {
     }
 
     setSaving(true)
+    setSaveError(null)
     try {
       const res = await fetch('/api/threshold', {
         method: 'PUT',
@@ -92,10 +95,7 @@ export default function ThresholdInput() {
       setValues({ week: String(data.week), avg4w: String(data.avg4w) })
       setJustSaved(true)
     } catch (e) {
-      setErrors((prev) => ({
-        ...prev,
-        week: e instanceof Error ? e.message : 'Failed to save',
-      }))
+      setSaveError(e instanceof Error ? e.message : 'Failed to save')
     } finally {
       setSaving(false)
     }
@@ -222,6 +222,8 @@ export default function ThresholdInput() {
             Saved
           </span>
         )}
+
+        {saveError && <span className="text-[#E333A3] text-xs">{saveError}</span>}
       </div>
     </div>
   )

--- a/apps/web/src/components/dashboard/ThresholdInput.tsx
+++ b/apps/web/src/components/dashboard/ThresholdInput.tsx
@@ -1,0 +1,212 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { healthScoreThresholdInputSchema } from '@/lib/schemas/admin'
+
+type ThresholdKey = 'week' | 'avg4w'
+
+interface ThresholdValues {
+  week: number
+  avg4w: number
+}
+
+const FIELDS: { key: ThresholdKey; label: string; help: string }[] = [
+  {
+    key: 'week',
+    label: 'Single-week threshold',
+    help: "Flags a project when this week's health score falls below this value.",
+  },
+  {
+    key: 'avg4w',
+    label: '4-week average threshold',
+    help: 'Flags a project when its 4-week average health score falls below this value.',
+  },
+]
+
+export default function ThresholdInput() {
+  const [values, setValues] = useState<Record<ThresholdKey, string>>({ week: '', avg4w: '' })
+  const [saved, setSaved] = useState<ThresholdValues | null>(null)
+  const [errors, setErrors] = useState<Record<ThresholdKey, string | null>>({
+    week: null,
+    avg4w: null,
+  })
+  const [saving, setSaving] = useState(false)
+  const [justSaved, setJustSaved] = useState(false)
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const res = await fetch('/api/threshold')
+        if (!res.ok) return
+        const data = (await res.json()) as ThresholdValues
+        setValues({ week: String(data.week), avg4w: String(data.avg4w) })
+        setSaved(data)
+      } catch (e) {
+        console.error('Failed to load thresholds', e)
+      }
+    }
+    load()
+  }, [])
+
+  const handleChange = (key: ThresholdKey, raw: string) => {
+    setValues((v) => ({ ...v, [key]: raw }))
+    setJustSaved(false)
+    const result = healthScoreThresholdInputSchema.safeParse(raw)
+    setErrors((e) => ({ ...e, [key]: result.success ? null : result.error.issues[0].message }))
+  }
+
+  const isDirty =
+    saved !== null && (values.week !== String(saved.week) || values.avg4w !== String(saved.avg4w))
+  const isValid =
+    !errors.week && !errors.avg4w && values.week.trim() !== '' && values.avg4w.trim() !== ''
+
+  const handleSave = async () => {
+    const weekResult = healthScoreThresholdInputSchema.safeParse(values.week)
+    const avg4wResult = healthScoreThresholdInputSchema.safeParse(values.avg4w)
+    if (!weekResult.success || !avg4wResult.success) {
+      setErrors({
+        week: weekResult.success ? null : weekResult.error.issues[0].message,
+        avg4w: avg4wResult.success ? null : avg4wResult.error.issues[0].message,
+      })
+      return
+    }
+
+    setSaving(true)
+    try {
+      const res = await fetch('/api/threshold', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ week: weekResult.data, avg4w: avg4wResult.data }),
+      })
+
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}))
+        throw new Error(body?.message ?? 'Failed to save thresholds')
+      }
+
+      const data = (await res.json()) as ThresholdValues
+      setSaved(data)
+      setValues({ week: String(data.week), avg4w: String(data.avg4w) })
+      setJustSaved(true)
+    } catch (e) {
+      setErrors((prev) => ({
+        ...prev,
+        week: e instanceof Error ? e.message : 'Failed to save',
+      }))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className="font-mono flex flex-col gap-6 w-full mx-auto px-5 sm:px-10 lg:px-20 py-10">
+      {/* Header */}
+      <div>
+        <h2 className="text-[#077CF1] font-extrabold text-sm uppercase tracking-widest m-0">
+          Struggling-Project Thresholds
+        </h2>
+        <p className="text-gray-500 text-xs mt-1.5 leading-relaxed">
+          Set the health score thresholds used to flag struggling projects on the all-projects
+          overview. A project is flagged if it falls below either threshold.
+        </p>
+      </div>
+
+      {/* Inputs */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        {FIELDS.map((f) => (
+          <div key={f.key} className="flex flex-col gap-2">
+            <label
+              htmlFor={`threshold-${f.key}`}
+              className="text-[0.78rem] font-bold text-[#077CF1]"
+            >
+              {f.label}
+            </label>
+            <p className="text-[0.7rem] text-gray-500 leading-snug -mt-1">{f.help}</p>
+            <div
+              className="rounded-2xl p-0.5 transition-all duration-300"
+              style={{
+                background: errors[f.key]
+                  ? 'linear-gradient(135deg, #E333A3 0%, #ff6b6b 100%)'
+                  : 'linear-gradient(135deg, #2a2a3e 0%, #3a3a5e 100%)',
+              }}
+            >
+              <input
+                id={`threshold-${f.key}`}
+                type="number"
+                inputMode="numeric"
+                value={values[f.key]}
+                onChange={(e) => handleChange(f.key, e.target.value)}
+                className="block w-full px-4 py-3 rounded-[14px] bg-[#0d0f1a] font-mono text-[0.88rem]
+                           text-gray-100 border-none outline-none"
+                style={{ caretColor: '#077CF1' }}
+              />
+            </div>
+            {errors[f.key] && <span className="text-[#E333A3] text-xs">{errors[f.key]}</span>}
+          </div>
+        ))}
+      </div>
+
+      {/* Save controls */}
+      <div className="flex items-center gap-3 flex-wrap">
+        <button
+          onClick={handleSave}
+          disabled={!isValid || saving || !isDirty}
+          className="inline-flex items-center gap-1.5 px-5 py-2.5 rounded-xl border-none
+             font-mono text-[0.8rem] font-bold uppercase tracking-widest
+             transition-all duration-200 disabled:cursor-not-allowed"
+          style={{
+            background:
+              isValid && !saving && isDirty
+                ? 'linear-gradient(135deg, #077CF1 0%, #0FAAA0 100%)'
+                : '#1f2231',
+            color: isValid && !saving && isDirty ? '#fff' : '#4b5563',
+          }}
+        >
+          {saving ? (
+            <>
+              <svg width="13" height="13" viewBox="0 0 16 16" fill="none" className="animate-spin">
+                <circle
+                  cx="8"
+                  cy="8"
+                  r="6"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeDasharray="20 15"
+                />
+              </svg>
+              Saving…
+            </>
+          ) : (
+            <>
+              <svg width="13" height="13" viewBox="0 0 16 16" fill="none">
+                <path
+                  d="M3 8l4 4 6-6"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+              Save
+            </>
+          )}
+        </button>
+
+        {justSaved && (
+          <span className="flex items-center gap-1 text-[#0FAAA0] text-xs">
+            <svg width="12" height="12" viewBox="0 0 16 16" fill="none">
+              <path
+                d="M3 8l4 4 6-6"
+                stroke="#0FAAA0"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+            Saved
+          </span>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/lib/admin/threshold.ts
+++ b/apps/web/src/lib/admin/threshold.ts
@@ -1,0 +1,7 @@
+// Config keys and defaults for the struggling-project health score thresholds.
+
+export const HEALTH_SCORE_WEEK_THRESHOLD_KEY = 'healthScoreWeekThreshold'
+export const HEALTH_SCORE_AVG4W_THRESHOLD_KEY = 'healthScoreAvg4wThreshold'
+
+export const DEFAULT_HEALTH_SCORE_WEEK_THRESHOLD = 200
+export const DEFAULT_HEALTH_SCORE_AVG4W_THRESHOLD = 200

--- a/apps/web/src/lib/schemas/admin.ts
+++ b/apps/web/src/lib/schemas/admin.ts
@@ -130,3 +130,23 @@ export const formulaSchema = z
     },
     { message: 'Formula must evaluate to a finite number' }
   )
+
+// -- Struggling-Project Thresholds --
+
+export const HEALTH_SCORE_THRESHOLD_MIN = 0
+export const HEALTH_SCORE_THRESHOLD_MAX = 100_000
+
+// threshold must be between specified range
+export const healthScoreThresholdSchema = z
+  .number({ error: 'Must be a number' })
+  .finite('Must be a finite number')
+  .min(HEALTH_SCORE_THRESHOLD_MIN, `Must be at least ${HEALTH_SCORE_THRESHOLD_MIN}`)
+  .max(HEALTH_SCORE_THRESHOLD_MAX, `Must be at most ${HEALTH_SCORE_THRESHOLD_MAX.toLocaleString()}`)
+
+// threshold input must be a string that can be coerced to a number and validated against the threshold schema
+export const healthScoreThresholdInputSchema = z
+  .string()
+  .trim()
+  .min(1, 'Threshold is required')
+  .pipe(z.coerce.number({ error: 'Must be a number' }))
+  .pipe(healthScoreThresholdSchema)


### PR DESCRIPTION
## Description

Allows the admins to configure weekly and 4 week average thresholds to determine what projects are struggling

## Solution

- Validates that the input is numeric and within a range of 0 and 100000
- Provided default values of 200 for both values
- Saved to the database in the config table
- The thresholds are described briefly in the UI

## Notes

<img width="1823" height="275" alt="image" src="https://github.com/user-attachments/assets/4da739c5-5c8e-4ede-9eb0-ec2724272401" />

