### PR TITLE
[#238] setup connection to ai service

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,8 @@ DIRECT_URL=postgresql://postgres.<project-ref>:[YOUR-PASSWORD]@aws-0-<region>.po
 # ─── GitHub App ───────────────────────────────────────────────────────────────
 # From: GitHub Developer Settings → GitHub Apps
 GITHUB_APP_ID=
+GITHUB_APP_INSTALLATION_ID=
+GITHUB_APP_PRIVATE_KEY=
 
 # ─── Discord Bot ──────────────────────────────────────────────────────────────
 # From: Discord Developer Portal → Bot → Token

--- a/.env.example
+++ b/.env.example
@@ -25,7 +25,6 @@ DIRECT_URL=postgresql://postgres.<project-ref>:[YOUR-PASSWORD]@aws-0-<region>.po
 # ─── GitHub App ───────────────────────────────────────────────────────────────
 # From: GitHub Developer Settings → GitHub Apps
 GITHUB_APP_ID=
-GITHUB_APP_PRIVATE_KEY=
 
 # ─── Discord Bot ──────────────────────────────────────────────────────────────
 # From: Discord Developer Portal → Bot → Token
@@ -34,4 +33,10 @@ DISCORD_BOT_TOKEN=
 DISCORD_GUILD_ID=
 
 # ─── LLM ─────────────────────────────────────────────────────────────────────
+# Base URL of an OpenAI-compatible API. Defaults to Ollama at http://localhost:11434/v1.
+# For OpenAI, use https://api.openai.com/v1.
+AI_BASE_URL=
+# Model identifier understood by the configured API (for example, llama3.1 or gpt-4.1-mini).
+# This value is required.
+AI_MODEL=
 OPENAI_API_KEY=

--- a/apps/worker/src/lib/ai-client.test.ts
+++ b/apps/worker/src/lib/ai-client.test.ts
@@ -132,4 +132,23 @@ describe('AI client', () => {
     await expect(client.request(request)).rejects.toThrow(message)
     await expect(client.request(request)).rejects.toBeInstanceOf(AiResponseError)
   })
+
+  it('wraps an invalid JSON response body in an AiResponseError', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ...response(undefined),
+      json: async () => {
+        throw new SyntaxError('Unexpected token')
+      },
+    } as Response)
+    const client = createAiClient(
+      { baseUrl: 'http://localhost:11434/v1', model: 'llama3.1', maxRetries: 2 },
+      { fetch: fetchMock }
+    )
+
+    const result = client.request(request)
+
+    await expect(result).rejects.toThrow('AI response body was not valid JSON')
+    await expect(result).rejects.toBeInstanceOf(AiResponseError)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
 })

