### PR TITLE
[#223] Health calculations saved

### DIFF
--- a/apps/web/src/app/api/formula/[type]/route.ts
+++ b/apps/web/src/app/api/formula/[type]/route.ts
@@ -3,6 +3,7 @@ import { db, Role } from '@repo/db'
 import { z } from 'zod'
 import { formulaSchema } from '@/lib/schemas/admin'
 import { hasRole } from '@/lib/auth'
+import { recomputeAllHealthScores } from '@/lib/admin/health-score'
 
 const VALID_TYPES = ['health', 'mvp'] as const
 type FormulaType = (typeof VALID_TYPES)[number]
@@ -73,6 +74,10 @@ export async function PUT(request: Request, { params }: { params: Promise<{ type
       value: validated.data,
     },
   })
+
+  if (type === 'health') {
+    await recomputeAllHealthScores(validated.data)
+  }
 
   return NextResponse.json({ formula: config.value as string, updatedAt: config.updatedAt })
 }

--- a/apps/web/src/lib/admin/health-score.test.ts
+++ b/apps/web/src/lib/admin/health-score.test.ts
@@ -45,6 +45,7 @@ describe('recomputeAllHealthScores', () => {
       data: {
         healthScore: 50,
         algorithmVersion: 'commits + prs * 2 + lines_changed / 10 + discord_messages',
+        computedAt: expect.any(Date),
       },
     })
   })
@@ -59,11 +60,11 @@ describe('recomputeAllHealthScores', () => {
 
     expect(db.weeklyStats.update).toHaveBeenCalledWith({
       where: { id: 'zero-commits' },
-      data: { healthScore: null, algorithmVersion: null },
+      data: { healthScore: null, algorithmVersion: null, computedAt: expect.any(Date) },
     })
     expect(db.weeklyStats.update).toHaveBeenCalledWith({
       where: { id: 'has-commits' },
-      data: { healthScore: 0.25, algorithmVersion: '1 / commits' },
+      data: { healthScore: 0.25, algorithmVersion: '1 / commits', computedAt: expect.any(Date) },
     })
   })
 
@@ -76,7 +77,7 @@ describe('recomputeAllHealthScores', () => {
 
     expect(db.weeklyStats.update).toHaveBeenCalledWith({
       where: { id: 'row-1' },
-      data: { healthScore: null, algorithmVersion: null },
+      data: { healthScore: null, algorithmVersion: null, computedAt: expect.any(Date) },
     })
   })
 
@@ -94,7 +95,7 @@ describe('recomputeAllHealthScores', () => {
 
     expect(db.weeklyStats.update).toHaveBeenCalledWith({
       where: { id: 'writes-fine' },
-      data: { healthScore: 2, algorithmVersion: 'commits' },
+      data: { healthScore: 2, algorithmVersion: 'commits', computedAt: expect.any(Date) },
     })
   })
 })

