### PR TITLE
[#270] Added RLS Select policy to project-images

### DIFF
--- a/apps/web/src/app/(admin)/projects/new/page.tsx
+++ b/apps/web/src/app/(admin)/projects/new/page.tsx
@@ -6,8 +6,43 @@ import Image from 'next/image'
 import Link from 'next/link'
 import { BORDER_DEFAULT, BORDER_HOVER, inputClass, inputErrorClass } from '@/lib/admin/layout'
 import { z } from 'zod'
-import { createProjectSchema, githubRepoUrl } from '@/lib/schemas/admin'
+import {
+  ALLOWED_IMAGE_TYPES,
+  createProjectSchema,
+  githubRepoUrl,
+  MAX_IMAGE_BYTES,
+} from '@/lib/schemas/admin'
 import FieldError from '@/components/utils/FieldError'
+
+const FIELD_ERROR_SLOTS = new Set(['projectName', 'githubLinks', 'discordSnowflakeIds'])
+
+async function readErrorMessage(response: Response): Promise<string> {
+  const fallback = `Request failed (${response.status} ${response.statusText})`.trim()
+
+  let body: string
+  try {
+    body = await response.text()
+  } catch (err) {
+    console.error('Could not read error response body:', err)
+    return fallback
+  }
+
+  if (!body.trim()) {
+    console.error(`Empty error response (${response.status})`)
+    return fallback
+  }
+
+  try {
+    const data = JSON.parse(body)
+    const message = data?.error ?? data?.message
+    if (typeof message === 'string' && message.trim()) return message
+    console.error(`Unexpected JSON error shape (${response.status}):`, data)
+    return fallback
+  } catch {
+    console.error(`Non-JSON error response (${response.status}):`, body.slice(0, 500))
+    return fallback
+  }
+}
 
 export default function CreateProjectPage() {
   const router = useRouter()
@@ -20,9 +55,11 @@ export default function CreateProjectPage() {
   const [repoInputError, setRepoInputError] = useState<string | null>(null)
   const [imagePreview, setImagePreview] = useState<string | null>(null)
   const [imageName, setImageName] = useState<string | null>(null)
+  const [imageError, setImageError] = useState<string | null>(null)
   const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({})
   const [error, setError] = useState<string | null>(null)
   const [success, setSuccess] = useState(false)
+  const [isSubmitting, setIsSubmitting] = useState(false)
 
   const addRepo = () => {
     const trimmed = repoInput.trim()
@@ -51,6 +88,26 @@ export default function CreateProjectPage() {
   const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0]
     if (!file) return
+
+    if (file.size > MAX_IMAGE_BYTES) {
+      setImageError(
+        `"${file.name}" is ${(file.size / 1024 / 1024).toFixed(1)}MB - maximum is ${MAX_IMAGE_BYTES / 1024 / 1024}MB`
+      )
+      setImagePreview(null)
+      setImageName(null)
+      e.target.value = ''
+      return
+    }
+
+    if (!ALLOWED_IMAGE_TYPES.includes(file.type)) {
+      setImageError('Unsupported file type - use PNG, JPG or WEBP')
+      setImagePreview(null)
+      setImageName(null)
+      e.target.value = ''
+      return
+    }
+
+    setImageError(null)
     setImageName(file.name)
     const reader = new FileReader()
     reader.onload = (ev) => setImagePreview(ev.target?.result as string)
@@ -59,6 +116,8 @@ export default function CreateProjectPage() {
 
   const handleSubmit = async (event: React.SyntheticEvent<HTMLFormElement>) => {
     event.preventDefault()
+    if (isSubmitting || success) return
+
     setError(null)
 
     const formData = new FormData(event.currentTarget)
@@ -81,6 +140,10 @@ export default function CreateProjectPage() {
         githubLinks: errors.githubLinks?.[0] ?? '',
         discordSnowflakeIds: errors.discordSnowflakeIds?.[0] ?? '',
       })
+      const unmapped = validation.error.issues.find(
+        (issue) => !FIELD_ERROR_SLOTS.has(String(issue.path[0] ?? ''))
+      )
+      if (unmapped) setError(unmapped.message)
       return
     }
 
@@ -91,17 +154,23 @@ export default function CreateProjectPage() {
       formData.append('discordChannelNames', c.name)
     })
 
-    const response = await fetch('/api/project', { method: 'POST', body: formData })
+    setIsSubmitting(true)
+    try {
+      const response = await fetch('/api/project', { method: 'POST', body: formData })
 
-    if (!response.ok) {
-      const text = await response.text()
-      const data = JSON.parse(text)
-      setError(data?.error ?? data?.message ?? text)
-      return
+      if (!response.ok) {
+        setError(await readErrorMessage(response))
+        return
+      }
+
+      setSuccess(true)
+      setTimeout(() => router.replace('/admin-dashboard'), 1200)
+    } catch (err) {
+      console.error('Project creation request failed:', err)
+      setError('Could not reach the server. Check your connection and try again.')
+    } finally {
+      setIsSubmitting(false)
     }
-
-    setSuccess(true)
-    setTimeout(() => router.replace('/admin-dashboard'), 1200)
   }
 
   return (
@@ -238,8 +307,6 @@ export default function CreateProjectPage() {
                   Add
                 </button>
               </div>
-              {/* Hidden input for first/required repo */}
-              <input type="hidden" name="githubLink" value={repos[0] ?? ''} />
               <FieldError message={fieldErrors.githubLinks} />
 
               {repos.length > 0 && (
@@ -329,12 +396,17 @@ export default function CreateProjectPage() {
 
             {/* Project Image */}
             <SectionLabel color="pink" icon="image">
-              Project Image
+              Project Image{' '}
+              <span className="text-wdcc-grey-light normal-case tracking-normal">(4MB max)</span>
             </SectionLabel>
 
             <div
               onClick={() => fileInputRef.current?.click()}
-              className="border-[1.5px] border-dashed border-wdcc-kelvin/40 rounded-2xl p-6 text-center cursor-pointer hover:bg-wdcc-kelvin/5 hover:border-wdcc-kelvin/70 transition-all"
+              className={`border-[1.5px] border-dashed rounded-2xl p-6 text-center cursor-pointer transition-all ${
+                imageError
+                  ? 'border-wdcc-kelvin bg-wdcc-kelvin/5'
+                  : 'border-wdcc-kelvin/40 hover:bg-wdcc-kelvin/5 hover:border-wdcc-kelvin/70'
+              }`}
             >
               {imagePreview ? (
                 <div className="flex items-center gap-3">
@@ -363,11 +435,12 @@ export default function CreateProjectPage() {
                 ref={fileInputRef}
                 type="file"
                 name="image"
-                accept="image/*"
+                accept={ALLOWED_IMAGE_TYPES.join(',')}
                 className="hidden"
                 onChange={handleImageChange}
               />
             </div>
+            <FieldError message={imageError ?? undefined} />
 
             {/* Status */}
             {error && (
@@ -391,10 +464,11 @@ export default function CreateProjectPage() {
               </Link>
               <button
                 type="submit"
-                className="flex items-center gap-2 font-mono text-sm font-semibold text-white bg-wdcc-oshan hover:bg-wdcc-oshan/80 transition-all duration-150 rounded-xl px-6 py-2.5"
+                disabled={isSubmitting || success}
+                className="flex items-center gap-2 font-mono text-sm font-semibold text-white bg-wdcc-oshan hover:bg-wdcc-oshan/80 disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-wdcc-oshan transition-all duration-150 rounded-xl px-6 py-2.5"
               >
-                <span>→</span>
-                Create Project
+                <span>{isSubmitting ? '⋯' : '→'}</span>
+                {isSubmitting ? 'Creating…' : 'Create Project'}
               </button>
             </div>
           </div>

--- a/apps/web/src/app/api/formula/[type]/route.ts
+++ b/apps/web/src/app/api/formula/[type]/route.ts
@@ -3,8 +3,6 @@ import { db, Role } from '@repo/db'
 import { z } from 'zod'
 import { formulaSchema } from '@/lib/schemas/admin'
 import { hasRole } from '@/lib/auth'
-import { recomputeAllHealthScores } from '@/lib/admin/health-score'
-import { recomputeAllVelocity } from '@/lib/admin/velocity'
 
 const VALID_TYPES = ['health', 'mvp'] as const
 type FormulaType = (typeof VALID_TYPES)[number]
@@ -62,7 +60,7 @@ export async function PUT(request: Request, { params }: { params: Promise<{ type
   }
 
   const config = await db.config.upsert({
-    where: {  
+    where: {
       scope_key: { scope: GLOBAL_SCOPE, key: formulaKey(type) },
     },
     update: {

--- a/apps/web/src/app/api/project/route.ts
+++ b/apps/web/src/app/api/project/route.ts
@@ -1,9 +1,11 @@
 import { hasRole } from '@/lib/auth'
-import { createProjectSchema } from '@/lib/schemas/admin'
+import { createProjectSchema, MAX_IMAGE_BYTES } from '@/lib/schemas/admin'
 import { db } from '@repo/db'
 import { getInstallationOctokit } from '@repo/github'
 import { revalidateTag } from 'next/cache'
 import { uploadImage } from '@/lib/storage'
+
+const MAX_REQUEST_BYTES = MAX_IMAGE_BYTES + 1024 * 1024
 
 export interface ValidatedRepo {
   owner: string
@@ -120,6 +122,16 @@ export async function validateSnowflakeExists(snowflakeId: string) {
 export async function POST(request: Request) {
   if (!(await hasRole('ADMIN'))) {
     return Response.json({ error: 'Unauthorized. Admin access required.' }, { status: 403 })
+  }
+
+  // Prevent accidentl OOM's since formData() bufferes incoming into memory.
+  // Won't do anything against requests without the content-length header.
+  const contentLength = Number(request.headers.get('content-length') ?? 0)
+  if (contentLength > MAX_REQUEST_BYTES) {
+    return Response.json(
+      { error: `Request too large. Maximum image size is ${MAX_IMAGE_BYTES / 1024 / 1024}MB` },
+      { status: 413 }
+    )
   }
 
   const installationId = process.env.GITHUB_APP_INSTALLATION_ID
@@ -268,6 +280,7 @@ export async function POST(request: Request) {
 
     return Response.json(newProject, { status: 201 })
   } catch (error) {
+    console.error('Project creation failed:', error)
     return Response.json(
       { error: error instanceof Error ? error.message : 'Failed to create project' },
       { status: 500 }

--- a/apps/web/src/lib/schemas/admin.ts
+++ b/apps/web/src/lib/schemas/admin.ts
@@ -16,6 +16,11 @@ export const discordSnowflake = z
   .min(1, 'Snowflake ID is required')
   .regex(/^\d{17,19}$/, 'Must be a 17-19 digit snowflake ID')
 
+// --- Image upload ---
+
+export const MAX_IMAGE_BYTES = 4 * 1024 * 1024 // 4MB
+export const ALLOWED_IMAGE_TYPES = ['image/jpeg', 'image/png', 'image/webp']
+
 // --- Project ---
 
 export const createProjectSchema = z.object({

--- a/apps/web/src/lib/storage.ts
+++ b/apps/web/src/lib/storage.ts
@@ -1,21 +1,19 @@
 import { createClient } from '@/lib/supabase/server'
+import { ALLOWED_IMAGE_TYPES, MAX_IMAGE_BYTES } from '@/lib/schemas/admin'
 
 type ImageBucket = 'project-images' | 'person-images'
-
-const MAX_FILE_SIZE = 4 * 1024 * 1024 // 4MB
-const ALLOWED_TYPES = ['image/jpeg', 'image/png', 'image/webp']
 
 export async function uploadImage(
   bucket: ImageBucket,
   entityId: string,
   file: File
 ): Promise<string> {
-  if (!ALLOWED_TYPES.includes(file.type)) {
+  if (!ALLOWED_IMAGE_TYPES.includes(file.type)) {
     throw new Error(`Invalid file type. Allowed: JPEG, PNG, WEBP`)
   }
 
-  if (file.size > MAX_FILE_SIZE) {
-    throw new Error(`File too large. Maximum size is ${MAX_FILE_SIZE / 1024 / 1024}MB`)
+  if (file.size > MAX_IMAGE_BYTES) {
+    throw new Error(`File too large. Maximum size is ${MAX_IMAGE_BYTES / 1024 / 1024}MB`)
   }
 
   const supabase = await createClient()
@@ -25,7 +23,16 @@ export async function uploadImage(
     upsert: true,
   })
 
-  if (error) throw new Error(`Failed to upload image: ${error.message}`)
+  if (error) {
+    console.error('Supabase storage upload failed:', {
+      bucket,
+      path,
+      size: file.size,
+      type: file.type,
+      error,
+    })
+    throw new Error(`Failed to upload image: ${error.message}`)
+  }
 
   const { data } = supabase.storage.from(bucket).getPublicUrl(path)
 

--- a/packages/db/prisma/migrations/20260826000000_storage_image_select_policy/migration.sql
+++ b/packages/db/prisma/migrations/20260826000000_storage_image_select_policy/migration.sql
@@ -1,0 +1,45 @@
+-- Completes 20260817000000_storage_admin_image_policies, which added INSERT and UPDATE policies
+-- on storage.objects but no SELECT policy, so every upload still failed with
+-- "new row violates row-level security policy".
+--
+-- The Storage API's upload query is:
+--   INSERT INTO storage.objects (...) VALUES (...)
+--   ON CONFLICT (name, bucket_id) DO UPDATE SET ... RETURNING *
+--
+-- Under RLS, RETURNING requires the returned row to satisfy SELECT policies, and
+-- ON CONFLICT DO UPDATE additionally requires SELECT to read the conflicting row. With no
+-- SELECT policy, a bare INSERT passes on the INSERT policy alone but this query never can --
+-- neither the first upload to a fresh path nor a replacement.
+--
+-- Verified against Postgres 16 with this schema reproduced: with the SELECT policy, an admin
+-- upload succeeds and a non-admin write is denied, a non-admin sees zero rows, and a write to
+-- any other bucket is denied. `authenticated` needs no grant on the public schema for this --
+-- is_admin() is reached through the policy expression, not by a direct call from the session.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname = 'storage' AND c.relname = 'objects'
+  ) AND EXISTS (
+    SELECT 1
+    FROM pg_proc p
+    JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public' AND p.proname = 'is_admin'
+  ) THEN
+
+    DROP POLICY IF EXISTS "Admins can read entity images" ON storage.objects;
+
+    CREATE POLICY "Admins can read entity images"
+      ON storage.objects
+      FOR SELECT
+      TO authenticated
+      USING (
+        bucket_id IN ('project-images', 'person-images')
+        AND public.is_admin()
+      );
+
+  END IF;
+END
+$$;


### PR DESCRIPTION
## Description

Attempting to create a new project as admin returned an RLS error from supabase

## Solution

When uploading via the storage API certain actions require a SELECT policy under the hood without directly saying it. Most notably ON CONFLICT DO UPDATE and RETURNING *. Both read a row, the former to find the existing one and the latter to hand back the one just written.

## Notes

There were also some other bugs and quirks I identified when testing the page:
- Fixed error handling that assumed every response would be JSON.
- Locked the "Create Project" button once pressed to prevent duplicate requests.
- Added a Content-Length check to the route so oversized bodies get rejected before formData() buffers them into memory. Previously the server read the whole thing in, then validated, so it was protecting Supabase but not itself.
- Added client-side file size/type validation so oversized uploads fail immediately instead of after a pointless round trip.
- Surfaced validation errors that had no field to attach to. These previously returned silently and made the button look dead.
- Added server-side error logging to the project route and storage helper; 500s were being returned with nothing in the logs.
- Deleted the unused form input from when you could only add one GitHub repo link.