--- a/apps/worker/src/lib/ai-client.test.ts
+++ b/apps/worker/src/lib/ai-client.test.ts
@@ -1,0 +1,135 @@
+import { AiConfigurationError, AiResponseError, createAiClient, loadAiConfig } from './ai-client'
+
+function response(body: unknown, status = 200, headers: Record<string, string> = {}): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: '',
+    headers: new Headers(headers),
+    json: async () => body,
+  } as Response
+}
+
+const request = {
+  messages: [
+    { role: 'system' as const, content: 'Return a health summary as JSON.' },
+    { role: 'user' as const, content: 'Summarise this project.' },
+  ],
+  promptVersion: 'weekly-summary-v1',
+}
+
+describe('AI client', () => {
+  it('sends an OpenAI-compatible request and returns structured data with provenance', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(response({ choices: [{ message: { content: '{"summary":"Healthy"}' } }] }))
+    const client = createAiClient(
+      { baseUrl: 'https://ai.example.com/v1/', model: 'gpt-4.1-mini', apiKey: 'secret' },
+      { fetch: fetchMock }
+    )
+
+    await expect(client.request<{ summary: string }>(request)).resolves.toEqual({
+      data: { summary: 'Healthy' },
+      provenance: { model: 'gpt-4.1-mini', promptVersion: 'weekly-summary-v1' },
+    })
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://ai.example.com/v1/chat/completions',
+      expect.objectContaining({
+        method: 'POST',
+        headers: { 'content-type': 'application/json', authorization: 'Bearer secret' },
+      })
+    )
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toEqual({
+      model: 'gpt-4.1-mini',
+      messages: request.messages,
+      response_format: { type: 'json_object' },
+    })
+  })
+
+  it('supports a local Ollama endpoint without an API key', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(response({ choices: [{ message: { content: '{"ok":true}' } }] }))
+    const client = createAiClient(
+      { baseUrl: 'http://localhost:11434/v1', model: 'llama3.1' },
+      { fetch: fetchMock }
+    )
+
+    await client.request(request)
+
+    expect(fetchMock.mock.calls[0][1].headers).toEqual({ 'content-type': 'application/json' })
+  })
+
+  it('reports clear configuration errors', async () => {
+    expect(() => loadAiConfig({ AI_BASE_URL: 'http://localhost:11434/v1' })).toThrow(
+      /AI_MODEL is required/
+    )
+    expect(() =>
+      loadAiConfig({ AI_BASE_URL: 'https://api.openai.com/v1', AI_MODEL: 'gpt-4.1-mini' })
+    ).toThrow(/AI_API_KEY is required/)
+    await expect(() =>
+      createAiClient({ baseUrl: 'http://localhost:11434/v1', model: 'llama3.1' }).request({
+        ...request,
+        promptVersion: ' ',
+      })
+    ).rejects.toBeInstanceOf(AiConfigurationError)
+  })
+
+  it('retries temporary failures and respects retry-after', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(response({ error: { message: 'busy' } }, 429, { 'retry-after': '2' }))
+      .mockResolvedValueOnce(response({ choices: [{ message: { content: '{"ok":true}' } }] }))
+    const sleep = vi.fn().mockResolvedValue(undefined)
+    const client = createAiClient(
+      { baseUrl: 'http://localhost:11434/v1', model: 'llama3.1', maxRetries: 2 },
+      { fetch: fetchMock, sleep }
+    )
+
+    await expect(client.request(request)).resolves.toMatchObject({ data: { ok: true } })
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(sleep).toHaveBeenCalledWith(2000)
+  })
+
+  it('retries network failures and stops at the configured limit', async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new Error('connection refused'))
+    const sleep = vi.fn().mockResolvedValue(undefined)
+    const client = createAiClient(
+      { baseUrl: 'http://localhost:11434/v1', model: 'llama3.1', maxRetries: 2 },
+      { fetch: fetchMock, sleep }
+    )
+
+    await expect(client.request(request)).rejects.toThrow(/after 3 attempts: connection refused/)
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+    expect(sleep).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not retry permanent HTTP errors', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(response({ error: { message: 'bad request' } }, 400))
+    const sleep = vi.fn()
+    const client = createAiClient(
+      { baseUrl: 'http://localhost:11434/v1', model: 'llama3.1' },
+      { fetch: fetchMock, sleep }
+    )
+
+    await expect(client.request(request)).rejects.toMatchObject({ status: 400 })
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(sleep).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    [{ choices: [] }, 'did not contain message content'],
+    [{ choices: [{ message: { content: 'not json' } }] }, 'was not valid JSON'],
+  ])('rejects malformed successful responses', async (body, message) => {
+    const client = createAiClient(
+      { baseUrl: 'http://localhost:11434/v1', model: 'llama3.1' },
+      { fetch: vi.fn().mockResolvedValue(response(body)) }
+    )
+
+    await expect(client.request(request)).rejects.toThrow(message)
+    await expect(client.request(request)).rejects.toBeInstanceOf(AiResponseError)
+  })
+})