--- a/apps/web/src/lib/admin/health-score.test.ts
+++ b/apps/web/src/lib/admin/health-score.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('@repo/db', () => ({
+  db: {
+    weeklyStats: {
+      findMany: vi.fn(),
+      update: vi.fn(),
+    },
+  },
+}))
+
+import { db } from '@repo/db'
+import { recomputeAllHealthScores } from './health-score'
+
+const baseStats = {
+  commits: 0,
+  prsMerged: 0,
+  linesAdded: 0,
+  linesRemoved: 0,
+  discordMessages: 0,
+}
+
+describe('recomputeAllHealthScores', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('maps formula variable names to the right fields and writes healthScore + algorithmVersion', async () => {
+    vi.mocked(db.weeklyStats.findMany).mockResolvedValue([
+      {
+        id: 'row-1',
+        ...baseStats,
+        commits: 10,
+        prsMerged: 3,
+        linesAdded: 100,
+        linesRemoved: 40,
+        discordMessages: 20,
+      },
+    ] as never)
+
+    await recomputeAllHealthScores('commits + prs * 2 + lines_changed / 10 + discord_messages')
+
+    expect(db.weeklyStats.update).toHaveBeenCalledWith({
+      where: { id: 'row-1' },
+      data: {
+        healthScore: 50,
+        algorithmVersion: 'commits + prs * 2 + lines_changed / 10 + discord_messages',
+      },
+    })
+  })
+
+  it('writes null healthScore/algorithmVersion for a row that evaluates to a non-finite result, and keeps processing other rows', async () => {
+    vi.mocked(db.weeklyStats.findMany).mockResolvedValue([
+      { id: 'zero-commits', ...baseStats, commits: 0 },
+      { id: 'has-commits', ...baseStats, commits: 4 },
+    ] as never)
+
+    await recomputeAllHealthScores('1 / commits')
+
+    expect(db.weeklyStats.update).toHaveBeenCalledWith({
+      where: { id: 'zero-commits' },
+      data: { healthScore: null, algorithmVersion: null },
+    })
+    expect(db.weeklyStats.update).toHaveBeenCalledWith({
+      where: { id: 'has-commits' },
+      data: { healthScore: 0.25, algorithmVersion: '1 / commits' },
+    })
+  })
+
+  it('writes null for every row without throwing when the formula fails to compile', async () => {
+    vi.mocked(db.weeklyStats.findMany).mockResolvedValue([
+      { id: 'row-1', ...baseStats, commits: 5 },
+    ] as never)
+
+    await expect(recomputeAllHealthScores('commits +* 2')).resolves.toBeUndefined()
+
+    expect(db.weeklyStats.update).toHaveBeenCalledWith({
+      where: { id: 'row-1' },
+      data: { healthScore: null, algorithmVersion: null },
+    })
+  })
+
+  it('continues processing remaining rows when writing one row fails', async () => {
+    vi.mocked(db.weeklyStats.findMany).mockResolvedValue([
+      { id: 'fails-to-write', ...baseStats, commits: 1 },
+      { id: 'writes-fine', ...baseStats, commits: 2 },
+    ] as never)
+    vi.mocked(db.weeklyStats.update).mockImplementation(((args: { where: { id: string } }) => {
+      if (args.where.id === 'fails-to-write') return Promise.reject(new Error('db down'))
+      return Promise.resolve({})
+    }) as unknown as typeof db.weeklyStats.update)
+
+    await expect(recomputeAllHealthScores('commits')).resolves.toBeUndefined()
+
+    expect(db.weeklyStats.update).toHaveBeenCalledWith({
+      where: { id: 'writes-fine' },
+      data: { healthScore: 2, algorithmVersion: 'commits' },
+    })
+  })
+})

--- a/apps/web/src/lib/admin/health-score.ts
+++ b/apps/web/src/lib/admin/health-score.ts
@@ -1,0 +1,64 @@
+// Recomputes WeeklyStats.healthScore for every project and every week whenever the
+// global health formula changes, using the same variable mapping as the weekly worker job.
+
+import { db } from '@repo/db'
+import { math } from './formula'
+
+type WeeklyStatsCounts = {
+  commits: number
+  prsMerged: number
+  linesAdded: number
+  linesRemoved: number
+  discordMessages: number
+}
+
+function buildFormulaScope(stats: WeeklyStatsCounts): Record<string, number> {
+  return {
+    commits: stats.commits,
+    prs: stats.prsMerged,
+    lines_changed: stats.linesAdded + stats.linesRemoved,
+    discord_messages: stats.discordMessages,
+  }
+}
+
+function evaluateFormula(formula: string, scope: Record<string, number>): number | null {
+  try {
+    const result = math.compile(formula).evaluate(scope)
+    return typeof result === 'number' && Number.isFinite(result) ? result : null
+  } catch {
+    return null
+  }
+}
+
+export async function recomputeAllHealthScores(formula: string): Promise<void> {
+  const allStats = await db.weeklyStats.findMany({
+    select: {
+      id: true,
+      commits: true,
+      prsMerged: true,
+      linesAdded: true,
+      linesRemoved: true,
+      discordMessages: true,
+    },
+  })
+
+  console.log(
+    `Recomputing health scores for ${allStats.length} WeeklyStats row(s) using: ${formula}`
+  )
+
+  let succeeded = 0
+  for (const stats of allStats) {
+    const healthScore = evaluateFormula(formula, buildFormulaScope(stats))
+    try {
+      await db.weeklyStats.update({
+        where: { id: stats.id },
+        data: { healthScore, algorithmVersion: healthScore !== null ? formula : null },
+      })
+      succeeded++
+    } catch (err) {
+      console.error(`WeeklyStats ${stats.id}: failed to write recomputed health score: ${err}`)
+    }
+  }
+
+  console.log(`Health score recompute finished: ${succeeded}/${allStats.length} row(s) written`)
+}

