### PR TITLE
[#257] Weekly velocity calculation

### DIFF
--- a/apps/web/src/app/api/formula/[type]/route.ts
+++ b/apps/web/src/app/api/formula/[type]/route.ts
@@ -4,6 +4,7 @@ import { z } from 'zod'
 import { formulaSchema } from '@/lib/schemas/admin'
 import { hasRole } from '@/lib/auth'
 import { recomputeAllHealthScores } from '@/lib/admin/health-score'
+import { recomputeAllVelocity } from '@/lib/admin/velocity'
 
 const VALID_TYPES = ['health', 'mvp'] as const
 type FormulaType = (typeof VALID_TYPES)[number]
@@ -77,6 +78,9 @@ export async function PUT(request: Request, { params }: { params: Promise<{ type
 
   if (type === 'health') {
     await recomputeAllHealthScores(validated.data)
+    // Health scores just changed for every week, so velocity (which is derived from
+    // them) must be recalculated too.
+    await recomputeAllVelocity()
   }
 
   return NextResponse.json({ formula: config.value as string, updatedAt: config.updatedAt })

--- a/apps/web/src/lib/admin/velocity.test.ts
+++ b/apps/web/src/lib/admin/velocity.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('@repo/db', () => ({
+  db: {
+    weeklyStats: {
+      findMany: vi.fn(),
+      update: vi.fn(),
+    },
+  },
+}))
+
+import { db } from '@repo/db'
+import { recomputeAllVelocity } from './velocity'
+
+describe('recomputeAllVelocity', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('sets velocityScore to null for a project’s first scored week (no preceding weeks)', async () => {
+    vi.mocked(db.weeklyStats.findMany).mockResolvedValue([
+      { id: 'row-1', projectId: 'p1', weekStart: new Date('2026-05-04'), healthScore: 50 },
+    ] as never)
+
+    await recomputeAllVelocity()
+
+    expect(db.weeklyStats.update).toHaveBeenCalledWith({
+      where: { id: 'row-1' },
+      data: { velocityScore: null },
+    })
+  })
+
+  it('computes % difference against the rolling average of up to 4 preceding weeks, in weekStart order', async () => {
+    vi.mocked(db.weeklyStats.findMany).mockResolvedValue([
+      { id: 'w1', projectId: 'p1', weekStart: new Date('2026-04-06'), healthScore: 40 },
+      { id: 'w2', projectId: 'p1', weekStart: new Date('2026-04-13'), healthScore: 60 },
+      { id: 'w3', projectId: 'p1', weekStart: new Date('2026-04-20'), healthScore: 50 },
+      { id: 'w4', projectId: 'p1', weekStart: new Date('2026-04-27'), healthScore: 50 },
+      { id: 'w5', projectId: 'p1', weekStart: new Date('2026-05-04'), healthScore: 60 },
+    ] as never)
+
+    await recomputeAllVelocity()
+
+    // w5 baseline = avg(40, 60, 50, 50) = 50; velocity = (60-50)/50*100 = 20
+    expect(db.weeklyStats.update).toHaveBeenCalledWith({
+      where: { id: 'w5' },
+      data: { velocityScore: 20 },
+    })
+  })
+
+  it('keeps each project’s rolling window independent', async () => {
+    vi.mocked(db.weeklyStats.findMany).mockResolvedValue([
+      { id: 'a1', projectId: 'A', weekStart: new Date('2026-04-27'), healthScore: 40 },
+      { id: 'a2', projectId: 'A', weekStart: new Date('2026-05-04'), healthScore: 60 },
+      { id: 'b1', projectId: 'B', weekStart: new Date('2026-04-27'), healthScore: 100 },
+      { id: 'b2', projectId: 'B', weekStart: new Date('2026-05-04'), healthScore: 80 },
+    ] as never)
+
+    await recomputeAllVelocity()
+
+    expect(db.weeklyStats.update).toHaveBeenCalledWith({
+      where: { id: 'a2' },
+      data: { velocityScore: 50 }, // (60-40)/40*100
+    })
+    expect(db.weeklyStats.update).toHaveBeenCalledWith({
+      where: { id: 'b2' },
+      data: { velocityScore: -20 }, // (80-100)/100*100
+    })
+  })
+
+  it('sets velocityScore to null for weeks with no health score, without breaking the rolling window for later weeks', async () => {
+    vi.mocked(db.weeklyStats.findMany).mockResolvedValue([
+      { id: 'w1', projectId: 'p1', weekStart: new Date('2026-04-27'), healthScore: 40 },
+      { id: 'w2', projectId: 'p1', weekStart: new Date('2026-05-04'), healthScore: null },
+      { id: 'w3', projectId: 'p1', weekStart: new Date('2026-05-11'), healthScore: 60 },
+    ] as never)
+
+    await recomputeAllVelocity()
+
+    expect(db.weeklyStats.update).toHaveBeenCalledWith({
+      where: { id: 'w2' },
+      data: { velocityScore: null },
+    })
+    // w3 baseline should still be avg(40) = 40, skipping the null week
+    expect(db.weeklyStats.update).toHaveBeenCalledWith({
+      where: { id: 'w3' },
+      data: { velocityScore: 50 },
+    })
+  })
+
+  it('continues processing remaining rows when writing one row fails', async () => {
+    vi.mocked(db.weeklyStats.findMany).mockResolvedValue([
+      { id: 'w1', projectId: 'p1', weekStart: new Date('2026-04-27'), healthScore: 40 },
+      { id: 'fails-to-write', projectId: 'p1', weekStart: new Date('2026-05-04'), healthScore: 50 },
+      { id: 'w3', projectId: 'p1', weekStart: new Date('2026-05-11'), healthScore: 60 },
+    ] as never)
+    vi.mocked(db.weeklyStats.update).mockImplementation(((args: { where: { id: string } }) => {
+      if (args.where.id === 'fails-to-write') return Promise.reject(new Error('db down'))
+      return Promise.resolve({})
+    }) as unknown as typeof db.weeklyStats.update)
+
+    await expect(recomputeAllVelocity()).resolves.toBeUndefined()
+
+    // w3 baseline should still include the failed row's healthScore (40, 50) = 45
+    expect(db.weeklyStats.update).toHaveBeenCalledWith({
+      where: { id: 'w3' },
+      data: { velocityScore: expect.closeTo(33.33, 1) },
+    })
+  })
+})

--- a/apps/web/src/lib/admin/velocity.ts
+++ b/apps/web/src/lib/admin/velocity.ts
@@ -1,0 +1,67 @@
+// Recomputes WeeklyStats.velocityScore for every project and every week whenever the
+// global health formula changes (and therefore every WeeklyStats.healthScore) — using
+// the same rolling-average logic as the weekly worker job.
+
+import { db } from '@repo/db'
+
+const ROLLING_WINDOW_WEEKS = 4
+
+function average(values: number[]): number {
+  return values.reduce((sum, value) => sum + value, 0) / values.length
+}
+
+function computeVelocity(healthScore: number, precedingScores: number[]): number | null {
+  if (precedingScores.length === 0) return null
+  const baseline = average(precedingScores)
+  return baseline === 0 ? null : ((healthScore - baseline) / baseline) * 100
+}
+
+export async function recomputeAllVelocity(): Promise<void> {
+  const allStats = await db.weeklyStats.findMany({
+    select: { id: true, projectId: true, weekStart: true, healthScore: true },
+    orderBy: { weekStart: 'asc' },
+  })
+
+  const byProject = new Map<string, typeof allStats>()
+  for (const stats of allStats) {
+    const group = byProject.get(stats.projectId)
+    if (group) {
+      group.push(stats)
+    } else {
+      byProject.set(stats.projectId, [stats])
+    }
+  }
+
+  console.log(
+    `Recomputing velocity for ${allStats.length} WeeklyStats row(s) across ${byProject.size} project(s)`
+  )
+
+  let succeeded = 0
+  for (const weeks of byProject.values()) {
+    // weeks is sorted ascending by weekStart, so prior scored weeks are always
+    // already at the front of the sliding window by the time we reach `week`.
+    const scoredHistory: number[] = []
+
+    for (const week of weeks) {
+      const precedingScores = scoredHistory.slice(-ROLLING_WINDOW_WEEKS)
+      const velocityScore =
+        week.healthScore === null ? null : computeVelocity(week.healthScore, precedingScores)
+
+      try {
+        await db.weeklyStats.update({
+          where: { id: week.id },
+          data: { velocityScore },
+        })
+        succeeded++
+      } catch (err) {
+        console.error(`WeeklyStats ${week.id}: failed to write recomputed velocity: ${err}`)
+      }
+
+      if (week.healthScore !== null) {
+        scoredHistory.push(week.healthScore)
+      }
+    }
+  }
+
+  console.log(`Velocity recompute finished: ${succeeded}/${allStats.length} row(s) written`)
+}

--- a/apps/worker/src/index.test.ts
+++ b/apps/worker/src/index.test.ts
@@ -9,6 +9,9 @@ vi.mock('./jobs/discord', () => ({
 vi.mock('./lib/health-score', () => ({
   computeHealthScoresForActiveProjects: vi.fn(() => Promise.resolve()),
 }))
+vi.mock('./lib/velocity', () => ({
+  computeVelocityForActiveProjects: vi.fn(() => Promise.resolve()),
+}))
 vi.mock('./lib/logger', () => ({
   logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
 }))
@@ -22,6 +25,7 @@ vi.mock('./lib/date-utils', () => ({
 import { main } from './index'
 import { runGitHubIngestion } from './jobs/github'
 import { runDiscordIngestion } from './jobs/discord'
+import { computeVelocityForActiveProjects } from './lib/velocity'
 import { logger } from './lib/logger'
 
 const SUCCESS_LOG = 'Weekly ingestion complete'
@@ -65,5 +69,26 @@ describe('main', () => {
     expect(logger.error).toHaveBeenCalledWith(
       expect.stringContaining('Weekly ingestion completed with errors')
     )
+  })
+
+  it('computes velocity for the previous and current week once ingestion succeeds', async () => {
+    vi.mocked(runGitHubIngestion).mockResolvedValue(undefined)
+
+    await main()
+
+    // getCollectionWindow is mocked to always return the same fixed week regardless
+    // of its argument, so both prevWeekStart and weekStart resolve to that week here.
+    expect(computeVelocityForActiveProjects).toHaveBeenCalledWith([
+      new Date('2026-05-04T00:00:00Z'),
+      new Date('2026-05-04T00:00:00Z'),
+    ])
+  })
+
+  it('skips velocity computation when GitHub ingestion fails', async () => {
+    vi.mocked(runGitHubIngestion).mockRejectedValue(new Error('boom'))
+
+    await main()
+
+    expect(computeVelocityForActiveProjects).not.toHaveBeenCalled()
   })
 })

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -3,6 +3,7 @@
 import { runGitHubIngestion } from './jobs/github'
 import { runDiscordIngestion } from './jobs/discord'
 import { computeHealthScoresForActiveProjects } from './lib/health-score'
+import { computeVelocityForActiveProjects } from './lib/velocity'
 import { logger } from './lib/logger'
 import { getCollectionWindow } from './lib/date-utils'
 
@@ -57,6 +58,12 @@ export async function main() {
     )
     await computeHealthScoresForActiveProjects([prevWeekStart, weekStart]).catch((err: unknown) => {
       logger.error(`Health score computation failed: ${err}`)
+    })
+
+    // Velocity compares each week's health score against preceding weeks', so it
+    // must run after health scores are written above.
+    await computeVelocityForActiveProjects([prevWeekStart, weekStart]).catch((err: unknown) => {
+      logger.error(`Velocity computation failed: ${err}`)
     })
   }
 

--- a/apps/worker/src/lib/velocity.integration.test.ts
+++ b/apps/worker/src/lib/velocity.integration.test.ts
@@ -44,6 +44,27 @@ describe('velocity (integration)', () => {
       expect(stats!.velocityScore).toBeNull()
     })
 
+    it("clears a stale velocityScore when the current week's health score becomes null", async () => {
+      const { project } = await seedProjectWithRepo()
+      await seedWeeklyStats(project.id, weeksBefore(WEEK_START, 1), 40)
+      const current = await seedWeeklyStats(project.id, WEEK_START, 50)
+      await db.weeklyStats.update({
+        where: { id: current.id },
+        data: { velocityScore: 25 },
+      })
+      await db.weeklyStats.update({
+        where: { id: current.id },
+        data: { healthScore: null },
+      })
+
+      await computeVelocityForWeek(project.id, WEEK_START)
+
+      const stats = await db.weeklyStats.findUnique({
+        where: { projectId_weekStart: { projectId: project.id, weekStart: WEEK_START } },
+      })
+      expect(stats!.velocityScore).toBeNull()
+    })
+
     it('sets velocityScore to null when there are no preceding weeks to compare against', async () => {
       const { project } = await seedProjectWithRepo()
       await seedWeeklyStats(project.id, WEEK_START, 50)

--- a/apps/worker/src/lib/velocity.integration.test.ts
+++ b/apps/worker/src/lib/velocity.integration.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { db } from '@repo/db'
+import { computeVelocityForWeek, computeVelocityForActiveProjects } from './velocity'
+import { seedProjectWithRepo } from '../test-config/integration.helpers'
+
+const WEEK_START = new Date('2026-05-25T00:00:00Z')
+const WEEK_MS = 7 * 24 * 60 * 60 * 1000
+
+function weeksBefore(weekStart: Date, n: number): Date {
+  return new Date(weekStart.getTime() - n * WEEK_MS)
+}
+
+async function seedWeeklyStats(projectId: string, weekStart: Date, healthScore: number | null) {
+  return db.weeklyStats.create({
+    data: { projectId, weekStart, healthScore },
+  })
+}
+
+describe('velocity (integration)', () => {
+  beforeEach(async () => {
+    await db.weeklyStats.deleteMany()
+    await db.project.deleteMany()
+  })
+
+  describe('computeVelocityForWeek', () => {
+    it('does nothing when no WeeklyStats row exists yet for that week', async () => {
+      const { project } = await seedProjectWithRepo()
+
+      await expect(computeVelocityForWeek(project.id, WEEK_START)).resolves.toBeUndefined()
+
+      const stats = await db.weeklyStats.findFirst({ where: { projectId: project.id } })
+      expect(stats).toBeNull()
+    })
+
+    it('leaves velocityScore null when the current week has no health score yet', async () => {
+      const { project } = await seedProjectWithRepo()
+      await seedWeeklyStats(project.id, WEEK_START, null)
+
+      await computeVelocityForWeek(project.id, WEEK_START)
+
+      const stats = await db.weeklyStats.findUnique({
+        where: { projectId_weekStart: { projectId: project.id, weekStart: WEEK_START } },
+      })
+      expect(stats!.velocityScore).toBeNull()
+    })
+
+    it('sets velocityScore to null when there are no preceding weeks to compare against', async () => {
+      const { project } = await seedProjectWithRepo()
+      await seedWeeklyStats(project.id, WEEK_START, 50)
+
+      await computeVelocityForWeek(project.id, WEEK_START)
+
+      const stats = await db.weeklyStats.findUnique({
+        where: { projectId_weekStart: { projectId: project.id, weekStart: WEEK_START } },
+      })
+      expect(stats!.velocityScore).toBeNull()
+    })
+
+    it('computes % difference against the average of up to 4 preceding weeks', async () => {
+      const { project } = await seedProjectWithRepo()
+      await seedWeeklyStats(project.id, weeksBefore(WEEK_START, 4), 40)
+      await seedWeeklyStats(project.id, weeksBefore(WEEK_START, 3), 60)
+      await seedWeeklyStats(project.id, weeksBefore(WEEK_START, 2), 50)
+      await seedWeeklyStats(project.id, weeksBefore(WEEK_START, 1), 50)
+      await seedWeeklyStats(project.id, WEEK_START, 60)
+
+      await computeVelocityForWeek(project.id, WEEK_START)
+
+      // baseline = avg(40, 60, 50, 50) = 50; velocity = (60 - 50) / 50 * 100 = 20
+      const stats = await db.weeklyStats.findUnique({
+        where: { projectId_weekStart: { projectId: project.id, weekStart: WEEK_START } },
+      })
+      expect(stats!.velocityScore).toBe(20)
+    })
+
+    it('only uses the 4 most recent preceding weeks, ignoring older ones', async () => {
+      const { project } = await seedProjectWithRepo()
+      await seedWeeklyStats(project.id, weeksBefore(WEEK_START, 5), 1000) // outside window
+      await seedWeeklyStats(project.id, weeksBefore(WEEK_START, 4), 100)
+      await seedWeeklyStats(project.id, weeksBefore(WEEK_START, 3), 100)
+      await seedWeeklyStats(project.id, weeksBefore(WEEK_START, 2), 100)
+      await seedWeeklyStats(project.id, weeksBefore(WEEK_START, 1), 100)
+      await seedWeeklyStats(project.id, WEEK_START, 150)
+
+      await computeVelocityForWeek(project.id, WEEK_START)
+
+      // baseline = avg(100, 100, 100, 100) = 100; velocity = (150 - 100) / 100 * 100 = 50
+      const stats = await db.weeklyStats.findUnique({
+        where: { projectId_weekStart: { projectId: project.id, weekStart: WEEK_START } },
+      })
+      expect(stats!.velocityScore).toBe(50)
+    })
+
+    it('partially calculates velocity when fewer than 4 preceding weeks of data exist', async () => {
+      const { project } = await seedProjectWithRepo()
+      await seedWeeklyStats(project.id, weeksBefore(WEEK_START, 1), 40)
+      await seedWeeklyStats(project.id, WEEK_START, 50)
+
+      await computeVelocityForWeek(project.id, WEEK_START)
+
+      // baseline = avg(40) = 40; velocity = (50 - 40) / 40 * 100 = 25
+      const stats = await db.weeklyStats.findUnique({
+        where: { projectId_weekStart: { projectId: project.id, weekStart: WEEK_START } },
+      })
+      expect(stats!.velocityScore).toBe(25)
+    })
+
+    it('skips preceding weeks with a null health score', async () => {
+      const { project } = await seedProjectWithRepo()
+      await seedWeeklyStats(project.id, weeksBefore(WEEK_START, 2), null)
+      await seedWeeklyStats(project.id, weeksBefore(WEEK_START, 1), 40)
+      await seedWeeklyStats(project.id, WEEK_START, 50)
+
+      await computeVelocityForWeek(project.id, WEEK_START)
+
+      // baseline = avg(40) = 40 (null week excluded); velocity = (50 - 40) / 40 * 100 = 25
+      const stats = await db.weeklyStats.findUnique({
+        where: { projectId_weekStart: { projectId: project.id, weekStart: WEEK_START } },
+      })
+      expect(stats!.velocityScore).toBe(25)
+    })
+
+    it('is idempotent and only touches velocityScore, leaving other fields untouched', async () => {
+      const { project } = await seedProjectWithRepo()
+      await seedWeeklyStats(project.id, weeksBefore(WEEK_START, 1), 40)
+      await seedWeeklyStats(project.id, WEEK_START, 50)
+
+      await computeVelocityForWeek(project.id, WEEK_START)
+      await computeVelocityForWeek(project.id, WEEK_START)
+
+      const stats = await db.weeklyStats.findUnique({
+        where: { projectId_weekStart: { projectId: project.id, weekStart: WEEK_START } },
+      })
+      expect(stats!.velocityScore).toBe(25)
+      expect(stats!.healthScore).toBe(50)
+
+      const allRows = await db.weeklyStats.findMany({ where: { projectId: project.id } })
+      expect(allRows).toHaveLength(2)
+    })
+  })
+
+  describe('computeVelocityForActiveProjects', () => {
+    it('computes velocity for multiple active projects independently', async () => {
+      const { project: projectA } = await seedProjectWithRepo()
+      const { project: projectB } = await seedProjectWithRepo()
+
+      await seedWeeklyStats(projectA.id, weeksBefore(WEEK_START, 1), 40)
+      await seedWeeklyStats(projectA.id, WEEK_START, 60)
+      await seedWeeklyStats(projectB.id, weeksBefore(WEEK_START, 1), 100)
+      await seedWeeklyStats(projectB.id, WEEK_START, 80)
+
+      await computeVelocityForActiveProjects([WEEK_START])
+
+      const statsA = await db.weeklyStats.findUnique({
+        where: { projectId_weekStart: { projectId: projectA.id, weekStart: WEEK_START } },
+      })
+      const statsB = await db.weeklyStats.findUnique({
+        where: { projectId_weekStart: { projectId: projectB.id, weekStart: WEEK_START } },
+      })
+
+      expect(statsA!.velocityScore).toBe(50) // (60-40)/40*100
+      expect(statsB!.velocityScore).toBe(-20) // (80-100)/100*100
+    })
+
+    it('does not compute velocity for inactive projects', async () => {
+      const { project } = await seedProjectWithRepo()
+      await db.project.update({ where: { id: project.id }, data: { isActive: false } })
+      await seedWeeklyStats(project.id, weeksBefore(WEEK_START, 1), 40)
+      await seedWeeklyStats(project.id, WEEK_START, 60)
+
+      await computeVelocityForActiveProjects([WEEK_START])
+
+      const stats = await db.weeklyStats.findUnique({
+        where: { projectId_weekStart: { projectId: project.id, weekStart: WEEK_START } },
+      })
+      expect(stats!.velocityScore).toBeNull()
+    })
+  })
+})

--- a/apps/worker/src/lib/velocity.ts
+++ b/apps/worker/src/lib/velocity.ts
@@ -1,0 +1,70 @@
+// Computes each project's weekly velocity — the % difference between that week's
+// WeeklyStats.healthScore and the rolling average of the up-to-4 preceding weeks'
+// health scores — and persists it to WeeklyStats.velocityScore.
+
+import { db } from '@repo/db'
+import { logger } from './logger'
+
+const ROLLING_WINDOW_WEEKS = 4
+
+function average(values: number[]): number {
+  return values.reduce((sum, value) => sum + value, 0) / values.length
+}
+
+export async function computeVelocityForWeek(projectId: string, weekStart: Date): Promise<void> {
+  const current = await db.weeklyStats.findUnique({
+    where: { projectId_weekStart: { projectId, weekStart } },
+    select: { id: true, healthScore: true },
+  })
+  if (!current || current.healthScore === null) return
+
+  const previousWeeks = await db.weeklyStats.findMany({
+    where: {
+      projectId,
+      weekStart: { lt: weekStart },
+      healthScore: { not: null },
+    },
+    orderBy: { weekStart: 'desc' },
+    take: ROLLING_WINDOW_WEEKS,
+    select: { healthScore: true },
+  })
+
+  // No prior weeks to compare against — there's nothing to measure velocity relative to.
+  const baseline =
+    previousWeeks.length > 0
+      ? average(previousWeeks.map((week) => week.healthScore as number))
+      : null
+
+  const velocityScore =
+    baseline === null || baseline === 0 ? null : ((current.healthScore - baseline) / baseline) * 100
+
+  try {
+    await db.weeklyStats.update({
+      where: { id: current.id },
+      data: { velocityScore },
+    })
+  } catch (err) {
+    logger.error(
+      `Project ${projectId}: failed to write velocity for week ${weekStart.toISOString()}: ${err}`
+    )
+  }
+}
+
+export async function computeVelocityForActiveProjects(weekStarts: Date[]): Promise<void> {
+  const projects = await db.project.findMany({
+    where: { isActive: true },
+    select: { id: true },
+  })
+
+  logger.info(
+    `Computing velocity for ${projects.length} active project(s) across ${weekStarts.length} week(s)`
+  )
+
+  for (const project of projects) {
+    for (const weekStart of weekStarts) {
+      await computeVelocityForWeek(project.id, weekStart)
+    }
+  }
+
+  logger.info('Velocity computation complete')
+}

--- a/apps/worker/src/lib/velocity.ts
+++ b/apps/worker/src/lib/velocity.ts
@@ -16,27 +16,35 @@ export async function computeVelocityForWeek(projectId: string, weekStart: Date)
     where: { projectId_weekStart: { projectId, weekStart } },
     select: { id: true, healthScore: true },
   })
-  if (!current || current.healthScore === null) return
+  if (!current) return
 
-  const previousWeeks = await db.weeklyStats.findMany({
-    where: {
-      projectId,
-      weekStart: { lt: weekStart },
-      healthScore: { not: null },
-    },
-    orderBy: { weekStart: 'desc' },
-    take: ROLLING_WINDOW_WEEKS,
-    select: { healthScore: true },
-  })
+  // If the health score was cleared (e.g. by a recompute), velocity must be cleared
+  // too — otherwise a stale value would linger for a week with no score to derive it from.
+  let velocityScore: number | null = null
 
-  // No prior weeks to compare against — there's nothing to measure velocity relative to.
-  const baseline =
-    previousWeeks.length > 0
-      ? average(previousWeeks.map((week) => week.healthScore as number))
-      : null
+  if (current.healthScore !== null) {
+    const previousWeeks = await db.weeklyStats.findMany({
+      where: {
+        projectId,
+        weekStart: { lt: weekStart },
+        healthScore: { not: null },
+      },
+      orderBy: { weekStart: 'desc' },
+      take: ROLLING_WINDOW_WEEKS,
+      select: { healthScore: true },
+    })
 
-  const velocityScore =
-    baseline === null || baseline === 0 ? null : ((current.healthScore - baseline) / baseline) * 100
+    // No prior weeks to compare against — there's nothing to measure velocity relative to.
+    const baseline =
+      previousWeeks.length > 0
+        ? average(previousWeeks.map((week) => week.healthScore as number))
+        : null
+
+    velocityScore =
+      baseline === null || baseline === 0
+        ? null
+        : ((current.healthScore - baseline) / baseline) * 100
+  }
 
   try {
     await db.weeklyStats.update({


### PR DESCRIPTION
## Description

Calculates and saves weekly velocity per project


## Solution

- Weekly job computes velocity for active projects (apps/worker/src/lib/velocity.ts). Runs computeVelocityForActiveProjects() after health score computation, for the current + previous week across all active projects.
- On formula save (apps/web/src/lib/admin/velocity.ts), recomputeAllVelocity() walks every WeeklyStats row per project in weekStart order with a sliding 4-week window, right after recomputeAllHealthScores for the health formula type.
- Also adds 10 integration tests and 5 unit tests.
## Notes

- Branches off #255 so that will need to be merged in first