--- a/apps/worker/src/lib/ai-client.ts
+++ b/apps/worker/src/lib/ai-client.ts
@@ -1,0 +1,201 @@
+const DEFAULT_BASE_URL = 'http://localhost:11434/v1'
+const DEFAULT_MAX_RETRIES = 3
+const DEFAULT_RETRY_DELAY_MS = 500
+
+export interface AiClientConfig {
+  baseUrl: string
+  model: string
+  apiKey?: string
+  maxRetries?: number
+  retryDelayMs?: number
+}
+
+export interface AiRequest {
+  messages: Array<{
+    role: 'system' | 'user' | 'assistant'
+    content: string
+  }>
+  promptVersion: string
+}
+
+export interface AiResult<T> {
+  data: T
+  provenance: {
+    model: string
+    promptVersion: string
+  }
+}
+
+export interface AiClientDependencies {
+  fetch?: typeof fetch
+  sleep?: (milliseconds: number) => Promise<void>
+}
+
+export class AiConfigurationError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'AiConfigurationError'
+  }
+}
+
+export class AiRequestError extends Error {
+  readonly status?: number
+
+  constructor(message: string, status?: number) {
+    super(message)
+    this.name = 'AiRequestError'
+    this.status = status
+  }
+}
+
+export class AiResponseError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'AiResponseError'
+  }
+}
+
+function isLocalUrl(baseUrl: string): boolean {
+  let url: URL
+
+  try {
+    url = new URL(baseUrl)
+  } catch {
+    throw new AiConfigurationError(`AI_BASE_URL is not a valid URL: ${baseUrl}`)
+  }
+
+  return ['localhost', '127.0.0.1', '::1'].includes(url.hostname)
+}
+
+export function loadAiConfig(env: NodeJS.ProcessEnv = process.env): AiClientConfig {
+  const baseUrl = env.AI_BASE_URL?.trim() || DEFAULT_BASE_URL
+  const model = env.AI_MODEL?.trim()
+  const apiKey = env.OPENAI_API_KEY?.trim()
+
+  if (!model) {
+    throw new AiConfigurationError(
+      'AI_MODEL is required (for example, set AI_MODEL=llama3.1 when using Ollama)'
+    )
+  }
+
+  if (!isLocalUrl(baseUrl) && !apiKey) {
+    throw new AiConfigurationError('OPENAI_API_KEY is required when AI_BASE_URL is not local')
+  }
+
+  return { baseUrl, model, apiKey }
+}
+
+function retryDelay(response: Response | undefined, fallbackMs: number): number {
+  const retryAfter = response?.headers.get('retry-after')
+  if (!retryAfter) return fallbackMs
+
+  const seconds = Number(retryAfter)
+  if (Number.isFinite(seconds) && seconds >= 0) return seconds * 1000
+
+  const date = Date.parse(retryAfter)
+  return Number.isNaN(date) ? fallbackMs : Math.max(0, date - Date.now())
+}
+
+function isRetryableStatus(status: number): boolean {
+  return status === 408 || status === 429 || status >= 500
+}
+
+async function responseErrorMessage(response: Response): Promise<string> {
+  try {
+    const body = (await response.json()) as { error?: { message?: string }; message?: string }
+    return body.error?.message || body.message || response.statusText || 'Unknown error'
+  } catch {
+    return response.statusText || 'Unknown error'
+  }
+}
+
+export function createAiClient(
+  config: AiClientConfig = loadAiConfig(),
+  dependencies: AiClientDependencies = {}
+) {
+  const fetchImplementation = dependencies.fetch ?? globalThis.fetch
+  const sleep =
+    dependencies.sleep ??
+    ((milliseconds: number) => new Promise((resolve) => setTimeout(resolve, milliseconds)))
+  const maxRetries = config.maxRetries ?? DEFAULT_MAX_RETRIES
+  const initialDelay = config.retryDelayMs ?? DEFAULT_RETRY_DELAY_MS
+
+  if (!config.model.trim()) throw new AiConfigurationError('AI model must not be empty')
+  if (!Number.isInteger(maxRetries) || maxRetries < 0) {
+    throw new AiConfigurationError('maxRetries must be a non-negative integer')
+  }
+  if (!isLocalUrl(config.baseUrl) && !config.apiKey) {
+    throw new AiConfigurationError('An API key is required for non-local AI endpoints')
+  }
+
+  const endpoint = `${config.baseUrl.replace(/\/$/, '')}/chat/completions`
+
+  return {
+    async request<T>(request: AiRequest): Promise<AiResult<T>> {
+      if (!request.promptVersion.trim()) {
+        throw new AiConfigurationError('promptVersion must not be empty')
+      }
+
+      let lastError: unknown
+
+      for (let attempt = 0; attempt <= maxRetries; attempt += 1) {
+        let response: Response | undefined
+
+        try {
+          response = await fetchImplementation(endpoint, {
+            method: 'POST',
+            headers: {
+              'content-type': 'application/json',
+              ...(config.apiKey ? { authorization: `Bearer ${config.apiKey}` } : {}),
+            },
+            body: JSON.stringify({
+              model: config.model,
+              messages: request.messages,
+              response_format: { type: 'json_object' },
+            }),
+          })
+
+          if (response.ok) {
+            const body = (await response.json()) as {
+              choices?: Array<{ message?: { content?: string } }>
+            }
+            const content = body.choices?.[0]?.message?.content
+
+            if (!content) throw new AiResponseError('AI response did not contain message content')
+
+            try {
+              return {
+                data: JSON.parse(content) as T,
+                provenance: { model: config.model, promptVersion: request.promptVersion },
+              }
+            } catch (error) {
+              if (error instanceof AiResponseError) throw error
+              throw new AiResponseError('AI response content was not valid JSON')
+            }
+          }
+
+          const message = await responseErrorMessage(response)
+          lastError = new AiRequestError(
+            `AI request failed with HTTP ${response.status}: ${message}`,
+            response.status
+          )
+
+          if (!isRetryableStatus(response.status)) throw lastError
+        } catch (error) {
+          if (error instanceof AiResponseError) throw error
+          if (error instanceof AiRequestError && response && !isRetryableStatus(response.status))
+            throw error
+          lastError = error
+        }
+
+        if (attempt < maxRetries) {
+          await sleep(retryDelay(response, initialDelay * 2 ** attempt))
+        }
+      }
+
+      if (lastError instanceof AiRequestError) throw lastError
+      const reason = lastError instanceof Error ? lastError.message : String(lastError)
+      throw new AiRequestError(`AI request failed after ${maxRetries + 1} attempts: ${reason}`)
+    },
+  }
+}

--- a/apps/worker/src/lib/ai-client.ts
+++ b/apps/worker/src/lib/ai-client.ts
@@ -156,9 +156,16 @@ export function createAiClient(
           })
 
           if (response.ok) {
-            const body = (await response.json()) as {
+            let body: {
               choices?: Array<{ message?: { content?: string } }>
             }
+
+            try {
+              body = (await response.json()) as typeof body
+            } catch {
+              throw new AiResponseError('AI response body was not valid JSON')
+            }
+
             const content = body.choices?.[0]?.message?.content
 
             if (!content) throw new AiResponseError('AI response did not contain message content')


### PR DESCRIPTION
## Description
Setup connection to Ollama for now, easy enough to switch over to OpenAI as Oshan says. A bunch of tests to verify connection logic without making a real API call.

## Solution
- Errors for missing model or api key config.
- Responses are parsed as structured JSON and include model/prompt-version provenance.
- Retry handling for network, rate limit, and server failures.
- Unit tests covering request format, retries, config errors, mallformed responses, and provenance.