--- a/apps/web/src/lib/admin/health-score.ts
+++ b/apps/web/src/lib/admin/health-score.ts
@@ -52,7 +52,11 @@ export async function recomputeAllHealthScores(formula: string): Promise<void> {
     try {
       await db.weeklyStats.update({
         where: { id: stats.id },
-        data: { healthScore, algorithmVersion: healthScore !== null ? formula : null },
+        data: {
+          healthScore,
+          algorithmVersion: healthScore !== null ? formula : null,
+          computedAt: new Date(),
+        },
       })
       succeeded++
     } catch (err) {

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@repo/db": "workspace:*",
     "@repo/github": "workspace:*",
+    "mathjs": "^15.2.0",
     "octokit": "^5.0.5"
   },
   "devDependencies": {

--- a/apps/worker/src/index.test.ts
+++ b/apps/worker/src/index.test.ts
@@ -6,6 +6,9 @@ vi.mock('./jobs/github', () => ({
 vi.mock('./jobs/discord', () => ({
   runDiscordIngestion: vi.fn(),
 }))
+vi.mock('./lib/health-score', () => ({
+  computeHealthScoresForActiveProjects: vi.fn(() => Promise.resolve()),
+}))
 vi.mock('./lib/logger', () => ({
   logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
 }))

--- a/apps/worker/src/index.test.ts
+++ b/apps/worker/src/index.test.ts
@@ -53,14 +53,16 @@ describe('main', () => {
     )
   })
 
-  it('still logs success when only Discord fails (completion signal is GitHub-specific)', async () => {
+  it('completion log reflects the failure when only Discord fails (both jobs must succeed)', async () => {
     vi.mocked(runGitHubIngestion).mockResolvedValue(undefined)
     vi.mocked(runDiscordIngestion).mockRejectedValue(new Error('discord down'))
 
     await main()
 
-    expect(logger.info).toHaveBeenCalledWith(SUCCESS_LOG)
-    expect(logger.error).not.toHaveBeenCalledWith(
+    // The success completion log must not fire when Discord fails...
+    expect(logger.info).not.toHaveBeenCalledWith(SUCCESS_LOG)
+    // ...and the completion log must clearly surface the failure.
+    expect(logger.error).toHaveBeenCalledWith(
       expect.stringContaining('Weekly ingestion completed with errors')
     )
   })

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -20,8 +20,9 @@ import { getCollectionWindow } from './lib/date-utils'
 //      sentimentParagraph, and summaryText to WeeklySummary. Dependency enforced
 //      in code, not by wall-clock timing.
 
-// Sentinel returned by the GitHub ingestion catch handler.
+// Sentinels returned by the ingestion catch handlers.
 export const GITHUB_INGESTION_FAILED = 'github-ingestion-failed' as const
+export const DISCORD_INGESTION_FAILED = 'discord-ingestion-failed' as const
 
 export async function main() {
   const [weekStart, weekEnd] = getCollectionWindow()
@@ -30,30 +31,42 @@ export async function main() {
     `Starting weekly ingestion jobs (GitHub + Discord in parallel) - week of ${weekStart.toISOString()}`
   )
 
-  const [githubResult, discordMessages] = await Promise.all([
+  const [githubResult, discordResult] = await Promise.all([
     runGitHubIngestion(weekStart, weekEnd).catch((err: unknown) => {
       logger.error(`GitHub ingestion failed: ${err}`)
       return GITHUB_INGESTION_FAILED
     }),
     runDiscordIngestion(weekStart, weekEnd).catch((err: unknown) => {
       logger.error(`Discord ingestion failed: ${err}`)
-      return []
+      return DISCORD_INGESTION_FAILED
     }),
   ])
+
+  const discordMessages = discordResult === DISCORD_INGESTION_FAILED ? [] : discordResult
 
   // TODO: await runLlmAnalysis(discordMessages)
   void discordMessages // placeholder to avoid unused variable error until LLM analysis is implemented
 
-  // Runs after both collection jobs have settled so it never scores against a
-  // discordMessages value that Discord ingestion hasn't written yet.
-  const [prevWeekStart] = getCollectionWindow(new Date(weekEnd.getTime() - 7 * 24 * 60 * 60 * 1000))
-  await computeHealthScoresForActiveProjects([prevWeekStart, weekStart]).catch((err: unknown) => {
-    logger.error(`Health score computation failed: ${err}`)
-  })
+  // Only score once both collection jobs have succeeded, so scores are never computed
+  // against stats that this week's ingestion failed to write.
+  if (githubResult === GITHUB_INGESTION_FAILED || discordResult === DISCORD_INGESTION_FAILED) {
+    logger.error('Skipping health score computation: one or more ingestion jobs failed')
+  } else {
+    const [prevWeekStart] = getCollectionWindow(
+      new Date(weekEnd.getTime() - 7 * 24 * 60 * 60 * 1000)
+    )
+    await computeHealthScoresForActiveProjects([prevWeekStart, weekStart]).catch((err: unknown) => {
+      logger.error(`Health score computation failed: ${err}`)
+    })
+  }
 
   if (githubResult === GITHUB_INGESTION_FAILED) {
     logger.error('Weekly ingestion completed with errors: GitHub ingestion failed')
-  } else {
+  }
+  if (discordResult === DISCORD_INGESTION_FAILED) {
+    logger.error('Weekly ingestion completed with errors: Discord ingestion failed')
+  }
+  if (githubResult !== GITHUB_INGESTION_FAILED && discordResult !== DISCORD_INGESTION_FAILED) {
     logger.info('Weekly ingestion complete')
   }
 }

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -2,6 +2,7 @@
 // import { runLlmAnalysis } from './jobs/llm'
 import { runGitHubIngestion } from './jobs/github'
 import { runDiscordIngestion } from './jobs/discord'
+import { computeHealthScoresForActiveProjects } from './lib/health-score'
 import { logger } from './lib/logger'
 import { getCollectionWindow } from './lib/date-utils'
 
@@ -42,6 +43,13 @@ export async function main() {
 
   // TODO: await runLlmAnalysis(discordMessages)
   void discordMessages // placeholder to avoid unused variable error until LLM analysis is implemented
+
+  // Runs after both collection jobs have settled so it never scores against a
+  // discordMessages value that Discord ingestion hasn't written yet.
+  const [prevWeekStart] = getCollectionWindow(new Date(weekEnd.getTime() - 7 * 24 * 60 * 60 * 1000))
+  await computeHealthScoresForActiveProjects([prevWeekStart, weekStart]).catch((err: unknown) => {
+    logger.error(`Health score computation failed: ${err}`)
+  })
 
   if (githubResult === GITHUB_INGESTION_FAILED) {
     logger.error('Weekly ingestion completed with errors: GitHub ingestion failed')

--- a/apps/worker/src/lib/health-score.integration.test.ts
+++ b/apps/worker/src/lib/health-score.integration.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { db } from '@repo/db'
+import { computeHealthScoreForWeek, computeHealthScoresForActiveProjects } from './health-score'
+import { seedProjectWithRepo } from '../test-config/integration.helpers'
+
+const WEEK_START = new Date('2026-05-04T00:00:00Z')
+
+const GLOBAL_SCOPE = 'GLOBAL'
+const HEALTH_FORMULA_KEY = 'healthFormula'
+
+async function seedHealthFormula(formula: string) {
+  return db.config.upsert({
+    where: { scope_key: { scope: GLOBAL_SCOPE, key: HEALTH_FORMULA_KEY } },
+    update: { value: formula },
+    create: { scope: GLOBAL_SCOPE, projectId: null, key: HEALTH_FORMULA_KEY, value: formula },
+  })
+}
+
+async function seedWeeklyStats(
+  projectId: string,
+  weekStart: Date,
+  counts: {
+    commits?: number
+    prsMerged?: number
+    linesAdded?: number
+    linesRemoved?: number
+    discordMessages?: number
+  } = {}
+) {
+  return db.weeklyStats.create({
+    data: {
+      projectId,
+      weekStart,
+      commits: counts.commits ?? 0,
+      prsMerged: counts.prsMerged ?? 0,
+      linesAdded: counts.linesAdded ?? 0,
+      linesRemoved: counts.linesRemoved ?? 0,
+      discordMessages: counts.discordMessages ?? 0,
+    },
+  })
+}
+
+describe('health-score (integration)', () => {
+  beforeEach(async () => {
+    await db.weeklyStats.deleteMany()
+    await db.config.deleteMany()
+    await db.project.deleteMany()
+  })
+
+  describe('computeHealthScoreForWeek', () => {
+    it('does nothing when no formula is configured', async () => {
+      const { project } = await seedProjectWithRepo()
+      await seedWeeklyStats(project.id, WEEK_START, { commits: 5 })
+
+      await computeHealthScoreForWeek(project.id, WEEK_START, null)
+
+      const stats = await db.weeklyStats.findUnique({
+        where: { projectId_weekStart: { projectId: project.id, weekStart: WEEK_START } },
+      })
+      expect(stats!.healthScore).toBeNull()
+    })
+
+    it('does nothing when no WeeklyStats row exists yet for that week', async () => {
+      const { project } = await seedProjectWithRepo()
+
+      await expect(
+        computeHealthScoreForWeek(project.id, WEEK_START, 'commits * 2')
+      ).resolves.toBeUndefined()
+
+      const stats = await db.weeklyStats.findFirst({ where: { projectId: project.id } })
+      expect(stats).toBeNull()
+    })
+
+    it('evaluates the formula against real weekly data and maps formula variable names correctly', async () => {
+      const { project } = await seedProjectWithRepo()
+      await seedWeeklyStats(project.id, WEEK_START, {
+        commits: 10,
+        prsMerged: 3,
+        linesAdded: 100,
+        linesRemoved: 40,
+        discordMessages: 20,
+      })
+
+      // prs -> prsMerged, lines_changed -> linesAdded + linesRemoved, discord_messages -> discordMessages
+      await computeHealthScoreForWeek(
+        project.id,
+        WEEK_START,
+        'commits + prs * 2 + lines_changed / 10 + discord_messages'
+      )
+
+      const stats = await db.weeklyStats.findUnique({
+        where: { projectId_weekStart: { projectId: project.id, weekStart: WEEK_START } },
+      })
+      // 10 + 3*2 + (100+40)/10 + 20 = 10 + 6 + 14 + 20 = 50
+      expect(stats!.healthScore).toBe(50)
+      expect(stats!.algorithmVersion).toBe(
+        'commits + prs * 2 + lines_changed / 10 + discord_messages'
+      )
+    })
+
+    it('sets healthScore to null without throwing when the formula fails to compile', async () => {
+      const { project } = await seedProjectWithRepo()
+      await seedWeeklyStats(project.id, WEEK_START, { commits: 5 })
+
+      await expect(
+        computeHealthScoreForWeek(project.id, WEEK_START, 'commits +* 2')
+      ).resolves.toBeUndefined()
+
+      const stats = await db.weeklyStats.findUnique({
+        where: { projectId_weekStart: { projectId: project.id, weekStart: WEEK_START } },
+      })
+      expect(stats!.healthScore).toBeNull()
+      expect(stats!.algorithmVersion).toBeNull()
+    })
+
+    it('sets healthScore to null without throwing when the formula evaluates to a non-finite result', async () => {
+      const { project } = await seedProjectWithRepo()
+      await seedWeeklyStats(project.id, WEEK_START, { commits: 0 })
+
+      await expect(
+        computeHealthScoreForWeek(project.id, WEEK_START, '1 / commits')
+      ).resolves.toBeUndefined()
+
+      const stats = await db.weeklyStats.findUnique({
+        where: { projectId_weekStart: { projectId: project.id, weekStart: WEEK_START } },
+      })
+      expect(stats!.healthScore).toBeNull()
+    })
+
+    it('is idempotent and only touches healthScore/algorithmVersion, leaving raw counts untouched', async () => {
+      const { project } = await seedProjectWithRepo()
+      await seedWeeklyStats(project.id, WEEK_START, { commits: 4, prsMerged: 1 })
+
+      await computeHealthScoreForWeek(project.id, WEEK_START, 'commits + prs')
+      await computeHealthScoreForWeek(project.id, WEEK_START, 'commits + prs')
+
+      const stats = await db.weeklyStats.findUnique({
+        where: { projectId_weekStart: { projectId: project.id, weekStart: WEEK_START } },
+      })
+      expect(stats!.healthScore).toBe(5)
+      expect(stats!.commits).toBe(4)
+      expect(stats!.prsMerged).toBe(1)
+    })
+  })
+
+  describe('computeHealthScoresForActiveProjects', () => {
+    it('skips all projects when no formula is configured', async () => {
+      const { project } = await seedProjectWithRepo()
+      await seedWeeklyStats(project.id, WEEK_START, { commits: 5 })
+
+      await computeHealthScoresForActiveProjects([WEEK_START])
+
+      const stats = await db.weeklyStats.findUnique({
+        where: { projectId_weekStart: { projectId: project.id, weekStart: WEEK_START } },
+      })
+      expect(stats!.healthScore).toBeNull()
+    })
+
+    it('scores multiple active projects independently across multiple weeks', async () => {
+      await seedHealthFormula('commits')
+      const { project: projectA } = await seedProjectWithRepo()
+      const { project: projectB } = await seedProjectWithRepo()
+
+      const prevWeek = new Date('2026-04-27T00:00:00Z')
+      await seedWeeklyStats(projectA.id, prevWeek, { commits: 3 })
+      await seedWeeklyStats(projectA.id, WEEK_START, { commits: 7 })
+      await seedWeeklyStats(projectB.id, WEEK_START, { commits: 2 })
+
+      await computeHealthScoresForActiveProjects([prevWeek, WEEK_START])
+
+      const statsAPrev = await db.weeklyStats.findUnique({
+        where: { projectId_weekStart: { projectId: projectA.id, weekStart: prevWeek } },
+      })
+      const statsACurrent = await db.weeklyStats.findUnique({
+        where: { projectId_weekStart: { projectId: projectA.id, weekStart: WEEK_START } },
+      })
+      const statsB = await db.weeklyStats.findUnique({
+        where: { projectId_weekStart: { projectId: projectB.id, weekStart: WEEK_START } },
+      })
+
+      expect(statsAPrev!.healthScore).toBe(3)
+      expect(statsACurrent!.healthScore).toBe(7)
+      expect(statsB!.healthScore).toBe(2)
+    })
+
+    it('does not score inactive projects', async () => {
+      await seedHealthFormula('commits')
+      const { project } = await seedProjectWithRepo()
+      await db.project.update({ where: { id: project.id }, data: { isActive: false } })
+      await seedWeeklyStats(project.id, WEEK_START, { commits: 9 })
+
+      await computeHealthScoresForActiveProjects([WEEK_START])
+
+      const stats = await db.weeklyStats.findUnique({
+        where: { projectId_weekStart: { projectId: project.id, weekStart: WEEK_START } },
+      })
+      expect(stats!.healthScore).toBeNull()
+    })
+  })
+})

--- a/apps/worker/src/lib/health-score.ts
+++ b/apps/worker/src/lib/health-score.ts
@@ -85,7 +85,11 @@ export async function computeHealthScoreForWeek(
   try {
     await db.weeklyStats.update({
       where: { projectId_weekStart: { projectId, weekStart } },
-      data: { healthScore, algorithmVersion: healthScore !== null ? formula : null },
+      data: {
+        healthScore,
+        algorithmVersion: healthScore !== null ? formula : null,
+        computedAt: new Date(),
+      },
     })
   } catch (err) {
     logger.error(

--- a/apps/worker/src/lib/health-score.ts
+++ b/apps/worker/src/lib/health-score.ts
@@ -1,0 +1,120 @@
+// Computes each project's weekly health score from the global formula stored in Config
+// (scope="GLOBAL", key="healthFormula") and persists it to WeeklyStats.healthScore.
+
+import { db } from '@repo/db'
+import { logger } from './logger'
+
+// Dynamic import avoids a static `require('mathjs')` under this project's CJS/node16
+// module resolution — mathjs is ESM-only. Mirrors the same workaround already used
+// for octokit in packages/github/src/index.ts.
+type MathInstance = ReturnType<
+  typeof import('mathjs', { with: { 'resolution-mode': 'import' } }).create
+>
+
+let mathInstance: MathInstance | null = null
+
+async function getMath(): Promise<MathInstance> {
+  if (!mathInstance) {
+    const { create, all } = await import('mathjs')
+    mathInstance = create(all)
+  }
+  return mathInstance
+}
+
+const GLOBAL_SCOPE = 'GLOBAL'
+const HEALTH_FORMULA_KEY = 'healthFormula'
+
+type WeeklyStatsCounts = {
+  commits: number
+  prsMerged: number
+  linesAdded: number
+  linesRemoved: number
+  discordMessages: number
+}
+
+function buildFormulaScope(stats: WeeklyStatsCounts): Record<string, number> {
+  return {
+    commits: stats.commits,
+    prs: stats.prsMerged,
+    lines_changed: stats.linesAdded + stats.linesRemoved,
+    discord_messages: stats.discordMessages,
+  }
+}
+
+async function evaluateFormula(
+  formula: string,
+  scope: Record<string, number>
+): Promise<number | null> {
+  try {
+    const math = await getMath()
+    const result = math.compile(formula).evaluate(scope)
+    return typeof result === 'number' && Number.isFinite(result) ? result : null
+  } catch {
+    return null
+  }
+}
+
+export async function getHealthFormula(): Promise<string | null> {
+  const config = await db.config.findUnique({
+    where: { scope_key: { scope: GLOBAL_SCOPE, key: HEALTH_FORMULA_KEY } },
+  })
+  return typeof config?.value === 'string' ? config.value : null
+}
+
+export async function computeHealthScoreForWeek(
+  projectId: string,
+  weekStart: Date,
+  formula: string | null
+): Promise<void> {
+  if (!formula) return
+
+  const stats = await db.weeklyStats.findUnique({
+    where: { projectId_weekStart: { projectId, weekStart } },
+    select: {
+      commits: true,
+      prsMerged: true,
+      linesAdded: true,
+      linesRemoved: true,
+      discordMessages: true,
+    },
+  })
+  if (!stats) return
+
+  const healthScore = await evaluateFormula(formula, buildFormulaScope(stats))
+
+  try {
+    await db.weeklyStats.update({
+      where: { projectId_weekStart: { projectId, weekStart } },
+      data: { healthScore, algorithmVersion: healthScore !== null ? formula : null },
+    })
+  } catch (err) {
+    logger.error(
+      `Project ${projectId}: failed to write health score for week ${weekStart.toISOString()}: ${err}`
+    )
+  }
+}
+
+export async function computeHealthScoresForActiveProjects(weekStarts: Date[]): Promise<void> {
+  const formula = await getHealthFormula()
+  if (!formula) {
+    logger.info('No health formula configured; skipping health score computation')
+    return
+  }
+
+  const projects = await db.project.findMany({
+    where: { isActive: true },
+    select: { id: true },
+  })
+
+  logger.info(
+    `Computing health scores for ${projects.length} active project(s) across ${weekStarts.length} week(s) using: ${formula}`
+  )
+
+  for (const project of projects) {
+    for (const weekStart of weekStarts) {
+      await computeHealthScoreForWeek(project.id, weekStart, formula)
+    }
+  }
+
+  logger.info('Health score computation complete')
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -140,6 +140,9 @@ importers:
       '@repo/github':
         specifier: workspace:*
         version: link:../../packages/github
+      mathjs:
+        specifier: ^15.2.0
+        version: 15.2.0
       octokit:
         specifier: ^5.0.5
         version: 5.0.5


### PR DESCRIPTION
## Description

Closes #223. Computes a health score for every project, every week, from the global formula saved in `Config`, and persists it to `WeeklyStats.healthScore`.

## Solution

Two triggers, matching the ticket's acceptance criteria:

- **Weekly job** (`apps/worker/src/lib/health-score.ts`) — computes `healthScore` for the current + previous week for every active project, hooked into `apps/worker/src/index.ts` after GitHub + Discord ingestion finish.
- **On formula save** (`apps/web/src/lib/admin/health-score.ts`) — recomputes `healthScore` for every `WeeklyStats` row, hooked into `PUT /api/formula/[type]/route.ts` for the health formula.

Missing/broken formulas resolve to `healthScore: null` without throwing, and writes only ever touch `healthScore`/`algorithmVersion`.