### PR TITLE
[#249] Team page admin view

### DIFF
--- a/apps/web/src/actions/project-page.ts
+++ b/apps/web/src/actions/project-page.ts
@@ -1,0 +1,37 @@
+// NOTE: These functions are for the admin view for /project/[slug]
+
+'use server'
+
+import { db } from '@repo/db'
+import { revalidatePath } from 'next/cache'
+import { redirect } from 'next/navigation'
+
+export async function updateRepository(
+  repositoryId: string,
+  data: { owner: string; name: string }
+) {
+  const repo = await db.gitHubRepository.update({
+    where: { id: repositoryId },
+    data,
+    include: { project: { select: { slug: true } } },
+  })
+
+  revalidatePath(`/${repo.project.slug}`)
+}
+
+export async function updateChannel(channelId: string, data: { externalId: string }) {
+  const channel = await db.discordChannel.update({
+    where: { id: channelId },
+    data,
+    include: { project: { select: { slug: true } } },
+  })
+
+  revalidatePath(`/${channel.project.slug}`)
+}
+
+export async function deleteProject(projectId: string) {
+  await db.project.delete({ where: { id: projectId } })
+
+  revalidatePath('/')
+  redirect('/')
+}

--- a/apps/web/src/actions/project-page.ts
+++ b/apps/web/src/actions/project-page.ts
@@ -3,6 +3,7 @@
 'use server'
 
 import { db } from '@repo/db'
+import { hasRole } from '@/lib/auth'
 import { revalidatePath } from 'next/cache'
 import { redirect } from 'next/navigation'
 
@@ -10,6 +11,10 @@ export async function updateRepository(
   repositoryId: string,
   data: { owner: string; name: string }
 ) {
+  if (!(await hasRole('ADMIN'))) {
+    throw new Error('Unauthorized. Admin access required.')
+  }
+
   const repo = await db.gitHubRepository.update({
     where: { id: repositoryId },
     data,
@@ -20,6 +25,10 @@ export async function updateRepository(
 }
 
 export async function updateChannel(channelId: string, data: { externalId: string }) {
+  if (!(await hasRole('ADMIN'))) {
+    throw new Error('Unauthorized. Admin access required.')
+  }
+
   const channel = await db.discordChannel.update({
     where: { id: channelId },
     data,
@@ -30,6 +39,10 @@ export async function updateChannel(channelId: string, data: { externalId: strin
 }
 
 export async function deleteProject(projectId: string) {
+  if (!(await hasRole('ADMIN'))) {
+    throw new Error('Unauthorized. Admin access required.')
+  }
+
   await db.project.delete({ where: { id: projectId } })
 
   revalidatePath('/')

--- a/apps/web/src/actions/project-page.ts
+++ b/apps/web/src/actions/project-page.ts
@@ -1,11 +1,24 @@
-// NOTE: These functions are for the admin view for /project/[slug]
-
+// apps/web/src/actions/project-page.ts
 'use server'
 
 import { db } from '@repo/db'
 import { hasRole } from '@/lib/auth'
 import { revalidatePath } from 'next/cache'
 import { redirect } from 'next/navigation'
+import {
+  validateGitHubLinkFormat,
+  validateGitHubExists,
+  validateSnowflakeExists,
+} from '@/app/api/project/route'
+
+async function responseErrorMessage(res: Response, fallback: string) {
+  try {
+    const body = await res.json()
+    return body?.error ?? fallback
+  } catch {
+    return fallback
+  }
+}
 
 export async function updateRepository(
   repositoryId: string,
@@ -13,6 +26,31 @@ export async function updateRepository(
 ) {
   if (!(await hasRole('ADMIN'))) {
     throw new Error('Unauthorized. Admin access required.')
+  }
+
+  const link = `https://github.com/${data.owner}/${data.name}`
+
+  if (!validateGitHubLinkFormat(link)) {
+    throw new Error(`Invalid GitHub link format: ${link}`)
+  }
+
+  const githubError = await validateGitHubExists(link)
+  if (githubError) {
+    throw new Error(await responseErrorMessage(githubError, `Failed to validate ${link}`))
+  }
+
+  const existingRepo = await db.gitHubRepository.findFirst({
+    where: {
+      owner: data.owner,
+      name: data.name,
+      isActive: true,
+      id: { not: repositoryId },
+    },
+  })
+  if (existingRepo) {
+    throw new Error(
+      `GitHub repository ${data.owner}/${data.name} is already linked to another project`
+    )
   }
 
   const repo = await db.gitHubRepository.update({
@@ -27,6 +65,25 @@ export async function updateRepository(
 export async function updateChannel(channelId: string, data: { externalId: string }) {
   if (!(await hasRole('ADMIN'))) {
     throw new Error('Unauthorized. Admin access required.')
+  }
+
+  const discordError = await validateSnowflakeExists(data.externalId)
+  if (discordError) {
+    throw new Error(
+      await responseErrorMessage(
+        discordError,
+        `Failed to validate Discord channel ${data.externalId}`
+      )
+    )
+  }
+
+  const existingChannel = await db.discordChannel.findUnique({
+    where: { externalId: data.externalId },
+  })
+  if (existingChannel && existingChannel.isActive && existingChannel.id !== channelId) {
+    throw new Error(
+      `Discord channel with snowflake ID ${data.externalId} is already linked to another project`
+    )
   }
 
   const channel = await db.discordChannel.update({

--- a/apps/web/src/app/(exec)/exec-dashboard/page.tsx
+++ b/apps/web/src/app/(exec)/exec-dashboard/page.tsx
@@ -2,7 +2,7 @@ import ExecProjectGraphs from '@/components/charts/ExecProjectGraphs'
 
 export default async function ExecDashboardPage() {
   return (
-    <main className="p-8 flex flex-col gap-10">
+    <main className="px-5 sm:px-10 lg:px-20 pt-8 flex flex-col gap-10">
       <h1 className="text-2xl font-bold">WDCC Projects Health Dashboard — Exec View</h1>
       <ExecProjectGraphs />
     </main>

--- a/apps/web/src/app/(public)/page.tsx
+++ b/apps/web/src/app/(public)/page.tsx
@@ -34,7 +34,7 @@ export default async function PublicDashboardPage() {
       <div className="lg:hidden h-10">
         <LiveCommitMarquee />
       </div>
-      <div className="flex flex-col lg:gap-y-40">
+      <div className="flex flex-col lg:gap-y-20">
         {/* PAGE HEADER */}
         <div className="bg-[#D4E5FD] lg:bg-inherit">
           <HomeHeader

--- a/apps/web/src/app/(public)/project/[slug]/page.tsx
+++ b/apps/web/src/app/(public)/project/[slug]/page.tsx
@@ -2,10 +2,12 @@ import TeamHeader from '@/components/headers/TeamHeader'
 import WeeklyMvp from '@/components/ui/WeeklyMvp'
 import TeamSection from '@/components/ui/TeamSection'
 import ViewAllMembersButton from '@/components/ui/ViewAllMembersButton'
+import ConnectedSources from '@/components/ui/ConnectedSources'
 import { getUserRoles } from '@/lib/auth'
 import { getProjectHeaderData } from '@/lib/project/projects'
 import { getProjectMembers } from '@/lib/project/members'
 import { getProjectWeeklyMvp } from '@/lib/project/weekly-stats'
+import { updateRepository, updateChannel, deleteProject } from '@/actions/project-page'
 import { notFound } from 'next/navigation'
 import GraphViewToggle from '@/components/charts/GraphViewToggle'
 import { Role } from '@repo/db'
@@ -25,14 +27,30 @@ export default async function ProjectPage({ params }: { params: Promise<{ slug: 
 
   // Only execs can drill into a member's contribution breakdown.
   const isExec = roles.includes(Role.EXEC) || roles.includes(Role.ADMIN)
+  const isAdmin = roles.includes(Role.ADMIN)
 
   const mvpName = mvp?.projectMember.displayName ?? mvp?.projectMember.person.displayName
 
   return (
     <>
-      <TeamHeader project={project} />
+      <TeamHeader
+        project={project}
+        isAdmin={isAdmin}
+        onDeleteProject={deleteProject.bind(null, project.id)}
+      />
 
-      <div className="px-5 sm:px-10 lg:px-20 py-8 sm:py-12 lg:py-20 w-full flex flex-col items-center gap-8 sm:gap-12 lg:gap-20">
+      {isAdmin && (
+        <div className="px-5 sm:px-10 lg:px-20 sm:mt-12 lg:mt-20">
+          <ConnectedSources
+            repositories={project.repositories}
+            channels={project.channels}
+            onSaveRepository={updateRepository}
+            onSaveChannel={updateChannel}
+          />
+        </div>
+      )}
+
+      <div className="px-5 sm:px-10 lg:px-20 pt-8 sm:pt-12 lg:pt-20 pb-[120px] lg:pb-20 w-full flex flex-col items-center gap-8 sm:gap-12 lg:gap-20">
         {mvp && mvpName && (
           <div className="w-full flex flex-col items-center gap-4 lg:gap-10">
             <h2 className="text-2xl lg:text-4xl font-extrabold self-start">Weekly MVP</h2>

--- a/apps/web/src/app/(public)/project/[slug]/page.tsx
+++ b/apps/web/src/app/(public)/project/[slug]/page.tsx
@@ -40,7 +40,7 @@ export default async function ProjectPage({ params }: { params: Promise<{ slug: 
       />
 
       {isAdmin && (
-        <div className="px-5 sm:px-10 lg:px-20 sm:mt-12 lg:mt-20">
+        <div className="px-5 sm:px-10 lg:px-20 mt-6 sm:mt-12 lg:mt-20">
           <ConnectedSources
             repositories={project.repositories}
             channels={project.channels}

--- a/apps/web/src/app/api/project/[slug]/route.ts
+++ b/apps/web/src/app/api/project/[slug]/route.ts
@@ -89,7 +89,12 @@ export async function PATCH(request: Request, { params }: { params: Promise<{ sl
       }
 
       const existingRepo = await db.gitHubRepository.findFirst({
-        where: { owner: repoInfo.owner, name: repoInfo.repo, projectId: { not: projectId } },
+        where: {
+          owner: repoInfo.owner,
+          name: repoInfo.repo,
+          projectId: { not: projectId },
+          isActive: true,
+        },
       })
       if (existingRepo) {
         return Response.json(
@@ -121,7 +126,7 @@ export async function PATCH(request: Request, { params }: { params: Promise<{ sl
       const existingChannel = await db.discordChannel.findUnique({
         where: { externalId: snowflakeId },
       })
-      if (existingChannel && existingChannel.projectId !== projectId) {
+      if (existingChannel && existingChannel.projectId !== projectId && existingChannel.isActive) {
         return Response.json(
           {
             error: `Discord Channel with Snowflake ID ${snowflakeId} has already been linked to another project`,
@@ -180,15 +185,32 @@ export async function PATCH(request: Request, { params }: { params: Promise<{ sl
         (nr) => !currentRepos.some((cr) => cr.owner === nr.owner && cr.name === nr.name)
       )
       for (const nr of reposToCreate) {
-        await tx.gitHubRepository.create({
-          data: {
-            projectId,
-            owner: nr.owner,
-            name: nr.name,
-            installationId: installationId,
-            isActive: true,
-          },
+        // owner/name is globally unique (@@unique([owner, name])) — an inactive
+        // row left behind by another project must be reclaimed, not inserted
+        // fresh, or this throws a P2002 unique-constraint violation.
+        const orphanedRepo = await tx.gitHubRepository.findFirst({
+          where: { owner: nr.owner, name: nr.name },
         })
+        if (orphanedRepo) {
+          await tx.gitHubRepository.update({
+            where: { id: orphanedRepo.id },
+            data: {
+              projectId,
+              installationId: installationId,
+              isActive: true,
+            },
+          })
+        } else {
+          await tx.gitHubRepository.create({
+            data: {
+              projectId,
+              owner: nr.owner,
+              name: nr.name,
+              installationId: installationId,
+              isActive: true,
+            },
+          })
+        }
       }
 
       // Soft delete, reactivate, or create Discord channels
@@ -224,15 +246,28 @@ export async function PATCH(request: Request, { params }: { params: Promise<{ sl
       const channelsToCreate = Array.from(discordChannels.entries()).filter(
         ([id]) => !currentChannels.some((cc) => cc.externalId === id)
       )
-      if (channelsToCreate.length > 0) {
-        await tx.discordChannel.createMany({
-          data: channelsToCreate.map(([id, name]) => ({
-            projectId,
-            externalId: id,
-            name,
-            isActive: true,
-          })),
+      for (const [id, name] of channelsToCreate) {
+        // externalId is globally unique (@unique) — an inactive channel left
+        // behind by another project must be reclaimed, not inserted fresh,
+        // or this throws a P2002 unique-constraint violation.
+        const orphanedChannel = await tx.discordChannel.findUnique({
+          where: { externalId: id },
         })
+        if (orphanedChannel) {
+          await tx.discordChannel.update({
+            where: { id: orphanedChannel.id },
+            data: { projectId, name, isActive: true },
+          })
+        } else {
+          await tx.discordChannel.create({
+            data: {
+              projectId,
+              externalId: id,
+              name,
+              isActive: true,
+            },
+          })
+        }
       }
 
       return await tx.project.findUnique({

--- a/apps/web/src/app/api/project/route.ts
+++ b/apps/web/src/app/api/project/route.ts
@@ -197,7 +197,7 @@ export async function POST(request: Request) {
       }
 
       const existingRepo = await db.gitHubRepository.findFirst({
-        where: { owner: repoInfo.owner, name: repoInfo.repo },
+        where: { owner: repoInfo.owner, name: repoInfo.repo, isActive: true },
       })
       if (existingRepo) {
         return Response.json(
@@ -223,7 +223,7 @@ export async function POST(request: Request) {
       const existingChannel = await db.discordChannel.findUnique({
         where: { externalId: snowflakeId },
       })
-      if (existingChannel) {
+      if (existingChannel && existingChannel.isActive) {
         return Response.json(
           {
             error: `Discord Channel with Snowflake ID ${snowflakeId} has already been linked to another project`,

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -18,6 +18,7 @@ const dmMono = DM_Mono({
 const cartographMonoCf = localFont({
   src: '../fonts/cartograph-mono-cf.otf',
   variable: '--font-cartograph-mono-cf',
+  display: 'swap',
 })
 
 const figtree = Figtree({

--- a/apps/web/src/components/charts/ExecProjectGraphs.tsx
+++ b/apps/web/src/components/charts/ExecProjectGraphs.tsx
@@ -83,7 +83,7 @@ export default function ExecProjectGraphs() {
   }
 
   return (
-    <div className="mx-4 mt-6 flex w-full flex-col gap-6">
+    <div className="mt-6 flex w-full flex-col gap-6">
       {/* Toggle bar */}
       <div className="flex flex-wrap gap-2">
         {teamMeta.map((team) => {

--- a/apps/web/src/components/headers/HomeHeader.tsx
+++ b/apps/web/src/components/headers/HomeHeader.tsx
@@ -12,10 +12,10 @@ const HomeHeader: React.FC<HomeHeaderProps> = ({
   lastCommitAt,
 }: HomeHeaderProps): React.JSX.Element => {
   return (
-    <div className="px-5 sm:px-10 lg:px-20 pt-4 sm:pt-10 lg:pt-20 relative w-full">
+    <div className="px-5 sm:px-10 lg:px-20 pt-6 sm:pt-8 relative w-full lg:min-h-[calc(100dvh-4rem)] lg:flex lg:flex-col lg:justify-center lg:py-0">
       {/* Status pill */}
       {activeProjectCount > 0 && (
-        <div className="backdrop-blur-xl rounded-full border-1 lg:border-2 border-white font-mono px-3 sm:px-4 lg:px-5 py-1 sm:py-2 lg:py-2.5 flex gap-2 sm:gap-3 items-center w-fit bg-white/60 hover:brightness-95 cursor-default transition-all duration-500 ease-in-out">
+        <div className="backdrop-blur-xl rounded-full border-1 lg:border-2 border-white font-mono px-3 sm:px-4 lg:px-5 py-1 sm:py-1.5 lg:py-2 flex gap-2 sm:gap-3 items-center w-fit bg-white/60 hover:brightness-95 cursor-default transition-all duration-500 ease-in-out">
           <svg
             width="12"
             height="12"
@@ -26,7 +26,7 @@ const HomeHeader: React.FC<HomeHeaderProps> = ({
           >
             <rect width="12" height="12" rx="5.90908" fill="#16A34A" />
           </svg>
-          <span className="text-wdcc-grey text-xs sm:text-sm lg:text-2xl font-medium whitespace-nowrap">
+          <span className="text-wdcc-grey text-xs sm:text-sm lg:text-lg font-medium whitespace-nowrap">
             {activeProjectCount} active project{activeProjectCount !== 1 ? 's' : ''}
             {lastCommitAt && (
               <>
@@ -39,16 +39,16 @@ const HomeHeader: React.FC<HomeHeaderProps> = ({
       )}
 
       {/* Main Headings*/}
-      <div className="flex items-end justify-between mt-4 sm:mt-6 lg:mt-11 ">
+      <div className="flex items-end justify-between mt-4 sm:mt-6 lg:mt-6">
         <div className="flex flex-col justify-between">
           <div>
-            <h1 className="text-wdcc-oshan uppercase font-extrabold tracking-tight !leading-none m-0 text-[clamp(2.625rem,8vw,6.3125rem)]">
+            <h1 className="text-wdcc-oshan uppercase font-extrabold tracking-tight !leading-none m-0 text-[clamp(2.625rem,6vw+1vh,4.75rem)]">
               Projects Health Dashboard
             </h1>
 
             {/* Subheading */}
-            <div className="mt-4 sm:mt-6 lg:mt-10 max-w-[54.1875rem]">
-              <h3 className="text-wdcc-grey font-medium text-[clamp(0.81rem,2.5vw,1.75rem)] leading-relaxed m-0">
+            <div className="mt-3 sm:mt-4 lg:mt-5 max-w-[54.1875rem]">
+              <h3 className="text-wdcc-grey font-medium text-[clamp(0.81rem,1.4vw+0.6vh,1.25rem)] leading-relaxed m-0">
                 Track commits, team vibes, and health scores across all WDCC projects — live and at
                 a glance.
               </h3>
@@ -56,10 +56,10 @@ const HomeHeader: React.FC<HomeHeaderProps> = ({
           </div>
 
           {/* CTA */}
-          <div className="pt-4 sm:pt-6 lg:pt-16 pb-6">
+          <div className="pt-4 sm:pt-6 lg:pt-8 pb-8 sm:pb-6">
             <Link
               href="/leaderboard"
-              className="rounded-full px-7 sm:px-8 lg:px-8 py-3 sm:py-4 lg:py-4 bg-wdcc-oshan hover:bg-wdcc-orange transition-all duration-500 ease-in-out text-white font-bold text-base sm:text-lg lg:text-lg inline-block"
+              className="rounded-full px-7 sm:px-8 lg:px-8 py-3 sm:py-3.5 lg:py-3.5 bg-wdcc-oshan hover:bg-wdcc-orange transition-all duration-500 ease-in-out text-white font-bold text-base sm:text-lg lg:text-base inline-block"
             >
               See leaderboard
             </Link>

--- a/apps/web/src/components/headers/HomeHeader.tsx
+++ b/apps/web/src/components/headers/HomeHeader.tsx
@@ -12,10 +12,10 @@ const HomeHeader: React.FC<HomeHeaderProps> = ({
   lastCommitAt,
 }: HomeHeaderProps): React.JSX.Element => {
   return (
-    <div className="px-5 sm:px-10 lg:px-20 pt-4 sm:pt-10 lg:pt-20 relative w-full">
+    <div className="px-5 sm:px-10 lg:px-20 pt-4 sm:pt-8 relative w-full lg:min-h-[calc(100dvh-4rem)] lg:flex lg:flex-col lg:justify-center lg:py-0">
       {/* Status pill */}
       {activeProjectCount > 0 && (
-        <div className="backdrop-blur-xl rounded-full border-1 lg:border-2 border-white font-mono px-3 sm:px-4 lg:px-5 py-1 sm:py-2 lg:py-2.5 flex gap-2 sm:gap-3 items-center w-fit bg-white/60 hover:brightness-95 cursor-default transition-all duration-500 ease-in-out">
+        <div className="backdrop-blur-xl rounded-full border-1 lg:border-2 border-white font-mono px-3 sm:px-4 lg:px-5 py-1 sm:py-1.5 lg:py-2 flex gap-2 sm:gap-3 items-center w-fit bg-white/60 hover:brightness-95 cursor-default transition-all duration-500 ease-in-out">
           <svg
             width="12"
             height="12"
@@ -26,7 +26,7 @@ const HomeHeader: React.FC<HomeHeaderProps> = ({
           >
             <rect width="12" height="12" rx="5.90908" fill="#16A34A" />
           </svg>
-          <span className="text-wdcc-grey text-xs sm:text-sm lg:text-2xl font-medium whitespace-nowrap">
+          <span className="text-wdcc-grey text-xs sm:text-sm lg:text-lg font-medium whitespace-nowrap">
             {activeProjectCount} active project{activeProjectCount !== 1 ? 's' : ''}
             {lastCommitAt && (
               <>
@@ -39,16 +39,16 @@ const HomeHeader: React.FC<HomeHeaderProps> = ({
       )}
 
       {/* Main Headings*/}
-      <div className="flex items-end justify-between mt-4 sm:mt-6 lg:mt-11 ">
+      <div className="flex items-end justify-between mt-4 sm:mt-6 lg:mt-6">
         <div className="flex flex-col justify-between">
           <div>
-            <h1 className="text-wdcc-oshan uppercase font-extrabold tracking-tight !leading-none m-0 text-[clamp(2.625rem,8vw,6.3125rem)]">
+            <h1 className="text-wdcc-oshan uppercase font-extrabold tracking-tight !leading-none m-0 text-[clamp(2.625rem,6vw+1vh,4.75rem)]">
               Projects Health Dashboard
             </h1>
 
             {/* Subheading */}
-            <div className="mt-4 sm:mt-6 lg:mt-10 max-w-[54.1875rem]">
-              <h3 className="text-wdcc-grey font-medium text-[clamp(0.81rem,2.5vw,1.75rem)] leading-relaxed m-0">
+            <div className="mt-3 sm:mt-4 lg:mt-5 max-w-[54.1875rem]">
+              <h3 className="text-wdcc-grey font-medium text-[clamp(0.81rem,1.4vw+0.6vh,1.25rem)] leading-relaxed m-0">
                 Track commits, team vibes, and health scores across all WDCC projects — live and at
                 a glance.
               </h3>
@@ -56,10 +56,10 @@ const HomeHeader: React.FC<HomeHeaderProps> = ({
           </div>
 
           {/* CTA */}
-          <div className="pt-4 sm:pt-6 lg:pt-16 pb-6">
+          <div className="pt-4 sm:pt-6 lg:pt-8 pb-6">
             <Link
               href="/leaderboard"
-              className="rounded-full px-7 sm:px-8 lg:px-8 py-3 sm:py-4 lg:py-4 bg-wdcc-oshan hover:bg-wdcc-orange transition-all duration-500 ease-in-out text-white font-bold text-base sm:text-lg lg:text-lg inline-block"
+              className="rounded-full px-7 sm:px-8 lg:px-8 py-3 sm:py-3.5 lg:py-3.5 bg-wdcc-oshan hover:bg-wdcc-orange transition-all duration-500 ease-in-out text-white font-bold text-base sm:text-lg lg:text-base inline-block"
             >
               See leaderboard
             </Link>

--- a/apps/web/src/components/headers/HomeHeader.tsx
+++ b/apps/web/src/components/headers/HomeHeader.tsx
@@ -12,10 +12,10 @@ const HomeHeader: React.FC<HomeHeaderProps> = ({
   lastCommitAt,
 }: HomeHeaderProps): React.JSX.Element => {
   return (
-    <div className="px-5 sm:px-10 lg:px-20 pt-4 sm:pt-8 relative w-full lg:min-h-[calc(100dvh-4rem)] lg:flex lg:flex-col lg:justify-center lg:py-0">
+    <div className="px-5 sm:px-10 lg:px-20 pt-4 sm:pt-10 lg:pt-20 relative w-full">
       {/* Status pill */}
       {activeProjectCount > 0 && (
-        <div className="backdrop-blur-xl rounded-full border-1 lg:border-2 border-white font-mono px-3 sm:px-4 lg:px-5 py-1 sm:py-1.5 lg:py-2 flex gap-2 sm:gap-3 items-center w-fit bg-white/60 hover:brightness-95 cursor-default transition-all duration-500 ease-in-out">
+        <div className="backdrop-blur-xl rounded-full border-1 lg:border-2 border-white font-mono px-3 sm:px-4 lg:px-5 py-1 sm:py-2 lg:py-2.5 flex gap-2 sm:gap-3 items-center w-fit bg-white/60 hover:brightness-95 cursor-default transition-all duration-500 ease-in-out">
           <svg
             width="12"
             height="12"
@@ -26,7 +26,7 @@ const HomeHeader: React.FC<HomeHeaderProps> = ({
           >
             <rect width="12" height="12" rx="5.90908" fill="#16A34A" />
           </svg>
-          <span className="text-wdcc-grey text-xs sm:text-sm lg:text-lg font-medium whitespace-nowrap">
+          <span className="text-wdcc-grey text-xs sm:text-sm lg:text-2xl font-medium whitespace-nowrap">
             {activeProjectCount} active project{activeProjectCount !== 1 ? 's' : ''}
             {lastCommitAt && (
               <>
@@ -39,16 +39,16 @@ const HomeHeader: React.FC<HomeHeaderProps> = ({
       )}
 
       {/* Main Headings*/}
-      <div className="flex items-end justify-between mt-4 sm:mt-6 lg:mt-6">
+      <div className="flex items-end justify-between mt-4 sm:mt-6 lg:mt-11 ">
         <div className="flex flex-col justify-between">
           <div>
-            <h1 className="text-wdcc-oshan uppercase font-extrabold tracking-tight !leading-none m-0 text-[clamp(2.625rem,6vw+1vh,4.75rem)]">
+            <h1 className="text-wdcc-oshan uppercase font-extrabold tracking-tight !leading-none m-0 text-[clamp(2.625rem,8vw,6.3125rem)]">
               Projects Health Dashboard
             </h1>
 
             {/* Subheading */}
-            <div className="mt-3 sm:mt-4 lg:mt-5 max-w-[54.1875rem]">
-              <h3 className="text-wdcc-grey font-medium text-[clamp(0.81rem,1.4vw+0.6vh,1.25rem)] leading-relaxed m-0">
+            <div className="mt-4 sm:mt-6 lg:mt-10 max-w-[54.1875rem]">
+              <h3 className="text-wdcc-grey font-medium text-[clamp(0.81rem,2.5vw,1.75rem)] leading-relaxed m-0">
                 Track commits, team vibes, and health scores across all WDCC projects — live and at
                 a glance.
               </h3>
@@ -56,10 +56,10 @@ const HomeHeader: React.FC<HomeHeaderProps> = ({
           </div>
 
           {/* CTA */}
-          <div className="pt-4 sm:pt-6 lg:pt-8 pb-6">
+          <div className="pt-4 sm:pt-6 lg:pt-16 pb-6">
             <Link
               href="/leaderboard"
-              className="rounded-full px-7 sm:px-8 lg:px-8 py-3 sm:py-3.5 lg:py-3.5 bg-wdcc-oshan hover:bg-wdcc-orange transition-all duration-500 ease-in-out text-white font-bold text-base sm:text-lg lg:text-base inline-block"
+              className="rounded-full px-7 sm:px-8 lg:px-8 py-3 sm:py-4 lg:py-4 bg-wdcc-oshan hover:bg-wdcc-orange transition-all duration-500 ease-in-out text-white font-bold text-base sm:text-lg lg:text-lg inline-block"
             >
               See leaderboard
             </Link>

--- a/apps/web/src/components/headers/TeamHeader.tsx
+++ b/apps/web/src/components/headers/TeamHeader.tsx
@@ -78,14 +78,14 @@ export default function TeamHeader({
             <div className="flex gap-3 mt-6">
               <Link
                 href={`/project/${project.slug}`}
-                className="flex-1 text-center rounded-full bg-black text-white text-sm font-semibold px-5 py-2.5"
+                className="flex-1 text-center rounded-full bg-black text-white text-sm font-semibold px-5 py-2.5 whitespace-nowrap"
               >
                 Edit details
               </Link>
               <button
                 type="button"
                 onClick={() => setShowDeleteConfirm(true)}
-                className="flex-1 rounded-full bg-white text-red-500 text-sm font-semibold px-5 py-2.5 border border-[#e5e7eb]"
+                className="flex-1 rounded-full bg-white text-red-500 text-sm font-semibold px-5 py-2.5 border border-[#e5e7eb] whitespace-nowrap"
               >
                 Delete project
               </button>

--- a/apps/web/src/components/headers/TeamHeader.tsx
+++ b/apps/web/src/components/headers/TeamHeader.tsx
@@ -8,16 +8,10 @@ import type { ProjectHeaderData } from '@/lib/project/projects'
 interface TeamHeaderProps {
   project: ProjectHeaderData
   isAdmin?: boolean
-  activeProjectCount?: number
   onDeleteProject?: () => void
 }
 
-export default function TeamHeader({
-  project,
-  isAdmin = false,
-  activeProjectCount,
-  onDeleteProject,
-}: TeamHeaderProps) {
+export default function TeamHeader({ project, isAdmin = false, onDeleteProject }: TeamHeaderProps) {
   const memberCount = project._count.members
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
   const [isDeleting, setIsDeleting] = useState(false)
@@ -38,13 +32,6 @@ export default function TeamHeader({
       {/* MOBILE*/}
       <div className="lg:hidden bg-wdcc-blue-light rounded-2xl mx-5 sm:mx-10 mt-4 overflow-hidden">
         <div className="p-6 sm:p-8">
-          {isAdmin && activeProjectCount !== undefined && (
-            <div className="inline-flex items-center gap-2 rounded-full bg-white/70 px-3 py-1 mb-4 text-xs font-medium">
-              <span className="w-2 h-2 rounded-full bg-green-500 shrink-0" />
-              {activeProjectCount} active project{activeProjectCount !== 1 ? 's' : ''}
-            </div>
-          )}
-
           <div className="flex flex-row items-center gap-5">
             <div className="w-[72px] h-[72px] bg-[#d9d9d9] overflow-hidden rounded-[20px] shrink-0">
               {project.imageUrl && (
@@ -114,47 +101,49 @@ export default function TeamHeader({
               </span>
             </div>
 
-            <div className="flex items-start">
-              <div className="xl:w-[127px] xl:h-[127px] lg:w-[96px] lg:h-[96px] w-[72px] h-[72px] bg-[#d9d9d9] overflow-hidden rounded-[20px] shrink-0">
-                {project.imageUrl && (
-                  <Image
-                    src={project.imageUrl}
-                    alt={project.name}
-                    width={127}
-                    height={127}
-                    className="w-full h-full object-cover"
-                  />
-                )}
+            <div className="flex items-start justify-between gap-8">
+              <div className="flex items-start">
+                <div className="xl:w-[127px] xl:h-[127px] lg:w-[96px] lg:h-[96px] w-[72px] h-[72px] bg-[#d9d9d9] overflow-hidden rounded-[20px] shrink-0">
+                  {project.imageUrl && (
+                    <Image
+                      src={project.imageUrl}
+                      alt={project.name}
+                      width={127}
+                      height={127}
+                      className="w-full h-full object-cover"
+                    />
+                  )}
+                </div>
+
+                <div className="ml-[49px] flex-1 min-w-0">
+                  <h1 className="font-extrabold xl:text-[48px] lg:text-[36px] text-[28px] font-sans leading-none">
+                    {project.name}
+                  </h1>
+                  <p className="xl:text-[20px] lg:text-[16px] text-[14px] xl:mt-[20px] md:mt-[16px] font-mono text-wdcc-grey max-w-[70%]">
+                    {project.description && <span>{project.description}</span>}
+                  </p>
+                </div>
               </div>
 
-              <div className="ml-[49px] flex-1 min-w-0">
-                <h1 className="font-extrabold xl:text-[64px] lg:text-[48px] text-[36px] font-sans leading-tight">
-                  {project.name}
-                </h1>
-                <p className="xl:text-[20px] lg:text-[16px] text-[14px] xl:mt-[20px] md:mt-[16px] font-mono text-wdcc-grey max-w-[70%]">
-                  {project.description && <span>{project.description}</span>}
-                </p>
-              </div>
+              {isAdmin && (
+                <div className="flex flex-col gap-3 shrink-0">
+                  <Link
+                    href={`/project/${project.slug}`}
+                    className="text-center rounded-full bg-gradient-to-b from-[#252C48] to-[#161B30] text-white text-sm font-semibold px-10 py-4 hover:brightness-200 transition-colors"
+                  >
+                    Edit details
+                  </Link>
+                  <button
+                    type="button"
+                    onClick={() => setShowDeleteConfirm(true)}
+                    className="rounded-full bg-white/50 text-red-700 text-sm font-bold px-10 py-4 border border-[#DAA5A5] hover:bg-red-50 transition-colors"
+                  >
+                    Delete project
+                  </button>
+                </div>
+              )}
             </div>
           </div>
-
-          {isAdmin && (
-            <div className="flex flex-col gap-3 shrink-0 ml-8 mt-1">
-              <Link
-                href={`/project/${project.slug}`}
-                className="text-center rounded-full bg-gradient-to-b from-[#252C48] to-[#161B30] text-white text-sm font-semibold px-10 py-4 hover:brightness-200 transition-colors"
-              >
-                Edit details
-              </Link>
-              <button
-                type="button"
-                onClick={() => setShowDeleteConfirm(true)}
-                className="rounded-full bg-white/50 text-red-700 text-sm font-bold px-10 py-4 border border-[#DAA5A5] hover:bg-red-50 transition-colors"
-              >
-                Delete project
-              </button>
-            </div>
-          )}
         </div>
 
         {!isAdmin && (

--- a/apps/web/src/components/headers/TeamHeader.tsx
+++ b/apps/web/src/components/headers/TeamHeader.tsx
@@ -156,6 +156,16 @@ export default function TeamHeader({
             </div>
           )}
         </div>
+
+        {!isAdmin && (
+          <Image
+            src="/webster-team-header.svg"
+            width={190}
+            height={249}
+            alt="Team Header Image"
+            className="absolute right-[20px] md:right-[60px] xl:right-[110px] bottom-[-90px] w-[120px] md:w-[160px] xl:w-[190px] h-auto z-10 shrink-0"
+          />
+        )}
       </div>
 
       {/* DELETE CONFIRMATION MODAL */}

--- a/apps/web/src/components/headers/TeamHeader.tsx
+++ b/apps/web/src/components/headers/TeamHeader.tsx
@@ -1,14 +1,50 @@
+'use client'
+
+import { useState } from 'react'
 import Image from 'next/image'
+import Link from 'next/link'
 import type { ProjectHeaderData } from '@/lib/project/projects'
 
-export default function TeamHeader({ project }: { project: ProjectHeaderData }) {
+interface TeamHeaderProps {
+  project: ProjectHeaderData
+  isAdmin?: boolean
+  activeProjectCount?: number
+  onDeleteProject?: () => void
+}
+
+export default function TeamHeader({
+  project,
+  isAdmin = false,
+  activeProjectCount,
+  onDeleteProject,
+}: TeamHeaderProps) {
   const memberCount = project._count.members
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
+  const [isDeleting, setIsDeleting] = useState(false)
+
+  const handleConfirmDelete = async () => {
+    if (!onDeleteProject) return
+    setIsDeleting(true)
+    try {
+      await onDeleteProject()
+    } finally {
+      setIsDeleting(false)
+      setShowDeleteConfirm(false)
+    }
+  }
 
   return (
     <>
       {/* MOBILE*/}
       <div className="lg:hidden bg-wdcc-blue-light rounded-2xl mx-5 sm:mx-10 mt-4 overflow-hidden">
         <div className="p-6 sm:p-8">
+          {isAdmin && activeProjectCount !== undefined && (
+            <div className="inline-flex items-center gap-2 rounded-full bg-white/70 px-3 py-1 mb-4 text-xs font-medium">
+              <span className="w-2 h-2 rounded-full bg-green-500 shrink-0" />
+              {activeProjectCount} active project{activeProjectCount !== 1 ? 's' : ''}
+            </div>
+          )}
+
           <div className="flex flex-row items-center gap-5">
             <div className="w-[72px] h-[72px] bg-[#d9d9d9] overflow-hidden rounded-[20px] shrink-0">
               {project.imageUrl && (
@@ -37,45 +73,133 @@ export default function TeamHeader({ project }: { project: ProjectHeaderData }) 
               {project.description}
             </p>
           )}
+
+          {isAdmin && (
+            <div className="flex gap-3 mt-6">
+              <Link
+                href={`/project/${project.slug}`}
+                className="flex-1 text-center rounded-full bg-black text-white text-sm font-semibold px-5 py-2.5"
+              >
+                Edit details
+              </Link>
+              <button
+                type="button"
+                onClick={() => setShowDeleteConfirm(true)}
+                className="flex-1 rounded-full bg-white text-red-500 text-sm font-semibold px-5 py-2.5 border border-[#e5e7eb]"
+              >
+                Delete project
+              </button>
+            </div>
+          )}
         </div>
       </div>
 
       {/* DESKTOP */}
       <div className="hidden lg:block relative bg-wdcc-blue-light w-full">
-        <div className="flex pt-[80px] pl-[80px] pb-[80px]">
-          <div className="xl:w-[127px] xl:h-[127px] lg:w-[96px] lg:h-[96px] w-[72px] h-[72px] bg-[#d9d9d9] overflow-hidden rounded-[20px] shrink-0">
-            {project.imageUrl && (
-              <Image
-                src={project.imageUrl}
-                alt={project.name}
-                width={127}
-                height={127}
-                className="w-full h-full object-cover"
-              />
-            )}
+        <div className="flex pt-[80px] pl-[80px] pr-[80px] pb-[80px]">
+          <div className="flex-1 min-w-0">
+            <div className="xl:ml-[176px] lg:ml-[145px] ml-[121px] backdrop-blur-xl rounded-full border-2 border-white font-mono px-3 sm:px-4 lg:px-5 py-1.5 sm:py-2 lg:py-2.5 flex gap-2 sm:gap-3 items-center w-fit bg-white/60 hover:brightness-95 cursor-default transition-all duration-500 ease-in-out mb-4">
+              <svg
+                width="12"
+                height="12"
+                viewBox="0 0 12 12"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+                className="shrink-0 w-2 h-2 sm:w-2.5 sm:h-2.5 lg:w-3 lg:h-3"
+              >
+                <rect width="12" height="12" rx="5.90908" fill="#16A34A" />
+              </svg>
+              <span className="text-wdcc-grey text-xs sm:text-sm lg:text-xl font-medium whitespace-nowrap">
+                {memberCount} active member{memberCount !== 1 ? 's' : ''}
+              </span>
+            </div>
+
+            <div className="flex items-start">
+              <div className="xl:w-[127px] xl:h-[127px] lg:w-[96px] lg:h-[96px] w-[72px] h-[72px] bg-[#d9d9d9] overflow-hidden rounded-[20px] shrink-0">
+                {project.imageUrl && (
+                  <Image
+                    src={project.imageUrl}
+                    alt={project.name}
+                    width={127}
+                    height={127}
+                    className="w-full h-full object-cover"
+                  />
+                )}
+              </div>
+
+              <div className="ml-[49px] flex-1 min-w-0">
+                <h1 className="font-extrabold xl:text-[64px] lg:text-[48px] text-[36px] font-sans leading-tight">
+                  {project.name}
+                </h1>
+                <p className="xl:text-[20px] lg:text-[16px] text-[14px] xl:mt-[20px] md:mt-[16px] font-mono text-wdcc-grey max-w-[70%]">
+                  {project.description && <span>{project.description}</span>}
+                </p>
+              </div>
+            </div>
           </div>
 
-          <div className="ml-[49px] flex-1">
-            <h1 className="font-extrabold xl:text-[64px] lg:text-[48px] text-[36px] font-sans leading-tight">
-              {project.name}
-            </h1>
-            <p className="xl:text-[20px] lg:text-[16px] text-[14px] xl:mt-[20px] md:mt-[16px] font-mono text-wdcc-grey max-w-[70%]">
-              {project.description && <span>{project.description} • </span>}
-              <span>
-                {memberCount} Member{memberCount !== 1 ? 's' : ''}
-              </span>
+          {isAdmin && (
+            <div className="flex flex-col gap-3 shrink-0 ml-8 mt-1">
+              <Link
+                href={`/project/${project.slug}`}
+                className="text-center rounded-full bg-gradient-to-b from-[#252C48] to-[#161B30] text-white text-sm font-semibold px-10 py-4 hover:brightness-200 transition-colors"
+              >
+                Edit details
+              </Link>
+              <button
+                type="button"
+                onClick={() => setShowDeleteConfirm(true)}
+                className="rounded-full bg-white/50 text-red-700 text-sm font-bold px-10 py-4 border border-[#DAA5A5] hover:bg-red-50 transition-colors"
+              >
+                Delete project
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* DELETE CONFIRMATION MODAL */}
+      {showDeleteConfirm && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 px-4"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="delete-project-title"
+          onClick={() => !isDeleting && setShowDeleteConfirm(false)}
+        >
+          <div
+            className="w-full max-w-sm rounded-2xl bg-white p-6 shadow-xl"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h2 id="delete-project-title" className="text-lg font-bold font-sans">
+              Delete &ldquo;{project.name}&rdquo;?
+            </h2>
+            <p className="mt-2 text-sm font-mono text-wdcc-grey leading-relaxed">
+              This permanently deletes the project and everything linked to it - repositories,
+              members, weekly stats, and Discord data. This can&apos;t be undone.
             </p>
+
+            <div className="mt-6 flex gap-3">
+              <button
+                type="button"
+                onClick={() => setShowDeleteConfirm(false)}
+                disabled={isDeleting}
+                className="flex-1 rounded-full border border-[#e5e7eb] px-5 py-2.5 text-sm font-semibold disabled:opacity-50"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={handleConfirmDelete}
+                disabled={isDeleting}
+                className="flex-1 rounded-full bg-red-600 text-white px-5 py-2.5 text-sm font-semibold hover:bg-red-700 disabled:opacity-50 whitespace-nowrap"
+              >
+                {isDeleting ? 'Deleting…' : 'Delete permanently'}
+              </button>
+            </div>
           </div>
         </div>
-
-        <Image
-          src="/webster-team-header.svg"
-          width={190}
-          height={249}
-          alt="Team Header Image"
-          className="absolute right-[20px] md:right-[60px] xl:right-[110px] bottom-[-90px] w-[120px] md:w-[160px] xl:w-[190px] h-auto z-10 shrink-0"
-        />
-      </div>
+      )}
     </>
   )
 }

--- a/apps/web/src/components/navbar/Navbar.tsx
+++ b/apps/web/src/components/navbar/Navbar.tsx
@@ -32,23 +32,27 @@ export async function Navbar() {
         <NavbarBrand />
         <div className="flex items-center gap-4 xl:gap-10 text-[16px]">
           <div className="hidden lg:flex gap-4 xl:gap-8 font-figtree">
-            <Link href={isAdmin ? '/' : '/'} className="group flex items-center">
+            <Link href={isAdmin ? '/metric-weighting' : '/'} className="group flex items-center">
               <span className="inline-block -translate-x-0.5 transition-transform duration-200 ease-out group-hover:translate-x-1">
                 {'('}
               </span>
-              <span className="px-1">{isAdmin ? 'Metric Weighting' : 'Projects'}</span>
+              <span className="px-1 whitespace-nowrap">
+                {isAdmin ? 'Metric Weighting' : 'Projects'}
+              </span>
               <span className="inline-block translate-x-0.5 transition-transform duration-200 ease-out group-hover:-translate-x-1">
                 {')'}
               </span>
             </Link>
             <Link
               href={isAdmin ? '/admin-dashboard/auth-list' : '/leaderboard'}
-              className="group flex items-center"
+              className="group flex items-center "
             >
               <span className="inline-block -translate-x-0.5 transition-transform duration-200 ease-out group-hover:translate-x-1">
                 {'('}
               </span>
-              <span className="px-1">{isAdmin ? 'Authorised Users' : 'Leaderboard'}</span>
+              <span className="px-1 whitespace-nowrap">
+                {isAdmin ? 'Authorised Users' : 'Leaderboard'}
+              </span>
               <span className="inline-block translate-x-0.5 transition-transform duration-200 ease-out group-hover:-translate-x-1">
                 {')'}
               </span>
@@ -59,7 +63,7 @@ export async function Navbar() {
             {(isExec || isAdmin) && (
               <Link
                 href="/exec-dashboard"
-                className="hidden lg:block rounded-full bg-wdcc-oshan text-white hover:bg-gray-300 px-4 py-1.5"
+                className="hidden lg:block rounded-full bg-wdcc-oshan text-white hover:bg-gray-300 px-4 py-1.5 whitespace-nowrap"
               >
                 Exec dashboard
               </Link>
@@ -67,7 +71,7 @@ export async function Navbar() {
             {isAdmin && (
               <Link
                 href="/admin-dashboard"
-                className="hidden lg:block rounded-full bg-wdcc-oshan text-white hover:bg-gray-300 px-4 py-1.5"
+                className="hidden lg:block rounded-full bg-wdcc-oshan text-white hover:bg-gray-300 px-4 py-1.5 whitespace-nowrap"
               >
                 Admin dashboard
               </Link>

--- a/apps/web/src/components/navbar/Navbar.tsx
+++ b/apps/web/src/components/navbar/Navbar.tsx
@@ -63,7 +63,7 @@ export async function Navbar() {
             {(isExec || isAdmin) && (
               <Link
                 href="/exec-dashboard"
-                className="hidden lg:block rounded-full bg-wdcc-oshan text-white hover:bg-gray-300 px-4 py-1.5 whitespace-nowrap"
+                className="hidden lg:block rounded-full bg-wdcc-oshan text-white hover:bg-gray-600 px-4 py-1.5 whitespace-nowrap"
               >
                 Exec dashboard
               </Link>
@@ -71,7 +71,7 @@ export async function Navbar() {
             {isAdmin && (
               <Link
                 href="/admin-dashboard"
-                className="hidden lg:block rounded-full bg-wdcc-oshan text-white hover:bg-gray-300 px-4 py-1.5 whitespace-nowrap"
+                className="hidden lg:block rounded-full bg-wdcc-oshan text-white hover:bg-gray-600 px-4 py-1.5 whitespace-nowrap"
               >
                 Admin dashboard
               </Link>

--- a/apps/web/src/components/navbar/Navbar.tsx
+++ b/apps/web/src/components/navbar/Navbar.tsx
@@ -28,10 +28,10 @@ export async function Navbar() {
 
   return (
     <>
-      <header className="z-50 sticky top-0 flex items-center justify-between px-5 sm:px-10 lg:px-20 h-16 bg-white/65 border-b border-gray-200 backdrop-blur-sm">
+      <header className="z-50 text-[13px] 2xl:text-[16px] sticky top-0 flex items-center justify-between px-5 sm:px-10 lg:px-20 h-16 bg-white/65 border-b border-gray-200 backdrop-blur-sm">
         <NavbarBrand />
-        <div className="flex items-center gap-4 xl:gap-10 text-[16px]">
-          <div className="hidden lg:flex gap-4 xl:gap-8 font-figtree">
+        <div className="flex items-center gap-4 xl:gap-6">
+          <div className="hidden lg:flex gap-4 xl:gap-6 font-figtree">
             <Link href={isAdmin ? '/metric-weighting' : '/'} className="group flex items-center">
               <span className="inline-block -translate-x-0.5 transition-transform duration-200 ease-out group-hover:translate-x-1">
                 {'('}
@@ -59,7 +59,7 @@ export async function Navbar() {
             </Link>
           </div>
 
-          <div className="flex items-center gap-2 xl:gap-4 font-arial text-[16px]">
+          <div className="flex items-center gap-2 xl:gap-4 font-arial">
             {(isExec || isAdmin) && (
               <Link
                 href="/exec-dashboard"

--- a/apps/web/src/components/navbar/NavbarBrand.tsx
+++ b/apps/web/src/components/navbar/NavbarBrand.tsx
@@ -18,7 +18,7 @@ export function NavbarBrand() {
       {isProjectDetail && (
         <Link
           href="/"
-          className="flex lg:hidden items-center gap-2 font-figtree text-[16px] text-wdcc-oshan font-semibold"
+          className="flex xl:hidden items-center gap-2 font-figtree text-[16px] text-wdcc-oshan font-semibold whitespace-nowrap"
         >
           <ArrowLeft className="w-6 h-6" strokeWidth={2.5} />
           <span>Projects</span>
@@ -28,10 +28,10 @@ export function NavbarBrand() {
       {/* Logo + wordmark */}
       <Link
         href="/"
-        className={`items-center gap-4 xl:gap-6 ${isProjectDetail ? 'hidden lg:flex' : 'flex'}`}
+        className={`items-center gap-4 xl:gap-6 ${isProjectDetail ? 'hidden xl:flex' : 'flex'}`}
       >
         <Image src="/logo.svg" alt="WDCC Logo" width={60} height={40} />
-        <span className="text-[16px] xl:text-[24px] text-wdcc-blue leading-none font-cartograph-mono-cf uppercase whitespace-nowrap">
+        <span className="hidden lg:inline-block text-[16px] xl:text-[24px] text-wdcc-blue leading-none font-cartograph-mono-cf uppercase whitespace-nowrap">
           Projects Health Dashboard
         </span>
       </Link>

--- a/apps/web/src/components/navbar/NavbarBrand.tsx
+++ b/apps/web/src/components/navbar/NavbarBrand.tsx
@@ -31,7 +31,7 @@ export function NavbarBrand() {
         className={`items-center gap-4 xl:gap-6 ${isProjectDetail ? 'hidden lg:flex' : 'flex'}`}
       >
         <Image src="/logo.svg" alt="WDCC Logo" width={60} height={40} />
-        <span className="text-[16px] xl:text-[24px] text-wdcc-blue leading-none font-cartograph-mono-cf uppercase">
+        <span className="text-[16px] xl:text-[24px] text-wdcc-blue leading-none font-cartograph-mono-cf uppercase whitespace-nowrap">
           Projects Health Dashboard
         </span>
       </Link>

--- a/apps/web/src/components/navbar/NavbarBrand.tsx
+++ b/apps/web/src/components/navbar/NavbarBrand.tsx
@@ -28,10 +28,10 @@ export function NavbarBrand() {
       {/* Logo + wordmark */}
       <Link
         href="/"
-        className={`items-center gap-4 xl:gap-6 ${isProjectDetail ? 'hidden xl:flex' : 'flex'}`}
+        className={`items-center gap-2 ${isProjectDetail ? 'hidden xl:flex' : 'flex'}`}
       >
         <Image src="/logo.svg" alt="WDCC Logo" width={60} height={40} />
-        <span className="hidden lg:inline-block text-[16px] xl:text-[24px] text-wdcc-blue leading-none font-cartograph-mono-cf uppercase whitespace-nowrap">
+        <span className="hidden xl:inline-block text-[16px] mb-0.5 xl:text-[20px] text-wdcc-blue leading-none font-cartograph-mono-cf uppercase whitespace-nowrap">
           Projects Health Dashboard
         </span>
       </Link>

--- a/apps/web/src/components/navbar/ProfileDropdown.tsx
+++ b/apps/web/src/components/navbar/ProfileDropdown.tsx
@@ -56,7 +56,11 @@ export function ProfileDropdown({ user }: { user: ProfileUser | null }) {
             </span>
           ))}
         <span className="text-xs font-sans font-semibold">
-          {user ? <span className="hidden lg:inline">{user.displayName}</span> : 'Sign In'}
+          {user ? (
+            <span className="hidden lg:inline whitespace-nowrap">{user.displayName}</span>
+          ) : (
+            'Sign In'
+          )}
         </span>
       </button>
 

--- a/apps/web/src/components/navbar/ProfileDropdown.tsx
+++ b/apps/web/src/components/navbar/ProfileDropdown.tsx
@@ -39,7 +39,7 @@ export function ProfileDropdown({ user }: { user: ProfileUser | null }) {
         onClick={() => setOpen((prev) => !prev)}
         aria-label="Open profile menu"
         aria-expanded={open}
-        className="rounded-full flex items-center lg:gap-2 lg:px-3 lg:py-2 lg:bg-white/60 lg:border lg:border-wdcc-oshan/[18%] lg:hover:bg-gray-200 transition-all duration-200 ease-in-out"
+        className="rounded-full min-w-max flex items-center lg:gap-2 lg:px-3 lg:py-2 lg:bg-white/60 lg:border lg:border-wdcc-oshan/[18%] lg:hover:bg-gray-200 transition-all duration-200 ease-in-out"
       >
         {user &&
           (user.avatarUrl ? (

--- a/apps/web/src/components/ui/ConnectedSources.tsx
+++ b/apps/web/src/components/ui/ConnectedSources.tsx
@@ -1,0 +1,178 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import type { GitHubRepository, DiscordChannel } from '@repo/db'
+
+interface ConnectedSourcesProps {
+  repositories: GitHubRepository[]
+  channels: DiscordChannel[]
+  onSaveRepository: (
+    repositoryId: string,
+    data: { owner: string; name: string }
+  ) => Promise<void> | void
+  onSaveChannel: (channelId: string, data: { externalId: string }) => Promise<void> | void
+}
+
+function SourceRow({
+  variant,
+  label,
+  value,
+  onSave,
+}: {
+  variant: 'github' | 'discord'
+  label: string
+  value: string
+  onSave: (newValue: string) => Promise<void> | void
+}) {
+  const router = useRouter()
+
+  // displayValue is what's actually rendered when not editing. It starts as
+  // `value` but is updated optimistically the moment a save succeeds, since
+  // the `value` prop itself won't change until the parent Server Component
+  // re-renders (which router.refresh() below triggers, but that's async).
+  const [displayValue, setDisplayValue] = useState(value)
+  const [isEditing, setIsEditing] = useState(false)
+  const [draft, setDraft] = useState(value)
+  const [isSaving, setIsSaving] = useState(false)
+
+  // Keep in sync if the parent eventually re-renders with fresh server data
+  // (e.g. after router.refresh() resolves, or a full page reload).
+  useEffect(() => {
+    setDisplayValue(value)
+  }, [value])
+
+  const handleSave = async () => {
+    setIsSaving(true)
+    try {
+      await onSave(draft)
+      setDisplayValue(draft)
+      setIsEditing(false)
+      router.refresh()
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  const isDiscord = variant === 'discord'
+
+  return (
+    <div>
+      <p className="text-xs font-mono tracking-wide text-gray-400 mb-2">{label}</p>
+
+      <div
+        className={`flex items-center gap-2 rounded-xl border-2 px-4 py-3 ${
+          isDiscord ? 'bg-indigo-50/70 border-indigo-100' : 'bg-white border-[#e5e7eb]'
+        }`}
+      >
+        <span
+          className={`w-4 h-4 shrink-0 ${isDiscord ? 'rounded-md bg-wdcc-blue' : 'rounded-full bg-black'}`}
+        />
+
+        {isEditing ? (
+          <input
+            autoFocus
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            className="flex-1 min-w-0 text-sm font-mono text-wdcc-blue bg-transparent outline-none border-b border-wdcc-blue/40"
+          />
+        ) : (
+          <span className="flex-1 min-w-0 truncate text-sm font-mono text-wdcc-blue">
+            {displayValue}
+          </span>
+        )}
+
+        {isEditing ? (
+          <div className="flex items-center gap-2 shrink-0">
+            <button
+              type="button"
+              onClick={handleSave}
+              disabled={isSaving}
+              className="text-xs font-mono rounded-md bg-wdcc-blue text-white px-3 py-1.5 disabled:opacity-50"
+            >
+              {isSaving ? 'Saving…' : 'Save'}
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                setDraft(displayValue)
+                setIsEditing(false)
+              }}
+              className="text-xs font-mono rounded-md border-2 border-[#e5e7eb] bg-white text-wdcc-blue px-3 py-1.5"
+            >
+              Cancel
+            </button>
+          </div>
+        ) : (
+          <button
+            type="button"
+            onClick={() => {
+              setDraft(displayValue)
+              setIsEditing(true)
+            }}
+            className="text-xs font-mono rounded-lg px-3 py-1.5 shrink-0 bg-white text-wdcc-blue border-2 border-wdcc-blue-light hover:bg-gray-50"
+          >
+            edit
+          </button>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export default function ConnectedSources({
+  repositories,
+  channels,
+  onSaveRepository,
+  onSaveChannel,
+}: ConnectedSourcesProps) {
+  return (
+    <div className="rounded-2xl border-2 border-wdcc-blue-light/30 bg-[#fafbfc] px-8 py-6">
+      <p className="text-base font-mono tracking-widest text-wdcc-grey mb-5">CONNECTED SOURCES</p>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        <div className="flex flex-col gap-4">
+          {repositories.length === 0 && (
+            <p className="text-sm font-mono text-wdcc-grey">No repository connected.</p>
+          )}
+          {repositories.map((repo) => (
+            <SourceRow
+              key={repo.id}
+              variant="github"
+              label="GITHUB REPOSITORY"
+              value={`github.com/${repo.owner}/${repo.name}`}
+              onSave={async (newValue) => {
+                // Strips an optional protocol and an optional "github.com/" prefix,
+                // so "github.com/owner/name", "https://github.com/owner/name",
+                // and bare "owner/name" all resolve to the same owner/name pair.
+                const cleaned = newValue
+                  .trim()
+                  .replace(/^(https?:\/\/)?(www\.)?github\.com\//i, '')
+                  .replace(/\/+$/, '')
+                const [owner, name] = cleaned.split('/')
+                if (owner && name) {
+                  await onSaveRepository(repo.id, { owner, name })
+                }
+              }}
+            />
+          ))}
+        </div>
+
+        <div className="flex flex-col gap-4">
+          {channels.length === 0 && (
+            <p className="text-sm font-mono text-wdcc-grey">No Discord channel connected.</p>
+          )}
+          {channels.map((channel) => (
+            <SourceRow
+              key={channel.id}
+              variant="discord"
+              label={`DISCORD CHANNEL SNOWFLAKE${channels.length > 1 ? ` — ${channel.name}` : ''}`}
+              value={channel.externalId}
+              onSave={(newValue) => onSaveChannel(channel.id, { externalId: newValue })}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/components/ui/ConnectedSources.tsx
+++ b/apps/web/src/components/ui/ConnectedSources.tsx
@@ -27,28 +27,26 @@ function SourceRow({
 }) {
   const router = useRouter()
 
-  // displayValue is what's actually rendered when not editing. It starts as
-  // `value` but is updated optimistically the moment a save succeeds, since
-  // the `value` prop itself won't change until the parent Server Component
-  // re-renders (which router.refresh() below triggers, but that's async).
   const [displayValue, setDisplayValue] = useState(value)
   const [isEditing, setIsEditing] = useState(false)
   const [draft, setDraft] = useState(value)
   const [isSaving, setIsSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
 
-  // Keep in sync if the parent eventually re-renders with fresh server data
-  // (e.g. after router.refresh() resolves, or a full page reload).
   useEffect(() => {
     setDisplayValue(value)
   }, [value])
 
   const handleSave = async () => {
     setIsSaving(true)
+    setError(null)
     try {
       await onSave(draft)
       setDisplayValue(draft)
       setIsEditing(false)
       router.refresh()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to save')
     } finally {
       setIsSaving(false)
     }
@@ -109,6 +107,7 @@ function SourceRow({
             onClick={() => {
               setDraft(displayValue)
               setIsEditing(true)
+              setError(null)
             }}
             className="text-xs font-mono rounded-lg px-3 py-1.5 shrink-0 bg-white text-wdcc-blue border-2 border-wdcc-blue-light hover:bg-gray-50"
           >
@@ -116,6 +115,8 @@ function SourceRow({
           </button>
         )}
       </div>
+
+      {error && <p className="text-xs font-mono text-red-500 mt-1">{error}</p>}
     </div>
   )
 }
@@ -142,17 +143,15 @@ export default function ConnectedSources({
               label="GITHUB REPOSITORY"
               value={`github.com/${repo.owner}/${repo.name}`}
               onSave={async (newValue) => {
-                // Strips an optional protocol and an optional "github.com/" prefix,
-                // so "github.com/owner/name", "https://github.com/owner/name",
-                // and bare "owner/name" all resolve to the same owner/name pair.
                 const cleaned = newValue
                   .trim()
                   .replace(/^(https?:\/\/)?(www\.)?github\.com\//i, '')
                   .replace(/\/+$/, '')
                 const [owner, name] = cleaned.split('/')
-                if (owner && name) {
-                  await onSaveRepository(repo.id, { owner, name })
+                if (!owner || !name) {
+                  throw new Error('Please enter a valid GitHub URL')
                 }
+                await onSaveRepository(repo.id, { owner, name })
               }}
             />
           ))}

--- a/apps/web/src/components/ui/DesktopLeaderboardSections.tsx
+++ b/apps/web/src/components/ui/DesktopLeaderboardSections.tsx
@@ -13,7 +13,7 @@ export default function DesktopLeaderboardSections({
 }: DesktopLeaderboardSectionsProps) {
   return (
     <div className="flex justify-between px-5 sm:px-10 lg:px-20 gap-[21px] my-20 w-full">
-      <section className="flex flex-col gap-3 w-[415px]">
+      <section className="flex flex-col gap-3 flex-1 min-w-0 max-w-[415px]">
         <h2 className="flex items-center gap-3 text-lg font-semibold">
           <span className="w-[4.9px] h-5 rounded-full bg-wdcc-kelvin" />
           Lines of Code Changed
@@ -25,7 +25,7 @@ export default function DesktopLeaderboardSections({
         </ClientSuspense>
       </section>
 
-      <section className="flex flex-col gap-3 w-[415px]">
+      <section className="flex flex-col gap-3 flex-1 min-w-0 max-w-[415px]">
         <h2 className="flex items-center gap-3 text-lg font-semibold">
           <span className="w-[4.9px] h-5 rounded-full bg-wdcc-blue" />
           Commits Made
@@ -37,7 +37,7 @@ export default function DesktopLeaderboardSections({
         </ClientSuspense>
       </section>
 
-      <section className="flex flex-col gap-3 w-[415px]">
+      <section className="flex flex-col gap-3 flex-1 min-w-0 max-w-[415px]">
         <h2 className="flex items-center gap-3 text-lg font-semibold">
           <span className="w-[4.9px] h-5 rounded-full bg-wdcc-amber" />
           Pull Requests Merged

--- a/apps/web/src/components/ui/DesktopProjectGrid.tsx
+++ b/apps/web/src/components/ui/DesktopProjectGrid.tsx
@@ -11,10 +11,16 @@ interface DesktopProjectGridProps {
 }
 
 const HOVER_RADIUS_PX = 500
+const TOUCH_LIT_DURATION_MS = 600
 
 export default function DesktopProjectGrid({ projects }: DesktopProjectGridProps) {
   const cursorRef = useRef<{ x: number; y: number } | null>(null)
-  const computeAmount = useCallback((rect: DOMRect) => {
+  const touchLitKeyRef = useRef<number | null>(null)
+  const touchTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const computeAmount = useCallback((rect: DOMRect, key: number) => {
+    if (touchLitKeyRef.current === key) return 1
+
     const cursor = cursorRef.current
     if (!cursor) return 0
 
@@ -26,6 +32,22 @@ export default function DesktopProjectGrid({ projects }: DesktopProjectGridProps
   }, [])
 
   const { litAmounts, setCardRef, scheduleRecompute } = useLitAmounts<number>(computeAmount)
+
+  const handleTouchStart = useCallback(
+    (index: number) => {
+      touchLitKeyRef.current = index
+      scheduleRecompute()
+
+      if (touchTimeoutRef.current) clearTimeout(touchTimeoutRef.current)
+      touchTimeoutRef.current = setTimeout(() => {
+        if (touchLitKeyRef.current === index) {
+          touchLitKeyRef.current = null
+          scheduleRecompute()
+        }
+      }, TOUCH_LIT_DURATION_MS)
+    },
+    [scheduleRecompute]
+  )
 
   return (
     <div
@@ -41,7 +63,12 @@ export default function DesktopProjectGrid({ projects }: DesktopProjectGridProps
     >
       {projects.map((project, index) =>
         project ? (
-          <Link key={project.id} href={`/project/${project.slug}`} className="block w-full">
+          <Link
+            key={project.id}
+            href={`/project/${project.slug}`}
+            className="block w-full"
+            onTouchStart={() => handleTouchStart(index)}
+          >
             <ProjectCard
               ref={setCardRef(index)}
               project={project}

--- a/apps/web/src/components/ui/LiveCommitFeed.tsx
+++ b/apps/web/src/components/ui/LiveCommitFeed.tsx
@@ -8,7 +8,7 @@ export default function LiveCommitFeed() {
 
   return (
     <div className="flex rounded-3xl border-2 border-wdcc-grey/10 lg:border lg:border-white/50 w-full mx-auto flex-col bg-[#FAFBFC] lg:bg-white/70">
-      <div className="flex flex-row items-center gap-2 lg:gap-5 pl-5 lg:pl-8 py-3 lg:py-4 ">
+      <div className="flex flex-row items-center gap-2 lg:gap-5 pl-5 lg:pl-8 py-3 lg:py-4">
         <svg
           width="12"
           height="12"

--- a/apps/web/src/components/ui/LiveCommitFeed.tsx
+++ b/apps/web/src/components/ui/LiveCommitFeed.tsx
@@ -8,7 +8,7 @@ export default function LiveCommitFeed() {
 
   return (
     <div className="flex rounded-3xl border-2 border-wdcc-grey/10 lg:border lg:border-white/50 w-full mx-auto flex-col bg-[#FAFBFC] lg:bg-white/70">
-      <div className="flex flex-row items-center gap-2 lg:gap-5 pl-5 lg:pl-8 py-3 lg:py-4">
+      <div className="flex flex-row items-center gap-2 lg:gap-5 px-5 lg:px-8 pt-5 pb-3">
         <svg
           width="12"
           height="12"

--- a/apps/web/src/components/ui/LiveCommitRow.tsx
+++ b/apps/web/src/components/ui/LiveCommitRow.tsx
@@ -40,7 +40,7 @@ export default function LiveCommitRow({
           )}
           <Link
             href={`/project/${projectSlug}`}
-            className={`font-mono font-medium text-wdcc-blue text-[clamp(0.5rem,2vw,1rem)] bg-olive-200 hover:bg-wdcc-amber hover:text-white transition-colors duration-200 rounded-lg px-3 h-fit place-self-center truncate`}
+            className={`font-mono font-medium text-wdcc-blue text-[clamp(0.5rem,2vw,1rem)] bg-olive-200 hover:bg-wdcc-amber hover:text-white transition-colors duration-200 rounded-lg px-3 py-1 h-fit place-self-center truncate`}
           >
             {repoName}
           </Link>

--- a/apps/web/src/components/ui/ProjectCard.tsx
+++ b/apps/web/src/components/ui/ProjectCard.tsx
@@ -20,6 +20,11 @@ interface ProjectCardProps {
   litAmount?: number
 }
 
+// Cards ease toward their new litAmount instead of snapping — keep this in
+// sync with anything else animating the same border (e.g. duration used by
+// other lit-border components) if that ever becomes shared.
+const BORDER_TRANSITION = 'transition-[background,inset,border-radius] duration-300 ease-out'
+
 function borderStyle(amount: number, maxInsetPx: number, baseRadius: string): React.CSSProperties {
   const clamped = clamp01(amount)
   const alpha = 0.4 + clamped * 0.6
@@ -42,7 +47,10 @@ const ProjectCard = forwardRef<HTMLDivElement, ProjectCardProps>(function Projec
   if (viewMode === 'rows') {
     return (
       <div ref={ref} className="relative w-full rounded-2xl overflow-visible font-sans">
-        <div className="pointer-events-none absolute" style={borderStyle(litAmount, 2, '16px')} />
+        <div
+          className={`pointer-events-none absolute ${BORDER_TRANSITION}`}
+          style={borderStyle(litAmount, 1, '16px')}
+        />
         <div className="absolute inset-[2px] bg-white rounded-[14px]" />
 
         <div className="relative z-10 flex flex-row items-center gap-3 p-2.5">
@@ -88,7 +96,10 @@ const ProjectCard = forwardRef<HTMLDivElement, ProjectCardProps>(function Projec
         ref={ref}
         className="relative w-full aspect-square rounded-2xl overflow-visible font-sans"
       >
-        <div className="pointer-events-none absolute" style={borderStyle(litAmount, 2, '16px')} />
+        <div
+          className={`pointer-events-none absolute ${BORDER_TRANSITION}`}
+          style={borderStyle(litAmount, 1, '16px')}
+        />
         <div className="absolute inset-[2px] bg-white rounded-[14px]" />
 
         <div className="absolute inset-[2px] z-10 flex flex-col p-3 overflow-hidden">
@@ -140,8 +151,8 @@ const ProjectCard = forwardRef<HTMLDivElement, ProjectCardProps>(function Projec
       "
     >
       <div
-        className="pointer-events-none absolute"
-        style={borderStyle(litAmount, 4, 'clamp(18px,2.5vw,31px)')}
+        className={`pointer-events-none absolute ${BORDER_TRANSITION}`}
+        style={borderStyle(litAmount, 2, 'clamp(18px,2.5vw,31px)')}
       />
       <div className="absolute inset-[3px] md:inset-[4px] bg-white rounded-[clamp(15px,2.2vw,28px)]" />
 

--- a/apps/web/src/components/ui/ProjectCard.tsx
+++ b/apps/web/src/components/ui/ProjectCard.tsx
@@ -100,9 +100,9 @@ const ProjectCard = forwardRef<HTMLDivElement, ProjectCardProps>(function Projec
           className={`pointer-events-none absolute ${BORDER_TRANSITION}`}
           style={borderStyle(litAmount, 1, '16px')}
         />
-        <div className="absolute inset-[2px] bg-white rounded-[14px]" />
+        <div className="absolute inset-[3px] bg-white rounded-[13px]" />
 
-        <div className="absolute inset-[2px] z-10 flex flex-col p-3 overflow-hidden">
+        <div className="absolute inset-[3px] z-10 flex flex-col p-[clamp(12px,4vw,16px)] overflow-hidden">
           <div className="w-[34%] aspect-square max-w-[52px] rounded-[16px] bg-[#d9d9d9] overflow-hidden shrink-0">
             {imageUrl && (
               <Image

--- a/apps/web/src/hooks/useLitAmounts.ts
+++ b/apps/web/src/hooks/useLitAmounts.ts
@@ -21,16 +21,33 @@ export function useLitAmounts<K>(computeAmount: (rect: DOMRect, key: K) => numbe
       rafIdRef.current = null
 
       const last = lastLitAmountsRef.current
-      const next = new Map<K, number>()
-      let changed = false
 
+      // Compute every card's raw amount first, then keep only the single
+      // closest (highest) card lit and zero out the rest — prevents two
+      // adjacent cards both glowing when the cursor sits between them.
+      const entries: Array<[K, number]> = []
       cardRefs.current.forEach((el, key) => {
         const raw = computeAmountRef.current(el.getBoundingClientRect(), key)
         const litAmount = Math.round(clamp01(raw) * LIT_AMOUNT_PRECISION) / LIT_AMOUNT_PRECISION
+        entries.push([key, litAmount])
+      })
 
+      let winnerKey: K | null = null
+      let winnerAmount = 0
+      for (const [key, amount] of entries) {
+        if (amount > winnerAmount) {
+          winnerAmount = amount
+          winnerKey = key
+        }
+      }
+
+      const next = new Map<K, number>()
+      let changed = false
+      for (const [key] of entries) {
+        const litAmount = key === winnerKey ? winnerAmount : 0
         next.set(key, litAmount)
         if (last.get(key) !== litAmount) changed = true
-      })
+      }
 
       if (changed || next.size !== last.size) {
         lastLitAmountsRef.current = next

--- a/apps/web/src/lib/project/projects.ts
+++ b/apps/web/src/lib/project/projects.ts
@@ -11,6 +11,9 @@ const projectHeaderSelect = {
       members: true,
     },
   },
+  repositories: true,
+  channels: true,
+  slug: true,
 } satisfies Prisma.ProjectSelect
 
 const projectCardSelect = {

--- a/apps/web/src/lib/project/projects.ts
+++ b/apps/web/src/lib/project/projects.ts
@@ -11,8 +11,8 @@ const projectHeaderSelect = {
       members: true,
     },
   },
-  repositories: true,
-  channels: true,
+  repositories: { where: { isActive: true } },
+  channels: { where: { isActive: true } },
   slug: true,
 } satisfies Prisma.ProjectSelect
 

--- a/apps/worker/src/scripts/backfill-discord.ts
+++ b/apps/worker/src/scripts/backfill-discord.ts
@@ -152,7 +152,12 @@ export async function main() {
 
   const projects = await db.project.findMany({
     where: { isActive: true },
-    select: { id: true, name: true, channels: true, repositories: { select: { id: true } } },
+    select: {
+      id: true,
+      name: true,
+      channels: { where: { isActive: true } },
+      repositories: { where: { isActive: true }, select: { id: true } },
+    },
   })
 
   logger.info(

--- a/apps/worker/src/scripts/backfill-github.ts
+++ b/apps/worker/src/scripts/backfill-github.ts
@@ -265,6 +265,7 @@ export async function main() {
       id: true,
       name: true,
       repositories: {
+        where: { isActive: true },
         select: { id: true, owner: true, name: true, installationId: true },
       },
     },


### PR DESCRIPTION
## Description
Adds admin-facing view/functionality to public teams page and fixes several UI issues.

## Solution
- Redesigned header to conform to new Figma design
- Add a edit project button which redirects to admin dashboard page for that specific project and delete project button with confirmation model to page header
- Add connected sources panel under header with ability to edit source values
- Removed wrapping in nav bar text on screen shrink and hide brand text on smaller screen sizes
- Scaled down sizing for home page header and reduced gap between header and active projects
- Fixed bug for active projects where all cards entered hover state at the same time and reduced border thickness in hover state
- Increased horizontal padding for live commit feed
- Link metric weighting button in navbar to actual page
- Remove horizontal overflow of leaderboard on smaller screen sizes
- Added uniform horizontal padding for exec dashboard view

## Notes

<!-- Add any notes you think are needed -->
