### PR TITLE
[#251] weekly velocity graph

### DIFF
--- a/apps/web/src/app/api/formula/[type]/route.ts
+++ b/apps/web/src/app/api/formula/[type]/route.ts
@@ -62,7 +62,7 @@ export async function PUT(request: Request, { params }: { params: Promise<{ type
   }
 
   const config = await db.config.upsert({
-    where: {  
+    where: {
       scope_key: { scope: GLOBAL_SCOPE, key: formulaKey(type) },
     },
     update: {
@@ -75,6 +75,11 @@ export async function PUT(request: Request, { params }: { params: Promise<{ type
       value: validated.data,
     },
   })
+
+  if (type === 'health') {
+    await recomputeAllHealthScores(validated.data)
+    await recomputeAllVelocity()
+  }
 
   return NextResponse.json({ formula: config.value as string, updatedAt: config.updatedAt })
 }

--- a/apps/web/src/components/charts/ProjectGraphs.tsx
+++ b/apps/web/src/components/charts/ProjectGraphs.tsx
@@ -38,6 +38,11 @@ export default function ProjectGraphs({
         dates={dates}
         dataPoints={stats?.discordMessages ?? []}
       />
+      <LineGraph
+        title="Weekly Velocity"
+        dates={dates}
+        dataPoints={(stats?.velocity ?? []).map(Math.round)}
+      />
     </div>
   )
 }

--- a/apps/web/src/lib/project/weekly-stats.ts
+++ b/apps/web/src/lib/project/weekly-stats.ts
@@ -181,6 +181,7 @@ export interface ProjectWeeklyStats {
   linesChanged: number[]
   discordMessages: number[]
   healthScore: number[]
+  velocity: number[]
 }
 
 export interface TeamWeeklyStats extends ProjectWeeklyStats {
@@ -218,6 +219,7 @@ export async function getProjectWeeklyStats(projectId: string): Promise<ProjectW
       linesRemoved: true,
       discordMessages: true,
       healthScore: true,
+      velocityScore: true,
     },
   })
 
@@ -228,6 +230,7 @@ export async function getProjectWeeklyStats(projectId: string): Promise<ProjectW
     linesChanged: rows.map((r) => r.linesAdded + r.linesRemoved),
     discordMessages: rows.map((r) => r.discordMessages),
     healthScore: rows.map((r) => r.healthScore ?? 0),
+    velocity: rows.map((r) => r.velocityScore ?? 0),
   }
 }
 
@@ -253,6 +256,7 @@ export async function getAllProjectsWeeklyStats(): Promise<TeamWeeklyStats[]> {
       linesRemoved: true,
       discordMessages: true,
       healthScore: true,
+      velocityScore: true,
       project: {
         select: { slug: true, name: true },
       },
@@ -274,6 +278,7 @@ export async function getAllProjectsWeeklyStats(): Promise<TeamWeeklyStats[]> {
         linesChanged: [],
         discordMessages: [],
         healthScore: [],
+        velocity: [],
       }
       byProject.set(slug, team)
     }
@@ -284,6 +289,7 @@ export async function getAllProjectsWeeklyStats(): Promise<TeamWeeklyStats[]> {
     team.linesChanged.push(r.linesAdded + r.linesRemoved)
     team.discordMessages.push(r.discordMessages)
     team.healthScore.push(r.healthScore ?? 0)
+    team.velocity.push(r.velocityScore ?? 0)
   }
 
   return Array.from(byProject.values())


### PR DESCRIPTION
## Description

- Adds the weekly velocity graph to the projects page

## Solution

- Adds a new "Weekly Velocity" `LineGraph` reusing the existing chart component/style, sourced from `WeeklyStats.velocityScore` (already computed weekly by the worker)

## Notes

- Wires up `recomputeAllHealthScores` and `recomputeAllVelocity` in the formula API route so saving a health formula from the admin UI automatically recomputes all health scores and velocity scores
